### PR TITLE
Remove redundant NULL checks.

### DIFF
--- a/cifsiostat.c
+++ b/cifsiostat.c
@@ -201,15 +201,10 @@ void io_sys_free(void)
 
 	/* Free CIFS directories structures */
 	for (i = 0; i < 2; i++) {
-
-		if (st_cifs[i]) {
-			free(st_cifs[i]);
-		}
+		free(st_cifs[i]);
 	}
 	
-	if (st_hdr_cifs) {
-		free(st_hdr_cifs);
-	}
+	free(st_hdr_cifs);
 }
 
 /*

--- a/count.c
+++ b/count.c
@@ -362,9 +362,7 @@ int get_irqcpu_nr(char *file, int max_nr_irqcpu, int cpu_nr)
 
 	fclose(fp);
 
-	if (line) {
-		free(line);
-	}
+	free(line);
 
 	return irq;
 }

--- a/ioconf.c
+++ b/ioconf.c
@@ -340,10 +340,8 @@ int ioc_init(void)
 	 * after IOC_ALLOC( blkp->desc ... ).
 	 * Right now, we don't.
 	 */
-	if (blkp != NULL)
-		free(blkp);
-	if (iocp != NULL)
-		free(iocp);
+	free(blkp);
+	free(iocp);
 
 	/* Indicate that ioconf file has been parsed */
 	ioc_parsed = 1;

--- a/iostat.c
+++ b/iostat.c
@@ -251,9 +251,7 @@ void salloc_dev_list(int list_len)
  */
 void sfree_dev_list(void)
 {
-	if (st_dev_list) {
-		free(st_dev_list);
-	}
+	free(st_dev_list);
 }
 
 /*
@@ -402,21 +400,14 @@ void io_sys_free(void)
 	int i;
 	
 	for (i = 0; i < 2; i++) {
-
 		/* Free CPU structures */
-		if (st_cpu[i]) {
-			free(st_cpu[i]);
-		}
+		free(st_cpu[i]);
 
 		/* Free I/O device structures */
-		if (st_iodev[i]) {
-			free(st_iodev[i]);
-		}
+		free(st_iodev[i]);
 	}
 	
-	if (st_hdr_iodev) {
-		free(st_hdr_iodev);
-	}
+	free(st_hdr_iodev);
 }
 
 /*

--- a/mpstat.c
+++ b/mpstat.c
@@ -183,24 +183,13 @@ void sfree_mp_struct(void)
 	int i;
 
 	for (i = 0; i < 3; i++) {
-
-		if (st_cpu[i]) {
-			free(st_cpu[i]);
-		}
-		if (st_irq[i]) {
-			free(st_irq[i]);
-		}
-		if (st_irqcpu[i]) {
-			free(st_irqcpu[i]);
-		}
-		if (st_softirqcpu[i]) {
-			free(st_softirqcpu[i]);
-		}
+		free(st_cpu[i]);
+		free(st_irq[i]);
+		free(st_irqcpu[i]);
+		free(st_softirqcpu[i]);
 	}
 
-	if (cpu_bitmap) {
-		free(cpu_bitmap);
-	}
+	free(cpu_bitmap);
 }
 
 /*
@@ -718,9 +707,7 @@ void read_interrupts_stat(char *file, struct stats_irqcpu *st_ic[], int ic_nr, i
 
 		fclose(fp);
 		
-		if (line) {
-			free(line);
-		}
+		free(line);
 	}
 
 	while (irq < ic_nr) {

--- a/nfsiostat.c
+++ b/nfsiostat.c
@@ -225,15 +225,10 @@ void io_sys_free(void)
 
 	/* Free I/O NFS directories structures */
 	for (i = 0; i < 2; i++) {
-
-		if (st_ionfs[i]) {
-			free(st_ionfs[i]);
-		}
+		free(st_ionfs[i]);
 	}
 	
-	if (st_hdr_ionfs) {
-		free(st_hdr_ionfs);
-	}
+	free(st_hdr_ionfs);
 }
 
 /*

--- a/pidstat.c
+++ b/pidstat.c
@@ -174,9 +174,7 @@ void sfree_pid(void)
 	int i;
 	
 	for (i = 0; i < 3; i++) {
-		if (st_pid_list[i]) {
-			free(st_pid_list[i]);
-		}
+		free(st_pid_list[i]);
 	}
 }
 
@@ -2259,9 +2257,7 @@ int main(int argc, char **argv)
 	rw_pidstat_loop(dis_hdr, rows);
 	
 	/* Free structures */
-	if (pid_array) {
-		free(pid_array);
-	}
+	free(pid_array);
 	sfree_pid();
 
 	return 0;

--- a/sadf.c
+++ b/sadf.c
@@ -1338,9 +1338,7 @@ void read_stats_from_file(char dfile[])
 
 	close(ifd);
 	
-	if (file_actlst) {
-		free(file_actlst);
-	}
+	free(file_actlst);
 	free_structures(act);
 }
 

--- a/sar.c
+++ b/sar.c
@@ -1007,9 +1007,7 @@ void read_stats_from_file(char from_file[])
 
 	close(ifd);
 	
-	if (file_actlst) {
-		free(file_actlst);
-	}
+	free(file_actlst);
 }
 
 /*


### PR DESCRIPTION
Remove NULL checks before free() because free(NULL) performs no operation.
