### PR TITLE
add systemd timer units replacing cronjobs

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -380,6 +380,10 @@ install_all: install_base cron/crontab sysstat \
 	fi
 	if [ -d "$(DESTDIR)$(SYSTEMD_UNIT_DIR)" ]; then \
 	    $(INSTALL_DATA) sysstat.service $(DESTDIR)$(SYSTEMD_UNIT_DIR); \
+	    $(INSTALL_DATA) cron/sysstat-collect.service $(DESTDIR)$(SYSTEMD_UNIT_DIR); \
+	    $(INSTALL_DATA) cron/sysstat-collect.timer $(DESTDIR)$(SYSTEMD_UNIT_DIR); \
+	    $(INSTALL_DATA) cron/sysstat-summary.service $(DESTDIR)$(SYSTEMD_UNIT_DIR); \
+	    $(INSTALL_DATA) cron/sysstat-summary.timer $(DESTDIR)$(SYSTEMD_UNIT_DIR); \
 	elif [ -d $(DESTDIR)$(INIT_DIR) ]; then \
 	   $(INSTALL_BIN) sysstat $(DESTDIR)$(INIT_DIR)/sysstat; \
 	   if [ -x $(CHKCONFIG) ]; then \
@@ -492,6 +496,10 @@ ifeq ($(COPY_ONLY),n)
 endif
 	if [ -d "$(DESTDIR)$(SYSTEMD_UNIT_DIR)" ]; then \
 	    rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/sysstat.service; \
+	    rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/sysstat-collect.service; \
+	    rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/sysstat-collect.timer; \
+	    rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/sysstat-summary.service; \
+	    rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/sysstat-summary.timer; \
 	fi
 
 ifeq ($(INSTALL_CRON),y)
@@ -519,6 +527,7 @@ clean:
 almost-distclean: clean nls/sysstat.pot
 	rm -f sa1 sa2 sysstat cron/crontab version.h sysconfig.h prealloc.h
 	rm -f sysstat.sysconfig cron/sysstat.crond cron/sysstat.cron.daily sysstat.service
+	rm -f cron/sysstat-collect.service cron/sysstat-collect.timer cron/sysstat-summary.service cron/sysstat-summary.timer
 	rm -f cron/sysstat.cron.hourly cron/sysstat.crond.sample cron/sysstat.crond.sample.in
 	rm -f contrib/isag/isag
 	rm -f man/sa1.8 man/sa2.8 man/sadc.8 man/sadf.1 man/sar.1 man/iostat.1 man/sysstat.5

