### PR TITLE
Fix output of sadf -j with file-utc-time present

### DIFF
--- a/sadf_misc.c
+++ b/sadf_misc.c
@@ -579,7 +579,7 @@ __printf_funct_t print_json_header(int *tab, int action, char *dfile,
 		
 		if ((loc_t = gmtime((const time_t *) &file_hdr->sa_ust_time)) != NULL) {
 			strftime(cur_time, sizeof(cur_time), "%T", loc_t);
-			printf("\n");
+			printf(",\n");
 			xprintf0(*tab, "\"file-utc-time\": \"%s\"", cur_time);
 		}
 


### PR DESCRIPTION
Commit aea4561 added "file-utc-time" parameter output (if present in the
datafile), but didn't add comma before it in "sadf -j" output, making it
unparseable. Fix that.

Fixes #12 that I've opened a bit earlier.
