### PR TITLE
Replace comma with semi-colon in filesystem .hdr_line

### DIFF
--- a/activity.c
+++ b/activity.c
@@ -1214,7 +1214,7 @@ struct activity filesystem_act = {
 	.f_render	= render_filesystem_stats,
 	.f_xml_print	= xml_print_filesystem_stats,
 	.f_json_print	= json_print_filesystem_stats,
-	.hdr_line	= "FILESYSTEM,MBfsfree;MBfsused;%fsused;%ufsused;Ifree;Iused;%Iused",
+	.hdr_line	= "FILESYSTEM;MBfsfree;MBfsused;%fsused;%ufsused;Ifree;Iused;%Iused",
 	.name		= "A_FILESYSTEM",
 #endif
 	.nr		= -1,


### PR DESCRIPTION
Makes the .hdr_line for filesystem stats consistent with other .hdr_lines