--- a/README
+++ b/README
@@ -81,7 +81,11 @@ ${PREFIX}/share/locale/*/LC_MESSAGES/sysstat.mo
 ${PREFIX}/share/doc/sysstat-x.y.z/*
 /var/log/sa
 ${INIT_DIR}/sysstat
-/lib/systemd/system/sysstat.service	if OS uses systemd
+/lib/systemd/system/sysstat.service		if OS uses systemd
+/lib/systemd/system/sysstat-collect.service	if OS uses systemd
+/lib/systemd/system/sysstat-collect.timer	if OS uses systemd
+/lib/systemd/system/sysstat-summary.service	if OS uses systemd
+/lib/systemd/system/sysstat-summary.timer	if OS uses systemd
 /etc/sysconfig/sysstat
 /etc/sysconfig/sysstat.ioconf
 /etc/cron.d/sysstat

--- a/configure
+++ b/configure
@@ -5416,6 +5416,14 @@ ac_config_files="$ac_config_files sysstat"
 	# Permissions must be changed
 ac_config_files="$ac_config_files sysstat.service"
 
+ac_config_files="$ac_config_files cron/sysstat-collect.service"
+
+ac_config_files="$ac_config_files cron/sysstat-collect.timer"
+
+ac_config_files="$ac_config_files cron/sysstat-summary.service"
+
+ac_config_files="$ac_config_files cron/sysstat-summary.timer"
+
 ac_config_files="$ac_config_files man/sa1.8:man/sa1.in"
 		# File must be renamed
 ac_config_files="$ac_config_files man/sa2.8:man/sa2.in"
@@ -6157,6 +6165,10 @@ do
     "cron/sysstat.crond.sample.in") CONFIG_FILES="$CONFIG_FILES cron/sysstat.crond.sample.in:cron/sysstat.crond.in" ;;
     "sysstat") CONFIG_FILES="$CONFIG_FILES sysstat" ;;
     "sysstat.service") CONFIG_FILES="$CONFIG_FILES sysstat.service" ;;
+    "cron/sysstat-collect.service") CONFIG_FILES="$CONFIG_FILES cron/sysstat-collect.service" ;;
+    "cron/sysstat-collect.timer") CONFIG_FILES="$CONFIG_FILES cron/sysstat-collect.timer" ;;
+    "cron/sysstat-summary.service") CONFIG_FILES="$CONFIG_FILES cron/sysstat-summary.service" ;;
+    "cron/sysstat-summary.timer") CONFIG_FILES="$CONFIG_FILES cron/sysstat-summary.timer" ;;
     "man/sa1.8") CONFIG_FILES="$CONFIG_FILES man/sa1.8:man/sa1.in" ;;
     "man/sa2.8") CONFIG_FILES="$CONFIG_FILES man/sa2.8:man/sa2.in" ;;
     "man/sadc.8") CONFIG_FILES="$CONFIG_FILES man/sadc.8:man/sadc.in" ;;

--- a/configure.in
+++ b/configure.in
@@ -600,6 +600,10 @@ AC_CONFIG_FILES([cron/sysstat.crond])
 AC_CONFIG_FILES([cron/sysstat.crond.sample.in:cron/sysstat.crond.in], [sed s/^/#/ cron/sysstat.crond.sample.in > cron/sysstat.crond.sample])
 AC_CONFIG_FILES([sysstat], [chmod +x sysstat])	# Permissions must be changed
 AC_CONFIG_FILES([sysstat.service])
+AC_CONFIG_FILES([cron/sysstat-collect.service])
+AC_CONFIG_FILES([cron/sysstat-collect.timer])
+AC_CONFIG_FILES([cron/sysstat-summary.service])
+AC_CONFIG_FILES([cron/sysstat-summary.timer])
 AC_CONFIG_FILES([man/sa1.8:man/sa1.in])		# File must be renamed
 AC_CONFIG_FILES([man/sa2.8:man/sa2.in])		# File must be renamed
 AC_CONFIG_FILES([man/sadc.8:man/sadc.in])	# File must be renamed

--- a/cron/sysstat-collect.service.in
+++ b/cron/sysstat-collect.service.in
@@ -1,0 +1,16 @@
+# @SYSTEMD_UNIT_DIR@/sysstat-collect.service
+# (C) 2014 Tomasz Torcz <tomek@pipebreaker.pl>
+#
+# @PACKAGE_NAME@-@PACKAGE_VERSION@ systemd unit file:
+#        Collects system activity data
+#        Activated by sysstat-collect.timer unit
+
+[Unit]
+Description=system activity accounting tool
+Documentation=man:sa1(8)
+
+[Service]
+Type=oneshot
+User=@CRON_OWNER@
+ExecStart=@SA_LIB_DIR@/sa1 1 1
+

--- a/cron/sysstat-collect.timer.in
+++ b/cron/sysstat-collect.timer.in
@@ -1,0 +1,14 @@
+# @SYSTEMD_UNIT_DIR@/sysstat-collect.timer
+# (C) 2014 Tomasz Torcz <tomek@pipebreaker.pl>
+#
+# @PACKAGE_NAME@-@PACKAGE_VERSION@ systemd unit file:
+#        Activates activity collector every @CRON_INTERVAL@ minutes
+
+[Unit]
+Description=Run system activity accounting tool every @CRON_INTERVAL@ minutes
+
+[Timer]
+OnCalendar=*:00/@CRON_INTERVAL@
+
+[Install]
+WantedBy=sysstat.service

--- a/cron/sysstat-summary.service.in
+++ b/cron/sysstat-summary.service.in
@@ -1,0 +1,14 @@
+# @SYSTEMD_UNIT_DIR@/sysstat-summary.service
+# (C) 2014 Tomasz Torcz <tomek@pipebreaker.pl>
+#
+# @PACKAGE_NAME@-@PACKAGE_VERSION@ systemd unit file:
+#        Generates daily summary of process accounting
+
+[Unit]
+Description=Generate a daily summary of process accounting
+Documentation=man:sa2(8)
+
+[Service]
+Type=oneshot
+User=@CRON_OWNER@
+ExecStart=@SA_LIB_DIR@/sa2 -A

--- a/cron/sysstat-summary.timer.in
+++ b/cron/sysstat-summary.timer.in
@@ -1,0 +1,15 @@
+# @SYSTEMD_UNIT_DIR@/sysstat-summary.timer
+# (C) 2014 Tomasz Torcz <tomek@pipebreaker.pl>
+#
+# @PACKAGE_NAME@-@PACKAGE_VERSION@ systemd unit file:
+#        Triggers daily summary generation.
+#        Activates sysstat-summary.service
+
+[Unit]
+Description=Generate a daily summary of process accounting at 23:53
+
+[Timer]
+OnCalendar=23:53:00
+
+[Install]
+WantedBy=sysstat.service

--- a/sysstat.service.in
+++ b/sysstat.service.in
@@ -16,4 +16,6 @@ ExecStart=@SA_LIB_DIR@/sa1 --boot
 
 [Install]
 WantedBy=multi-user.target
+Also=sysstat-collect.timer
+Also=sysstat-summary.timer
 


### PR DESCRIPTION
Systemd timer units, while preserving functionality of cronjobs,
provide some additional features:
- dependency on cron can be dropped
- timer units next expiration is clearly visible in "systemctl list-timers"
- unit customization rules provide cleaner way for administrator to modify
  default parameters, enable, disable and override individual timers
