### PR TITLE
Changed serial line no to serialize to JSON as a string

### DIFF
--- a/json_stats.c
+++ b/json_stats.c
@@ -635,7 +635,7 @@ __print_funct_t json_print_serial_stats(struct activity *a, int curr, int tab,
 			}
 			sep = TRUE;
 			
-			xprintf0(tab, "{\"line\": %d, "
+			xprintf0(tab, "{\"line\": \"%d\", "
 				 "\"rcvin\": %.2f, "
 				 "\"xmtin\": %.2f, "
 				 "\"framerr\": %.2f, "


### PR DESCRIPTION
All other activities are using strings to represent "key" values
(like cpuno or intr) in JSON output.
