### PR TITLE
small tweak to archive members in Makefile.in

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -202,7 +202,7 @@ sadf_misc.o: sadf_misc.c sadf.h sa.h
 libsyscom.a: common.o ioconf.o
 	$(AR) rvs $@ $?
 
-librdstats.a: librdstats.a(rd_stats.o count.o)
+librdstats.a: librdstats.a(rd_stats.o) librdstats.a(count.o)
 
 librdsensors.a: librdsensors.a(rd_sensors.o)
 


### PR DESCRIPTION
librdstats.a(rd_stats.o count.o) in Makefile.in triggers a syntax error in gnumake.

make: **\* No rule to make target `librdstats.a(rd_stats.o', needed by`librdstats.a'.  Stop.

Changing it to librdstats.a(rd_stats.o) librdstats.a(count.o)  seems to solve the problem.
