### PR TITLE
Add /proc/meminfo fields so end users can calculate totals

### DIFF
--- a/activity.c
+++ b/activity.c
@@ -287,6 +287,37 @@ struct activity memory_act = {
 	.bitmap		= NULL
 };
 
+/* Memory utilization (extended 0) activity */
+struct activity memory_ext0_act = {
+	.id		= A_MEMORYEXT0,
+	.options	= AO_COLLECTED + AO_MULTIPLE_OUTPUTS,
+	.magic		= ACTIVITY_MAGIC_BASE,
+	.group		= G_DEFAULT,
+#ifdef SOURCE_SADC
+	.f_count	= NULL,
+	.f_count2	= NULL,
+	.f_read		= wrap_read_meminfo_ext0,
+#endif
+#ifdef SOURCE_SAR
+	.f_print	= print_memory_ext0_stats,
+	.f_print_avg	= print_avg_memory_ext0_stats,
+#endif
+#ifdef SOURCE_SADF
+	.f_render	= render_memory_ext0_stats,
+	.f_xml_print	= xml_print_memory_ext0_stats,
+	.f_json_print	= json_print_memory_ext0_stats,
+	.hdr_line	= "kbanon;kbslab;kbpagetbl;kbvmallocused;kbkrnstck",
+	.name		= "A_MEMORYEXT0",
+#endif
+	.nr		= 1,
+	.nr2		= 1,
+	.fsize		= STATS_MEMORY_EXT0_SIZE,
+	.msize		= STATS_MEMORY_EXT0_SIZE,
+	.opt_flags	= 0,
+	.buf		= {NULL, NULL, NULL},
+	.bitmap		= NULL
+};
+
 /* Kernel tables activity */
 struct activity ktables_act = {
 	.id		= A_KTABLES,
@@ -1239,6 +1270,7 @@ struct activity *act[NR_ACT] = {
 	&paging_act,
 	&io_act,
 	&memory_act,
+    &memory_ext0_act,
 	&huge_act,
 	&ktables_act,
 	&queue_act,

--- a/json_stats.c
+++ b/json_stats.c
@@ -123,20 +123,20 @@ __print_funct_t json_print_cpu_stats(struct activity *a, int curr, int tab,
 	}
 
 	for (i = 0; (i < a->nr) && (i < a->bitmap->b_size + 1); i++) {
-		
+
 		scc = (struct stats_cpu *) ((char *) a->buf[curr]  + i * a->msize);
 		scp = (struct stats_cpu *) ((char *) a->buf[!curr] + i * a->msize);
 
 		/* Should current CPU (including CPU "all") be displayed? */
 		if (a->bitmap->b_array[i >> 3] & (1 << (i & 0x07))) {
-			
+
 			/* Yes: Display current CPU stats */
 
 			if (sep) {
 				printf(",\n");
 			}
 			sep = TRUE;
-			
+
 			if (!i) {
 				/* This is CPU "all" */
 				strcpy(cpuno, "all");
@@ -171,7 +171,7 @@ __print_funct_t json_print_cpu_stats(struct activity *a, int curr, int tab,
 					g_itv = get_per_cpu_interval(scc, scp);
 					cpu_offline = FALSE;
 				}
-				
+
 				if (!g_itv) {
 					/* Current CPU is offline or tickless */
 					if (DISPLAY_CPU_DEF(a->opt_flags)) {
@@ -308,17 +308,17 @@ __print_funct_t json_print_irq_stats(struct activity *a, int curr, int tab,
 	struct stats_irq *sic, *sip;
 	int sep = FALSE;
 	char irqno[8];
-	
+
 	xprintf(tab++, "\"interrupts\": [");
 
 	for (i = 0; (i < a->nr) && (i < a->bitmap->b_size + 1); i++) {
 
 		sic = (struct stats_irq *) ((char *) a->buf[curr]  + i * a->msize);
 		sip = (struct stats_irq *) ((char *) a->buf[!curr] + i * a->msize);
-		
+
 		/* Should current interrupt (including int "sum") be displayed? */
 		if (a->bitmap->b_array[i >> 3] & (1 << (i & 0x07))) {
-			
+
 			/* Yes: Display it */
 
 			if (sep) {
@@ -362,7 +362,7 @@ __print_funct_t json_print_swap_stats(struct activity *a, int curr, int tab,
 	struct stats_swap
 		*ssc = (struct stats_swap *) a->buf[curr],
 		*ssp = (struct stats_swap *) a->buf[!curr];
-	
+
 	xprintf0(tab, "\"swap-pages\": {"
 		 "\"pswpin\": %.2f, "
 		 "\"pswpout\": %.2f}",
@@ -466,7 +466,7 @@ __print_funct_t json_print_memory_stats(struct activity *a, int curr, int tab,
 	int sep = FALSE;
 
 	xprintf0(tab, "\"memory\": {");
-	
+
 	if (DISPLAY_MEM_AMT(a->opt_flags)) {
 
 		sep = TRUE;
@@ -525,7 +525,7 @@ __print_funct_t json_print_memory_stats(struct activity *a, int curr, int tab,
 		if (sep) {
 			printf(", ");
 		}
-		
+
 		printf("\"frmpg\": %.2f, "
 		       "\"bufpg\": %.2f, "
 		       "\"campg\": %.2f",
@@ -538,6 +538,36 @@ __print_funct_t json_print_memory_stats(struct activity *a, int curr, int tab,
 	}
 
 	printf("}");
+}
+
+/*
+ ***************************************************************************
+ * Display memory extention 0 statistics in JSON.
+ *
+ * IN:
+ * @a		Activity structure with statistics.
+ * @curr	Index in array for current sample statistics.
+ * @tab		Indentation in output.
+ * @itv		Interval of time in jiffies.
+ ***************************************************************************
+ */
+__print_funct_t json_print_memory_ext0_stats(struct activity *a, int curr, int tab,
+					unsigned long long itv)
+{
+	struct stats_memory_ext0
+		*smc = (struct stats_memory_ext0 *) a->buf[curr];
+
+	xprintf0(tab, "\"memory-ext0\": {"
+         "\"anonpages\": %lu, "
+         "\"slab\": %lu, "
+	     "\"pagetables\": %lu, "
+	     "\"vmallocused\": %lu, "
+	     "\"kernelstack\": %lu}",
+	     smc->anonkb,
+	     smc->slabkb,
+	     smc->pagetblkb,
+	     smc->vmallocusedkb,
+	     smc->krnstckkb);
 }
 
 /*
@@ -556,7 +586,7 @@ __print_funct_t json_print_ktables_stats(struct activity *a, int curr, int tab,
 {
 	struct stats_ktables
 		*skc = (struct stats_ktables *) a->buf[curr];
-	
+
 	xprintf0(tab, "\"kernel\": {"
 		 "\"dentunusd\": %u, "
 		 "\"file-nr\": %u, "
@@ -584,7 +614,7 @@ __print_funct_t json_print_queue_stats(struct activity *a, int curr, int tab,
 {
 	struct stats_queue
 		*sqc = (struct stats_queue *) a->buf[curr];
-	
+
 	xprintf0(tab, "\"queue\": {"
 		 "\"runq-sz\": %lu, "
 		 "\"plist-sz\": %u, "
@@ -634,7 +664,7 @@ __print_funct_t json_print_serial_stats(struct activity *a, int curr, int tab,
 				printf(",\n");
 			}
 			sep = TRUE;
-			
+
 			xprintf0(tab, "{\"line\": %d, "
 				 "\"rcvin\": %.2f, "
 				 "\"xmtin\": %.2f, "
@@ -690,14 +720,14 @@ __print_funct_t json_print_disk_stats(struct activity *a, int curr, int tab,
 
 		/* Compute extended statistics values */
 		compute_ext_disk_stats(sdc, sdp, itv, &xds);
-		
+
 		dev_name = NULL;
 		persist_dev_name = NULL;
 
 		if (DISPLAY_PERSIST_NAME_S(flags)) {
 			persist_dev_name = get_persistent_name_from_pretty(get_devname(sdc->major, sdc->minor, TRUE));
 		}
-		
+
 		if (persist_dev_name) {
 			dev_name = persist_dev_name;
 		}
@@ -711,12 +741,12 @@ __print_funct_t json_print_disk_stats(struct activity *a, int curr, int tab,
 						       USE_PRETTY_OPTION(flags));
 			}
 		}
-		
+
 		if (sep) {
 			printf(",\n");
 		}
 		sep = TRUE;
-		
+
 		xprintf0(tab, "{\"disk-device\": \"%s\", "
 			 "\"tps\": %.2f, "
 			 "\"rd_sec\": %.2f, "
@@ -767,7 +797,7 @@ __print_funct_t json_print_net_dev_stats(struct activity *a, int curr, int tab,
 
 	json_markup_network(tab, OPEN_JSON_MARKUP);
 	tab++;
-	
+
 	xprintf(tab++, "\"net-dev\": [");
 
 	for (i = 0; i < a->nr; i++) {
@@ -776,7 +806,7 @@ __print_funct_t json_print_net_dev_stats(struct activity *a, int curr, int tab,
 
 		if (!strcmp(sndc->interface, ""))
 			continue;
-		
+
 		j = check_net_dev_reg(a, curr, !curr, i);
 		sndp = (struct stats_net_dev *) ((char *) a->buf[!curr] + j * a->msize);
 
@@ -784,7 +814,7 @@ __print_funct_t json_print_net_dev_stats(struct activity *a, int curr, int tab,
 			printf(",\n");
 		}
 		sep = TRUE;
-		
+
 		rxkb = S_VALUE(sndp->rx_bytes, sndc->rx_bytes, itv);
 		txkb = S_VALUE(sndp->tx_bytes, sndc->tx_bytes, itv);
 		ifutil = compute_ifutil(sndc, rxkb, txkb);
@@ -843,7 +873,7 @@ __print_funct_t json_print_net_edev_stats(struct activity *a, int curr, int tab,
 
 	json_markup_network(tab, OPEN_JSON_MARKUP);
 	tab++;
-	
+
 	xprintf(tab++, "\"net-edev\": [");
 
 	for (i = 0; i < a->nr; i++) {
@@ -852,10 +882,10 @@ __print_funct_t json_print_net_edev_stats(struct activity *a, int curr, int tab,
 
 		if (!strcmp(snedc->interface, ""))
 			continue;
-		
+
 		j = check_net_edev_reg(a, curr, !curr, i);
 		snedp = (struct stats_net_edev *) ((char *) a->buf[!curr] + j * a->msize);
-		
+
 		if (sep) {
 			printf(",\n");
 		}
@@ -911,7 +941,7 @@ __print_funct_t json_print_net_nfs_stats(struct activity *a, int curr, int tab,
 	struct stats_net_nfs
 		*snnc = (struct stats_net_nfs *) a->buf[curr],
 		*snnp = (struct stats_net_nfs *) a->buf[!curr];
-	
+
 	if (!IS_SELECTED(a->options) || (a->nr <= 0))
 		goto close_json_markup;
 
@@ -1010,7 +1040,7 @@ __print_funct_t json_print_net_sock_stats(struct activity *a, int curr, int tab,
 {
 	struct stats_net_sock
 		*snsc = (struct stats_net_sock *) a->buf[curr];
-	
+
 	if (!IS_SELECTED(a->options) || (a->nr <= 0))
 		goto close_json_markup;
 
@@ -1055,7 +1085,7 @@ __print_funct_t json_print_net_ip_stats(struct activity *a, int curr, int tab,
 	struct stats_net_ip
 		*snic = (struct stats_net_ip *) a->buf[curr],
 		*snip = (struct stats_net_ip *) a->buf[!curr];
-	
+
 	if (!IS_SELECTED(a->options) || (a->nr <= 0))
 		goto close_json_markup;
 
@@ -1104,7 +1134,7 @@ __print_funct_t json_print_net_eip_stats(struct activity *a, int curr, int tab,
 	struct stats_net_eip
 		*sneic = (struct stats_net_eip *) a->buf[curr],
 		*sneip = (struct stats_net_eip *) a->buf[!curr];
-	
+
 	if (!IS_SELECTED(a->options) || (a->nr <= 0))
 		goto close_json_markup;
 
@@ -1153,7 +1183,7 @@ __print_funct_t json_print_net_icmp_stats(struct activity *a, int curr, int tab,
 	struct stats_net_icmp
 		*snic = (struct stats_net_icmp *) a->buf[curr],
 		*snip = (struct stats_net_icmp *) a->buf[!curr];
-	
+
 	if (!IS_SELECTED(a->options) || (a->nr <= 0))
 		goto close_json_markup;
 
@@ -1214,7 +1244,7 @@ __print_funct_t json_print_net_eicmp_stats(struct activity *a, int curr, int tab
 	struct stats_net_eicmp
 		*sneic = (struct stats_net_eicmp *) a->buf[curr],
 		*sneip = (struct stats_net_eicmp *) a->buf[!curr];
-	
+
 	if (!IS_SELECTED(a->options) || (a->nr <= 0))
 		goto close_json_markup;
 
@@ -1271,7 +1301,7 @@ __print_funct_t json_print_net_tcp_stats(struct activity *a, int curr, int tab,
 	struct stats_net_tcp
 		*sntc = (struct stats_net_tcp *) a->buf[curr],
 		*sntp = (struct stats_net_tcp *) a->buf[!curr];
-	
+
 	if (!IS_SELECTED(a->options) || (a->nr <= 0))
 		goto close_json_markup;
 
@@ -1312,7 +1342,7 @@ __print_funct_t json_print_net_etcp_stats(struct activity *a, int curr, int tab,
 	struct stats_net_etcp
 		*snetc = (struct stats_net_etcp *) a->buf[curr],
 		*snetp = (struct stats_net_etcp *) a->buf[!curr];
-	
+
 	if (!IS_SELECTED(a->options) || (a->nr <= 0))
 		goto close_json_markup;
 
@@ -1355,7 +1385,7 @@ __print_funct_t json_print_net_udp_stats(struct activity *a, int curr, int tab,
 	struct stats_net_udp
 		*snuc = (struct stats_net_udp *) a->buf[curr],
 		*snup = (struct stats_net_udp *) a->buf[!curr];
-	
+
 	if (!IS_SELECTED(a->options) || (a->nr <= 0))
 		goto close_json_markup;
 
@@ -1395,7 +1425,7 @@ __print_funct_t json_print_net_sock6_stats(struct activity *a, int curr, int tab
 {
 	struct stats_net_sock6
 		*snsc = (struct stats_net_sock6 *) a->buf[curr];
-	
+
 	if (!IS_SELECTED(a->options) || (a->nr <= 0))
 		goto close_json_markup;
 
@@ -1436,7 +1466,7 @@ __print_funct_t json_print_net_ip6_stats(struct activity *a, int curr, int tab,
 	struct stats_net_ip6
 		*snic = (struct stats_net_ip6 *) a->buf[curr],
 		*snip = (struct stats_net_ip6 *) a->buf[!curr];
-	
+
 	if (!IS_SELECTED(a->options) || (a->nr <= 0))
 		goto close_json_markup;
 
@@ -1489,7 +1519,7 @@ __print_funct_t json_print_net_eip6_stats(struct activity *a, int curr, int tab,
 	struct stats_net_eip6
 		*sneic = (struct stats_net_eip6 *) a->buf[curr],
 		*sneip = (struct stats_net_eip6 *) a->buf[!curr];
-	
+
 	if (!IS_SELECTED(a->options) || (a->nr <= 0))
 		goto close_json_markup;
 
@@ -1544,7 +1574,7 @@ __print_funct_t json_print_net_icmp6_stats(struct activity *a, int curr, int tab
 	struct stats_net_icmp6
 		*snic = (struct stats_net_icmp6 *) a->buf[curr],
 		*snip = (struct stats_net_icmp6 *) a->buf[!curr];
-	
+
 	if (!IS_SELECTED(a->options) || (a->nr <= 0))
 		goto close_json_markup;
 
@@ -1611,7 +1641,7 @@ __print_funct_t json_print_net_eicmp6_stats(struct activity *a, int curr, int ta
 	struct stats_net_eicmp6
 		*sneic = (struct stats_net_eicmp6 *) a->buf[curr],
 		*sneip = (struct stats_net_eicmp6 *) a->buf[!curr];
-	
+
 	if (!IS_SELECTED(a->options) || (a->nr <= 0))
 		goto close_json_markup;
 
@@ -1666,7 +1696,7 @@ __print_funct_t json_print_net_udp6_stats(struct activity *a, int curr, int tab,
 	struct stats_net_udp6
 		*snuc = (struct stats_net_udp6 *) a->buf[curr],
 		*snup = (struct stats_net_udp6 *) a->buf[!curr];
-	
+
 	if (!IS_SELECTED(a->options) || (a->nr <= 0))
 		goto close_json_markup;
 
@@ -1716,11 +1746,11 @@ __print_funct_t json_print_pwr_cpufreq_stats(struct activity *a, int curr, int t
 	tab++;
 
 	xprintf(tab++, "\"cpu-frequency\": [");
-	
+
 	for (i = 0; (i < a->nr) && (i < a->bitmap->b_size + 1); i++) {
-		
+
 		spc = (struct stats_pwr_cpufreq *) ((char *) a->buf[curr]  + i * a->msize);
-	
+
 		/* Should current CPU (including CPU "all") be displayed? */
 		if (a->bitmap->b_array[i >> 3] & (1 << (i & 0x07))) {
 
@@ -1737,14 +1767,14 @@ __print_funct_t json_print_pwr_cpufreq_stats(struct activity *a, int curr, int t
 				printf(",\n");
 			}
 			sep = TRUE;
-			
+
 			xprintf0(tab, "{\"number\": \"%s\", "
 				 "\"frequency\": %.2f}",
 				 cpuno,
 				 ((double) spc->cpufreq) / 100);
 		}
 	}
-	
+
 	printf("\n");
 	xprintf0(--tab, "]");
 	tab--;
@@ -1788,7 +1818,7 @@ __print_funct_t json_print_pwr_fan_stats(struct activity *a, int curr, int tab,
 			printf(",\n");
 		}
 		sep = TRUE;
-		
+
 		xprintf0(tab, "{\"number\": %d, "
 			 "\"rpm\": %llu, "
 			 "\"drpm\": %llu, "
@@ -1842,7 +1872,7 @@ __print_funct_t json_print_pwr_temp_stats(struct activity *a, int curr, int tab,
 			printf(",\n");
 		}
 		sep = TRUE;
-		
+
 		xprintf0(tab, "{\"number\": %d, "
 			 "\"degC\": %.2f, "
 			 "\"percent-temp\": %.2f, "
@@ -1898,7 +1928,7 @@ __print_funct_t json_print_pwr_in_stats(struct activity *a, int curr, int tab,
 			printf(",\n");
 		}
 		sep = TRUE;
-		
+
 		xprintf0(tab, "{\"number\": %d, "
 			 "\"inV\": %.2f, "
 			 "\"percent-in\": %.2f, "
@@ -2068,7 +2098,7 @@ __print_funct_t json_print_pwr_usb_stats(struct activity *a, int curr, int tab,
 			printf(",\n");
 		}
 		sep = TRUE;
-		
+
 		xprintf0(tab, "{\"bus_number\": %d, "
 			 "\"idvendor\": \"%x\", "
 			 "\"idprod\": \"%x\", "
@@ -2124,7 +2154,7 @@ __print_funct_t json_print_filesystem_stats(struct activity *a, int curr, int ta
 			printf(",\n");
 		}
 		sep = TRUE;
-		
+
 		xprintf0(tab, "{\"filesystem\": \"%s\", "
 			 "\"MBfsfree\": %.0f, "
 			 "\"MBfsused\": %.0f, "

--- a/json_stats.h
+++ b/json_stats.h
@@ -29,6 +29,8 @@ extern __print_funct_t json_print_io_stats
 	(struct activity *, int, int, unsigned long long);
 extern __print_funct_t json_print_memory_stats
 	(struct activity *, int, int, unsigned long long);
+extern __print_funct_t json_print_memory_ext0_stats
+	(struct activity *, int, int, unsigned long long);
 extern __print_funct_t json_print_ktables_stats
 	(struct activity *, int, int, unsigned long long);
 extern __print_funct_t json_print_queue_stats

--- a/pr_stats.c
+++ b/pr_stats.c
@@ -73,9 +73,9 @@ __print_funct_t print_cpu_stats(struct activity *a, int prev, int curr,
 			       timestamp[!curr]);
 		}
 	}
-	
+
 	for (i = 0; (i < a->nr) && (i < a->bitmap->b_size + 1); i++) {
-		
+
 		/*
 		 * The size of a->buf[...] CPU structure may be different from the default
 		 * sizeof(struct stats_cpu) value if data have been read from a file!
@@ -92,13 +92,13 @@ __print_funct_t print_cpu_stats(struct activity *a, int prev, int curr,
 		 * used by sadc to create a file, and the version of sysstat
 		 * used by sar to read it...
 		 */
-		
+
 		/* Should current CPU (including CPU "all") be displayed? */
 		if (a->bitmap->b_array[i >> 3] & (1 << (i & 0x07))) {
-			
+
 			/* Yes: Display it */
 			printf("%-11s", timestamp[curr]);
-			
+
 			if (!i) {
 				/* This is CPU "all" */
 				printf("     all");
@@ -121,12 +121,12 @@ __print_funct_t print_cpu_stats(struct activity *a, int prev, int curr,
 					 * jump from zero when the CPU comes back online.
 					 */
 					*scc = *scp;
-					
+
 					/* %user, %nice, %system, %iowait, %steal, ..., %idle */
 					printf("    %6.2f    %6.2f    %6.2f"
 					       "    %6.2f    %6.2f    %6.2f",
 					       0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-					
+
 					if (DISPLAY_CPU_ALL(a->opt_flags)) {
 						/*
 						 * Four additional fields to display:
@@ -138,10 +138,10 @@ __print_funct_t print_cpu_stats(struct activity *a, int prev, int curr,
 					printf("\n");
 					continue;
 				}
-				
+
 				/* Recalculate interval for current proc */
 				g_itv = get_per_cpu_interval(scc, scp);
-				
+
 				if (!g_itv) {
 					/*
 					 * If the CPU is tickless then there is no change in CPU values
@@ -166,7 +166,7 @@ __print_funct_t print_cpu_stats(struct activity *a, int prev, int curr,
 					continue;
 				}
 			}
-			
+
 			if (DISPLAY_CPU_DEF(a->opt_flags)) {
 				printf("    %6.2f    %6.2f    %6.2f    %6.2f    %6.2f    %6.2f\n",
 				       ll_sp_value(scp->cpu_user, scc->cpu_user, g_itv),
@@ -223,7 +223,7 @@ __print_funct_t print_pcsw_stats(struct activity *a, int prev, int curr,
 	struct stats_pcsw
 		*spc = (struct stats_pcsw *) a->buf[curr],
 		*spp = (struct stats_pcsw *) a->buf[prev];
-	
+
 	if (dis) {
 		printf("\n%-11s    proc/s   cswch/s\n", timestamp[!curr]);
 	}
@@ -249,16 +249,16 @@ __print_funct_t print_irq_stats(struct activity *a, int prev, int curr,
 {
 	int i;
 	struct stats_irq *sic, *sip;
-	
+
 	if (dis) {
 		printf("\n%-11s      INTR    intr/s\n", timestamp[!curr]);
 	}
-	
+
 	for (i = 0; (i < a->nr) && (i < a->bitmap->b_size + 1); i++) {
 
 		sic = (struct stats_irq *) ((char *) a->buf[curr] + i * a->msize);
 		sip = (struct stats_irq *) ((char *) a->buf[prev] + i * a->msize);
-		
+
 		/*
 		 * Note: a->nr is in [0, NR_IRQS + 1].
 		 * Bitmap size is provided for (NR_IRQS + 1) interrupts.
@@ -266,10 +266,10 @@ __print_funct_t print_irq_stats(struct activity *a, int prev, int curr,
 		 * used by sadc to create a file, and the version of sysstat
 		 * used by sar to read it...
 		 */
-		
+
 		/* Should current interrupt (including int "sum") be displayed? */
 		if (a->bitmap->b_array[i >> 3] & (1 << (i & 0x07))) {
-			
+
 			/* Yes: Display it */
 			printf("%-11s", timestamp[curr]);
 			if (!i) {
@@ -303,7 +303,7 @@ __print_funct_t print_swap_stats(struct activity *a, int prev, int curr,
 	struct stats_swap
 		*ssc = (struct stats_swap *) a->buf[curr],
 		*ssp = (struct stats_swap *) a->buf[prev];
-	
+
 	if (dis) {
 		printf("\n%-11s  pswpin/s pswpout/s\n", timestamp[!curr]);
 	}
@@ -416,7 +416,7 @@ void stub_print_memory_stats(struct activity *a, int prev, int curr,
 		avg_frskb = 0,
 		avg_tlskb = 0,
 		avg_caskb = 0;
-	
+
 	if (DISPLAY_MEMORY(a->opt_flags)) {
 		if (dis) {
 			printf("\n%-11s   frmpg/s   bufpg/s   campg/s\n",
@@ -428,7 +428,7 @@ void stub_print_memory_stats(struct activity *a, int prev, int curr,
 		       S_VALUE((double) KB_TO_PG(smp->bufkb), (double) KB_TO_PG(smc->bufkb), itv),
 		       S_VALUE((double) KB_TO_PG(smp->camkb), (double) KB_TO_PG(smc->camkb), itv));
 	}
-	
+
 	if (DISPLAY_MEM_AMT(a->opt_flags)) {
 		if (dis) {
 			printf("\n%-11s kbmemfree kbmemused  %%memused kbbuffers  kbcached"
@@ -484,13 +484,13 @@ void stub_print_memory_stats(struct activity *a, int prev, int curr,
 			       (double) avg_activekb / avg_count,
 			       (double) avg_inactkb / avg_count,
 			       (double) avg_dirtykb / avg_count);
-			
+
 			/* Reset average counters */
 			avg_frmkb = avg_bufkb = avg_camkb = avg_comkb = 0;
 			avg_activekb = avg_inactkb = avg_dirtykb = 0;
 		}
 	}
-	
+
 	if (DISPLAY_SWAP(a->opt_flags)) {
 		if (dis) {
 			printf("\n%-11s kbswpfree kbswpused  %%swpused  kbswpcad   %%swpcad\n",
@@ -536,10 +536,77 @@ void stub_print_memory_stats(struct activity *a, int prev, int curr,
 					((double) avg_tlskb / avg_count) -
 					((double) avg_frskb / avg_count)) :
 			       0.0);
-			
+
 			/* Reset average counters */
 			avg_frskb = avg_tlskb = avg_caskb = 0;
 		}
+	}
+}
+
+/*
+ ***************************************************************************
+ * Display memory extention 0 statistics. This function is used to
+ * display instantaneous and average statistics.
+ *
+ * IN:
+ * @a		Activity structure with statistics.
+ * @prev	Index in array where stats used as reference are.
+ * @curr	Index in array for current sample statistics.
+ * @itv		Interval of time in jiffies.
+ * @dispavg	TRUE if displaying average statistics.
+ ***************************************************************************
+ */
+void stub_print_memory_ext0_stats(struct activity *a, int prev, int curr,
+			     unsigned long long itv, int dispavg)
+{
+	struct stats_memory_ext0
+		*smc = (struct stats_memory_ext0 *) a->buf[curr];
+	static unsigned long long
+		avg_anonkb    = 0,
+		avg_slabkb    = 0,
+		avg_pagetblkb    = 0,
+		avg_vmallocusedkb    = 0,
+		avg_krnstckkb = 0;
+
+	if (dis) {
+		printf("\n%-11s    kbanon    kbslab kbpagetbl kbvmallocused kbkrnstck\n",
+		       timestamp[!curr]);
+	}
+
+	if (!dispavg) {
+		/* Display instantaneous values */
+		printf("%-11s %9lu %9lu %9lu %13lu %9lu\n",
+		       timestamp[curr],
+		       smc->anonkb,
+		       smc->slabkb,
+		       smc->pagetblkb,
+		       smc->vmallocusedkb,
+		       smc->krnstckkb);
+
+		/*
+		 * Will be used to compute the average.
+		 * We assume that the total amount of memory installed can not vary
+		 * during the interval given on the command line.
+		 */
+		avg_anonkb        += smc->anonkb;
+		avg_slabkb        += smc->slabkb;
+        avg_pagetblkb     += smc->pagetblkb;
+        avg_vmallocusedkb += smc->vmallocusedkb;
+		avg_krnstckkb     += smc->krnstckkb;
+	}
+	else {
+		/* Display average values */
+		printf("%-11s %9.0f %9.0f %9.0f %9.0f %9.0f\n",
+		       timestamp[curr],
+		       (double) avg_anonkb / avg_count,
+		       (double) avg_slabkb / avg_count,
+		       (double) avg_pagetblkb / avg_count,
+		       (double) avg_vmallocusedkb / avg_count,
+               (double) avg_krnstckkb / avg_count);
+
+		/* Reset average counters */
+		avg_anonkb = avg_slabkb = avg_pagetblkb = 0;
+		avg_vmallocusedkb = avg_krnstckkb = 0;
 	}
 }
 
@@ -555,6 +622,23 @@ void stub_print_memory_stats(struct activity *a, int prev, int curr,
  ***************************************************************************
  */
 __print_funct_t print_memory_stats(struct activity *a, int prev, int curr,
+				   unsigned long long itv)
+{
+	stub_print_memory_stats(a, prev, curr, itv, FALSE);
+}
+
+/*
+ ***************************************************************************
+ * Display memory extention 0 statistics.
+ *
+ * IN:
+ * @a		Activity structure with statistics.
+ * @prev	Index in array where stats used as reference are.
+ * @curr	Index in array for current sample statistics.
+ * @itv		Interval of time in jiffies.
+ ***************************************************************************
+ */
+__print_funct_t print_memory_ext0_stats(struct activity *a, int prev, int curr,
 				   unsigned long long itv)
 {
 	stub_print_memory_stats(a, prev, curr, itv, FALSE);
@@ -579,6 +663,23 @@ __print_funct_t print_avg_memory_stats(struct activity *a, int prev, int curr,
 
 /*
  ***************************************************************************
+ * Display average memory extention 0 statistics.
+ *
+ * IN:
+ * @a		Activity structure with statistics.
+ * @prev	Index in array where stats used as reference are.
+ * @curr	Index in array for current sample statistics.
+ * @itv		Interval of time in jiffies.
+ ***************************************************************************
+ */
+__print_funct_t print_avg_memory_ext0_stats(struct activity *a, int prev, int curr,
+				       unsigned long long itv)
+{
+	stub_print_memory_ext0_stats(a, prev, curr, itv, TRUE);
+}
+
+/*
+ ***************************************************************************
  * Display kernel tables statistics. This function is used to display
  * instantaneous and average statistics.
  *
@@ -597,8 +698,8 @@ void stub_print_ktables_stats(struct activity *a, int curr, int dispavg)
 		avg_file_used   = 0,
 		avg_inode_used  = 0,
 		avg_pty_nr      = 0;
-		
-	
+
+
 	if (dis) {
 		printf("\n%-11s dentunusd   file-nr  inode-nr    pty-nr\n",
 		       timestamp[!curr]);
@@ -691,7 +792,7 @@ void stub_print_queue_stats(struct activity *a, int curr, int dispavg)
 		avg_load_avg_5    = 0,
 		avg_load_avg_15   = 0,
 		avg_procs_blocked = 0;
-	
+
 	if (dis) {
 		printf("\n%-11s   runq-sz  plist-sz   ldavg-1   ldavg-5  ldavg-15   blocked\n",
 		       timestamp[!curr]);
@@ -851,14 +952,14 @@ __print_funct_t print_disk_stats(struct activity *a, int prev, int curr,
 
 		/* Compute service time, etc. */
 		compute_ext_disk_stats(sdc, sdp, itv, &xds);
-		
+
 		dev_name = NULL;
 		persist_dev_name = NULL;
 
 		if (DISPLAY_PERSIST_NAME_S(flags)) {
 			persist_dev_name = get_persistent_name_from_pretty(get_devname(sdc->major, sdc->minor, TRUE));
 		}
-		
+
 		if (persist_dev_name) {
 			dev_name = persist_dev_name;
 		}
@@ -872,7 +973,7 @@ __print_funct_t print_disk_stats(struct activity *a, int prev, int curr,
 						       USE_PRETTY_OPTION(flags));
 			}
 		}
-		
+
 		printf("%-11s %9s %9.2f %9.2f %9.2f %9.2f %9.2f %9.2f %9.2f %9.2f\n",
 		       timestamp[curr],
 		       /* Confusion possible here between index and minor numbers */
@@ -918,7 +1019,7 @@ __print_funct_t print_net_dev_stats(struct activity *a, int prev, int curr,
 
 		if (!strcmp(sndc->interface, ""))
 			continue;
-		
+
 		j = check_net_dev_reg(a, curr, prev, i);
 		sndp = (struct stats_net_dev *) ((char *) a->buf[prev] + j * a->msize);
 
@@ -926,7 +1027,7 @@ __print_funct_t print_net_dev_stats(struct activity *a, int prev, int curr,
 
 		rxkb = S_VALUE(sndp->rx_bytes, sndc->rx_bytes, itv);
 		txkb = S_VALUE(sndp->tx_bytes, sndc->tx_bytes, itv);
-		
+
 		printf(" %9.2f %9.2f %9.2f %9.2f %9.2f %9.2f %9.2f",
 		       S_VALUE(sndp->rx_packets,    sndc->rx_packets,    itv),
 		       S_VALUE(sndp->tx_packets,    sndc->tx_packets,    itv),
@@ -935,7 +1036,7 @@ __print_funct_t print_net_dev_stats(struct activity *a, int prev, int curr,
 		       S_VALUE(sndp->rx_compressed, sndc->rx_compressed, itv),
 		       S_VALUE(sndp->tx_compressed, sndc->tx_compressed, itv),
 		       S_VALUE(sndp->multicast,     sndc->multicast,     itv));
-		
+
 		ifutil = compute_ifutil(sndc, rxkb, txkb);
 		printf("    %6.2f\n", ifutil);
 	}
@@ -970,7 +1071,7 @@ __print_funct_t print_net_edev_stats(struct activity *a, int prev, int curr,
 
 		if (!strcmp(snedc->interface, ""))
 			continue;
-		
+
 		j = check_net_edev_reg(a, curr, prev, i);
 		snedp = (struct stats_net_edev *) ((char *) a->buf[prev] + j * a->msize);
 
@@ -1006,7 +1107,7 @@ __print_funct_t print_net_nfs_stats(struct activity *a, int prev, int curr,
 	struct stats_net_nfs
 		*snnc = (struct stats_net_nfs *) a->buf[curr],
 		*snnp = (struct stats_net_nfs *) a->buf[prev];
-	
+
 	if (dis) {
 		printf("\n%-11s    call/s retrans/s    read/s   write/s  access/s"
 		       "  getatt/s\n", timestamp[!curr]);
@@ -1082,7 +1183,7 @@ void stub_print_net_sock_stats(struct activity *a, int curr, int dispavg)
 		avg_raw_inuse  = 0,
 		avg_frag_inuse = 0,
 		avg_tcp_tw     = 0;
-	
+
 	if (dis) {
 		printf("\n%-11s    totsck    tcpsck    udpsck    rawsck   ip-frag    tcp-tw\n",
 		       timestamp[!curr]);
@@ -1422,7 +1523,7 @@ void stub_print_net_sock6_stats(struct activity *a, int curr, int dispavg)
 		avg_udp6_inuse  = 0,
 		avg_raw6_inuse  = 0,
 		avg_frag6_inuse = 0;
-	
+
 	if (dis) {
 		printf("\n%-11s   tcp6sck   udp6sck   raw6sck  ip6-frag\n",
 		       timestamp[!curr]);
@@ -1699,7 +1800,7 @@ void stub_print_pwr_cpufreq_stats(struct activity *a, int curr, int dispavg)
 	struct stats_pwr_cpufreq *spc;
 	static unsigned long long
 		*avg_cpufreq = NULL;
-	
+
 	if (!avg_cpufreq) {
 		/* Allocate array of CPU frequency */
 		if ((avg_cpufreq = (unsigned long long *) malloc(sizeof(unsigned long long) * a->nr))
@@ -1709,14 +1810,14 @@ void stub_print_pwr_cpufreq_stats(struct activity *a, int curr, int dispavg)
 		}
 		memset(avg_cpufreq, 0, sizeof(unsigned long long) * a->nr);
 	}
-	
+
 	if (dis) {
 		printf("\n%-11s     CPU       MHz\n",
 		       timestamp[!curr]);
 	}
 
 	for (i = 0; (i < a->nr) && (i < a->bitmap->b_size + 1); i++) {
-		
+
 		/*
 		 * The size of a->buf[...] CPU structure may be different from the default
 		 * sizeof(struct stats_pwr_cpufreq) value if data have been read from a file!
@@ -1732,13 +1833,13 @@ void stub_print_pwr_cpufreq_stats(struct activity *a, int curr, int dispavg)
 		 * used by sadc to create a file, and the version of sysstat
 		 * used by sar to read it...
 		 */
-		
+
 		/* Should current CPU (including CPU "all") be displayed? */
 		if (a->bitmap->b_array[i >> 3] & (1 << (i & 0x07))) {
 
 			/* Yes: Display it */
 			printf("%-11s", timestamp[curr]);
-			
+
 			if (!i) {
 				/* This is CPU "all" */
 				printf("     all");
@@ -1746,7 +1847,7 @@ void stub_print_pwr_cpufreq_stats(struct activity *a, int curr, int dispavg)
 			else {
 				printf("     %3d", i - 1);
 			}
-			
+
 			if (!dispavg) {
 				/* Display instantaneous values */
 				printf(" %9.2f\n",
@@ -1760,11 +1861,11 @@ void stub_print_pwr_cpufreq_stats(struct activity *a, int curr, int dispavg)
 			else {
 				/* Display average values */
 				printf(" %9.2f\n",
-				       (double) avg_cpufreq[i] / (100 * avg_count));				
+				       (double) avg_cpufreq[i] / (100 * avg_count));
 			}
 		}
 	}
-	
+
 	if (dispavg) {
 		/* Array of CPU frequency no longer needed: Free it! */
 		if (avg_cpufreq) {
@@ -1987,7 +2088,7 @@ void stub_print_pwr_temp_stats(struct activity *a, int curr, int dispavg)
 			avg_temp_min[i] = spc->temp_min;
 			avg_temp_max[i] = spc->temp_max;
 		}
-		
+
 		printf(" %*s\n", MAX_SENSORS_DEV_LEN, spc->device);
 	}
 
@@ -2356,14 +2457,14 @@ void stub_print_pwr_usb_stats(struct activity *a, int curr, int dispavg)
 		printf(" %*s", MAX_MANUF_LEN - 1, "manufact");
 		printf(" %*s\n", MAX_PROD_LEN - 1, "product");
 	}
-	
+
 	for (i = 0; i < a->nr; i++) {
 		suc = (struct stats_pwr_usb *) ((char *) a->buf[curr] + i * a->msize);
 
 		if (!suc->bus_nr)
 			/* Bus#0 doesn't exist: We are at the end of the list */
 			break;
-		
+
 		printf("%-11s  %6d %9x %9x %9u",
 		       (dispavg ? _("Summary") : timestamp[curr]),
 		       suc->bus_nr,
@@ -2409,7 +2510,7 @@ void stub_print_pwr_usb_stats(struct activity *a, int curr, int dispavg)
 			}
 		}
 	}
-}	
+}
 
 /*
  ***************************************************************************
@@ -2461,7 +2562,7 @@ __print_funct_t stub_print_filesystem_stats(struct activity *a, int curr, int di
 	int i, j;
 	struct stats_filesystem *sfc, *sfm;
 
-	
+
 	if (dis) {
 		printf("\n%-11s  MBfsfree  MBfsused   %%fsused  %%ufsused"
 		       "     Ifree     Iused    %%Iused FILESYSTEM\n",
@@ -2470,11 +2571,11 @@ __print_funct_t stub_print_filesystem_stats(struct activity *a, int curr, int di
 
 	for (i = 0; i < a->nr; i++) {
 		sfc = (struct stats_filesystem *) ((char *) a->buf[curr] + i * a->msize);
-			
+
 		if (!sfc->f_blocks)
 			/* Size of filesystem is null: We are at the end of the list */
 			break;
-			
+
 		printf("%-11s %9.0f %9.0f    %6.2f    %6.2f"
 		       " %9llu %9llu    %6.2f %s\n",
 		       (dispavg ? _("Summary") : timestamp[curr]),
@@ -2490,12 +2591,12 @@ __print_funct_t stub_print_filesystem_stats(struct activity *a, int curr, int di
 		       sfc->f_files ? SP_VALUE(sfc->f_ffree, sfc->f_files, sfc->f_files)
 				    : 0.0,
 		       sfc->fs_name);
-		
+
 		if (!dispavg) {
 			/* Save current filesystem in summary list */
 			for (j = 0; j < a->nr; j++) {
 				sfm = (struct stats_filesystem *) ((char *) a->buf[2] + j * a->msize);
-				
+
 				if (!strcmp(sfm->fs_name, sfc->fs_name) ||
 				    !sfm->f_blocks) {
 					/*

--- a/pr_stats.h
+++ b/pr_stats.h
@@ -30,6 +30,8 @@ extern __print_funct_t print_io_stats
 	(struct activity *, int, int, unsigned long long);
 extern __print_funct_t print_memory_stats
 	(struct activity *, int, int, unsigned long long);
+extern __print_funct_t print_memory_ext0_stats
+	(struct activity *, int, int, unsigned long long);
 extern __print_funct_t print_ktables_stats
 	(struct activity *, int, int, unsigned long long);
 extern __print_funct_t print_queue_stats
@@ -93,6 +95,8 @@ extern __print_funct_t print_filesystem_stats
 
 /* Functions used to display average statistics */
 extern __print_funct_t print_avg_memory_stats
+	(struct activity *, int, int, unsigned long long);
+extern __print_funct_t print_avg_memory_ext0_stats
 	(struct activity *, int, int, unsigned long long);
 extern __print_funct_t print_avg_ktables_stats
 	(struct activity *, int, int, unsigned long long);

--- a/rd_stats.h
+++ b/rd_stats.h
@@ -166,9 +166,25 @@ struct stats_memory {
 	unsigned long activekb	__attribute__ ((aligned (8)));
 	unsigned long inactkb	__attribute__ ((aligned (8)));
 	unsigned long dirtykb	__attribute__ ((aligned (8)));
+	unsigned long anonkb	__attribute__ ((aligned (8)));
+	unsigned long slabkb	__attribute__ ((aligned (8)));
+	unsigned long pagetblkb	__attribute__ ((aligned (8)));
+	unsigned long vmallocusdkb	__attribute__ ((aligned (8)));
+	unsigned long krnstckkb	__attribute__ ((aligned (8)));
 };
 
 #define STATS_MEMORY_SIZE	(sizeof(struct stats_memory))
+
+/* Structure for memory and swap space utilization statistics */
+struct stats_memory_ext0 {
+	unsigned long anonkb	__attribute__ ((aligned (8)));
+	unsigned long slabkb	__attribute__ ((aligned (8)));
+	unsigned long pagetblkb	__attribute__ ((aligned (8)));
+	unsigned long vmallocusedkb	__attribute__ ((aligned (8)));
+	unsigned long krnstckkb	__attribute__ ((aligned (8)));
+};
+
+#define STATS_MEMORY_EXT0_SIZE	(sizeof(struct stats_memory_ext0))
 
 /* Structure for kernel tables statistics */
 struct stats_ktables {
@@ -557,6 +573,8 @@ extern void
 	read_stat_irq(struct stats_irq *, int);
 extern void
 	read_meminfo(struct stats_memory *);
+extern void
+	read_meminfo_ext0(struct stats_memory_ext0 *);
 extern void
 	read_uptime(unsigned long long *);
 

--- a/rndr_stats.c
+++ b/rndr_stats.c
@@ -180,13 +180,13 @@ __print_funct_t render_cpu_stats(struct activity *a, int isdb, char *pre,
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
 
 	for (i = 0; (i < a->nr) && (i < a->bitmap->b_size + 1); i++) {
-		
+
 		scc = (struct stats_cpu *) ((char *) a->buf[curr]  + i * a->msize);
 		scp = (struct stats_cpu *) ((char *) a->buf[!curr] + i * a->msize);
 
 		/* Should current CPU (including CPU "all") be displayed? */
 		if (a->bitmap->b_array[i >> 3] & (1 << (i & 0x07))) {
-			
+
 			if (!i) {
 				/* This is CPU "all" */
 				if (DISPLAY_CPU_DEF(a->opt_flags)) {
@@ -210,7 +210,7 @@ __print_funct_t render_cpu_stats(struct activity *a, int isdb, char *pre,
 							   g_itv),
 					       NULL);
 				}
-				
+
 				if (DISPLAY_CPU_DEF(a->opt_flags)) {
 					render(isdb, pre, PT_NOFLAG,
 					       "all\t%%nice", NULL, NULL,
@@ -228,7 +228,7 @@ __print_funct_t render_cpu_stats(struct activity *a, int isdb, char *pre,
 							   scc->cpu_nice - scc->cpu_guest_nice,
 							   g_itv),
 					       NULL);
-				}				
+				}
 
 				if (DISPLAY_CPU_DEF(a->opt_flags)) {
 					render(isdb, pre, PT_NOFLAG,
@@ -246,7 +246,7 @@ __print_funct_t render_cpu_stats(struct activity *a, int isdb, char *pre,
 					       ll_sp_value(scp->cpu_sys, scc->cpu_sys, g_itv),
 					       NULL);
 				}
-				
+
 				render(isdb, pre, PT_NOFLAG,
 				       "all\t%%iowait", NULL, NULL,
 				       NOVAL,
@@ -309,7 +309,7 @@ __print_funct_t render_cpu_stats(struct activity *a, int isdb, char *pre,
 					 * jump from zero when the CPU comes back online.
 					 */
 					*scc = *scp;
-					
+
 					g_itv = 0;
 					cpu_offline = TRUE;
 				}
@@ -344,7 +344,7 @@ __print_funct_t render_cpu_stats(struct activity *a, int isdb, char *pre,
 							   scc->cpu_user - scc->cpu_guest, g_itv),
 					       NULL);
 				}
-				
+
 				if (DISPLAY_CPU_DEF(a->opt_flags)) {
 					render(isdb, pre, PT_NOFLAG,
 					       "cpu%d\t%%nice", NULL, cons(iv, i - 1, NOVAL),
@@ -386,7 +386,7 @@ __print_funct_t render_cpu_stats(struct activity *a, int isdb, char *pre,
 					       ll_sp_value(scp->cpu_sys, scc->cpu_sys, g_itv),
 					       NULL);
 				}
-				
+
 				render(isdb, pre, PT_NOFLAG,
 				       "cpu%d\t%%iowait", NULL, cons(iv, i - 1, NOVAL),
 				       NOVAL,
@@ -419,7 +419,7 @@ __print_funct_t render_cpu_stats(struct activity *a, int isdb, char *pre,
 					       0.0 :
 					       ll_sp_value(scp->cpu_softirq, scc->cpu_softirq, g_itv),
 					       NULL);
-					
+
 					render(isdb, pre, PT_NOFLAG,
 					       "cpu%d\t%%guest", NULL, cons(iv, i - 1, NOVAL),
 					       NOVAL,
@@ -436,7 +436,7 @@ __print_funct_t render_cpu_stats(struct activity *a, int isdb, char *pre,
 					       ll_sp_value(scp->cpu_guest_nice, scc->cpu_guest_nice, g_itv),
 					       NULL);
 				}
-				
+
 				if (!g_itv) {
 					/* CPU is offline or tickless */
 					render(isdb, pre, pt_newlin,
@@ -480,7 +480,7 @@ __print_funct_t render_pcsw_stats(struct activity *a, int isdb, char *pre,
 		*spp = (struct stats_pcsw *) a->buf[!curr];
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-	
+
 	/* The first one as an example */
 	render(isdb,		/* db/ppc flag */
 	       pre,		/* the preformatted line leader */
@@ -519,15 +519,15 @@ __print_funct_t render_irq_stats(struct activity *a, int isdb, char *pre,
 	struct stats_irq *sic, *sip;
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-	
+
 	for (i = 0; (i < a->nr) && (i < a->bitmap->b_size + 1); i++) {
 
 		sic = (struct stats_irq *) ((char *) a->buf[curr]  + i * a->msize);
 		sip = (struct stats_irq *) ((char *) a->buf[!curr] + i * a->msize);
-		
+
 		/* Should current interrupt (including int "sum") be displayed? */
 		if (a->bitmap->b_array[i >> 3] & (1 << (i & 0x07))) {
-			
+
 			/* Yes: Display it */
 			if (!i) {
 				/* This is interrupt "sum" */
@@ -568,7 +568,7 @@ __print_funct_t render_swap_stats(struct activity *a, int isdb, char *pre,
 		*ssp = (struct stats_swap *) a->buf[!curr];
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tpswpin/s", NULL, NULL,
 	       NOVAL,
@@ -733,7 +733,7 @@ __print_funct_t render_memory_stats(struct activity *a, int isdb, char *pre,
 		*smp = (struct stats_memory *) a->buf[!curr];
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-		
+
 	if (DISPLAY_MEMORY(a->opt_flags)) {
 
 		render(isdb, pre, PT_NOFLAG,
@@ -804,7 +804,7 @@ __print_funct_t render_memory_stats(struct activity *a, int isdb, char *pre,
 		       "-\tkbdirty", NULL, NULL,
 		       smc->dirtykb, DNOVAL, NULL);
 	}
-	
+
 	if (DISPLAY_SWAP(a->opt_flags)) {
 
 		render(isdb, pre, PT_USEINT,
@@ -835,6 +835,47 @@ __print_funct_t render_memory_stats(struct activity *a, int isdb, char *pre,
 
 /*
  ***************************************************************************
+ * Display memory extention 0 statistics in selected format.
+ *
+ * IN:
+ * @a		Activity structure with statistics.
+ * @isdb	Flag, true if db printing, false if ppc printing.
+ * @pre		Prefix string for output entries
+ * @curr	Index in array for current sample statistics.
+ * @itv		Interval of time in jiffies.
+ ***************************************************************************
+ */
+__print_funct_t render_memory_ext0_stats(struct activity *a, int isdb, char *pre,
+				    int curr, unsigned long long itv)
+{
+	struct stats_memory_ext0
+		*smc = (struct stats_memory_ext0 *) a->buf[curr];
+	int pt_newlin
+		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
+
+	render(isdb, pre, PT_USEINT,
+	       "-\tkbanon", NULL, NULL,
+	       smc->anonkb, DNOVAL, NULL);
+
+	render(isdb, pre, PT_USEINT,
+	       "-\tkbslab", NULL, NULL,
+	       smc->slabkb, DNOVAL, NULL);
+
+	render(isdb, pre, PT_USEINT,
+	       "-\tkbpagetbl", NULL, NULL,
+	       smc->pagetblkb, DNOVAL, NULL);
+
+	render(isdb, pre, PT_USEINT,
+	       "-\tkbvmallocused", NULL, NULL,
+	       smc->vmallocusedkb, DNOVAL, NULL);
+
+	render(isdb, pre, PT_USEINT | pt_newlin,
+	       "-\tkbkrnstck", NULL, NULL,
+	       smc->krnstckkb, DNOVAL, NULL);
+}
+
+/*
+ ***************************************************************************
  * Display kernel tables statistics in selected format.
  *
  * IN:
@@ -852,7 +893,7 @@ __print_funct_t render_ktables_stats(struct activity *a, int isdb, char *pre,
 		*skc = (struct stats_ktables *) a->buf[curr];
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-	
+
 	render(isdb, pre, PT_USEINT,
 	       "-\tdentunusd", NULL, NULL,
 	       skc->dentry_stat, DNOVAL, NULL);
@@ -889,7 +930,7 @@ __print_funct_t render_queue_stats(struct activity *a, int isdb, char *pre,
 		*sqc = (struct stats_queue *) a->buf[curr];
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-	
+
 	render(isdb, pre, PT_USEINT,
 	       "-\trunq-sz", NULL, NULL,
 	       sqc->nr_running, DNOVAL, NULL);
@@ -915,7 +956,7 @@ __print_funct_t render_queue_stats(struct activity *a, int isdb, char *pre,
 	       NOVAL,
 	       (double) sqc->load_avg_15 / 100,
 	       NULL);
-	
+
 	render(isdb, pre, PT_USEINT | pt_newlin,
 	       "-\tblocked", NULL, NULL,
 	       sqc->procs_blocked, DNOVAL, NULL);
@@ -1026,7 +1067,7 @@ __print_funct_t render_disk_stats(struct activity *a, int isdb, char *pre,
 
 		j = check_disk_reg(a, curr, !curr, i);
 		sdp = (struct stats_disk *) ((char *) a->buf[!curr] + j * a->msize);
-		
+
 		/* Compute extended stats (service time, etc.) */
 		compute_ext_disk_stats(sdc, sdp, itv, &xds);
 
@@ -1036,7 +1077,7 @@ __print_funct_t render_disk_stats(struct activity *a, int isdb, char *pre,
 		if (DISPLAY_PERSIST_NAME_S(flags)) {
 			persist_dev_name = get_persistent_name_from_pretty(get_devname(sdc->major, sdc->minor, TRUE));
 		}
-		
+
 		if (persist_dev_name) {
 			dev_name = persist_dev_name;
 		}
@@ -1136,7 +1177,7 @@ __print_funct_t render_net_dev_stats(struct activity *a, int isdb, char *pre,
 
 		if (!strcmp(sndc->interface, ""))
 			continue;
-		
+
 		j = check_net_dev_reg(a, curr, !curr, i);
 		sndp = (struct stats_net_dev *) ((char *) a->buf[!curr] + j * a->msize);
 
@@ -1190,7 +1231,7 @@ __print_funct_t render_net_dev_stats(struct activity *a, int isdb, char *pre,
 		       NOVAL,
 		       S_VALUE(sndp->multicast, sndc->multicast, itv),
 		       NULL);
-		
+
 		ifutil = compute_ifutil(sndc, rxkb, txkb);
 		render(isdb, pre, pt_newlin,
 		       "%s\t%%ifutil", NULL,
@@ -1227,7 +1268,7 @@ __print_funct_t render_net_edev_stats(struct activity *a, int isdb, char *pre,
 
 		if (!strcmp(snedc->interface, ""))
 			continue;
-		
+
 		j = check_net_edev_reg(a, curr, !curr, i);
 		snedp = (struct stats_net_edev *) ((char *) a->buf[!curr] + j * a->msize);
 
@@ -1316,7 +1357,7 @@ __print_funct_t render_net_nfs_stats(struct activity *a, int isdb, char *pre,
 		*snnp = (struct stats_net_nfs *) a->buf[!curr];
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tcall/s", NULL, NULL,
 	       NOVAL,
@@ -1507,7 +1548,7 @@ __print_funct_t render_net_ip_stats(struct activity *a, int isdb, char *pre,
 		*snip = (struct stats_net_ip *) a->buf[!curr];
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tirec/s", NULL, NULL,
 	       NOVAL,
@@ -1543,7 +1584,7 @@ __print_funct_t render_net_ip_stats(struct activity *a, int isdb, char *pre,
 	       NOVAL,
 	       S_VALUE(snip->ReasmOKs, snic->ReasmOKs, itv),
 	       NULL);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tfragok/s", NULL, NULL,
 	       NOVAL,
@@ -1577,7 +1618,7 @@ __print_funct_t render_net_eip_stats(struct activity *a, int isdb, char *pre,
 		*sneip = (struct stats_net_eip *) a->buf[!curr];
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tihdrerr/s", NULL, NULL,
 	       NOVAL,
@@ -1613,7 +1654,7 @@ __print_funct_t render_net_eip_stats(struct activity *a, int isdb, char *pre,
 	       NOVAL,
 	       S_VALUE(sneip->OutNoRoutes, sneic->OutNoRoutes, itv),
 	       NULL);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tasmf/s", NULL, NULL,
 	       NOVAL,
@@ -1647,7 +1688,7 @@ __print_funct_t render_net_icmp_stats(struct activity *a, int isdb, char *pre,
 		*snip = (struct stats_net_icmp *) a->buf[!curr];
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\timsg/s", NULL, NULL,
 	       NOVAL,
@@ -1659,7 +1700,7 @@ __print_funct_t render_net_icmp_stats(struct activity *a, int isdb, char *pre,
 	       NOVAL,
 	       S_VALUE(snip->OutMsgs, snic->OutMsgs, itv),
 	       NULL);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tiech/s", NULL, NULL,
 	       NOVAL,
@@ -1689,7 +1730,7 @@ __print_funct_t render_net_icmp_stats(struct activity *a, int isdb, char *pre,
 	       NOVAL,
 	       S_VALUE(snip->InTimestamps, snic->InTimestamps, itv),
 	       NULL);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\titmr/s", NULL, NULL,
 	       NOVAL,
@@ -1701,7 +1742,7 @@ __print_funct_t render_net_icmp_stats(struct activity *a, int isdb, char *pre,
 	       NOVAL,
 	       S_VALUE(snip->OutTimestamps, snic->OutTimestamps, itv),
 	       NULL);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\totmr/s", NULL, NULL,
 	       NOVAL,
@@ -1713,19 +1754,19 @@ __print_funct_t render_net_icmp_stats(struct activity *a, int isdb, char *pre,
 	       NOVAL,
 	       S_VALUE(snip->InAddrMasks, snic->InAddrMasks, itv),
 	       NULL);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tiadrmkr/s", NULL, NULL,
 	       NOVAL,
 	       S_VALUE(snip->InAddrMaskReps, snic->InAddrMaskReps, itv),
 	       NULL);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\toadrmk/s", NULL, NULL,
 	       NOVAL,
 	       S_VALUE(snip->OutAddrMasks, snic->OutAddrMasks, itv),
 	       NULL);
-	
+
 	render(isdb, pre, pt_newlin,
 	       "-\toadrmkr/s", NULL, NULL,
 	       NOVAL,
@@ -1753,7 +1794,7 @@ __print_funct_t render_net_eicmp_stats(struct activity *a, int isdb, char *pre,
 		*sneip = (struct stats_net_eicmp *) a->buf[!curr];
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tierr/s", NULL, NULL,
 	       NOVAL,
@@ -1765,7 +1806,7 @@ __print_funct_t render_net_eicmp_stats(struct activity *a, int isdb, char *pre,
 	       NOVAL,
 	       S_VALUE(sneip->OutErrors, sneic->OutErrors, itv),
 	       NULL);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tidstunr/s", NULL, NULL,
 	       NOVAL,
@@ -1795,7 +1836,7 @@ __print_funct_t render_net_eicmp_stats(struct activity *a, int isdb, char *pre,
 	       NOVAL,
 	       S_VALUE(sneip->InParmProbs, sneic->InParmProbs, itv),
 	       NULL);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\toparmpb/s", NULL, NULL,
 	       NOVAL,
@@ -1847,7 +1888,7 @@ __print_funct_t render_net_tcp_stats(struct activity *a, int isdb, char *pre,
 		*sntp = (struct stats_net_tcp *) a->buf[!curr];
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tactive/s", NULL, NULL,
 	       NOVAL,
@@ -1893,19 +1934,19 @@ __print_funct_t render_net_etcp_stats(struct activity *a, int isdb, char *pre,
 		*snetp = (struct stats_net_etcp *) a->buf[!curr];
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tatmptf/s", NULL, NULL,
 	       NOVAL,
 	       S_VALUE(snetp->AttemptFails, snetc->AttemptFails, itv),
 	       NULL);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\testres/s", NULL, NULL,
 	       NOVAL,
 	       S_VALUE(snetp->EstabResets, snetc->EstabResets, itv),
 	       NULL);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tretrans/s", NULL, NULL,
 	       NOVAL,
@@ -1945,7 +1986,7 @@ __print_funct_t render_net_udp_stats(struct activity *a, int isdb, char *pre,
 		*snup = (struct stats_net_udp *) a->buf[!curr];
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tidgm/s", NULL, NULL,
 	       NOVAL,
@@ -2028,7 +2069,7 @@ __print_funct_t render_net_ip6_stats(struct activity *a, int isdb, char *pre,
 		*snip = (struct stats_net_ip6 *) a->buf[!curr];
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tirec6/s", NULL, NULL,
 	       NOVAL,
@@ -2076,7 +2117,7 @@ __print_funct_t render_net_ip6_stats(struct activity *a, int isdb, char *pre,
 	       NOVAL,
 	       S_VALUE(snip->OutMcastPkts6, snic->OutMcastPkts6, itv),
 	       NULL);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tfragok6/s", NULL, NULL,
 	       NOVAL,
@@ -2110,7 +2151,7 @@ __print_funct_t render_net_eip6_stats(struct activity *a, int isdb, char *pre,
 		*sneip = (struct stats_net_eip6 *) a->buf[!curr];
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tihdrer6/s", NULL, NULL,
 	       NOVAL,
@@ -2158,7 +2199,7 @@ __print_funct_t render_net_eip6_stats(struct activity *a, int isdb, char *pre,
 	       NOVAL,
 	       S_VALUE(sneip->OutNoRoutes6, sneic->OutNoRoutes6, itv),
 	       NULL);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tasmf6/s", NULL, NULL,
 	       NOVAL,
@@ -2170,7 +2211,7 @@ __print_funct_t render_net_eip6_stats(struct activity *a, int isdb, char *pre,
 	       NOVAL,
 	       S_VALUE(sneip->FragFails6, sneic->FragFails6, itv),
 	       NULL);
-	
+
 	render(isdb, pre, pt_newlin,
 	       "-\titrpck6/s", NULL, NULL,
 	       NOVAL,
@@ -2198,7 +2239,7 @@ __print_funct_t render_net_icmp6_stats(struct activity *a, int isdb, char *pre,
 		*snip = (struct stats_net_icmp6 *) a->buf[!curr];
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\timsg6/s", NULL, NULL,
 	       NOVAL,
@@ -2210,7 +2251,7 @@ __print_funct_t render_net_icmp6_stats(struct activity *a, int isdb, char *pre,
 	       NOVAL,
 	       S_VALUE(snip->OutMsgs6, snic->OutMsgs6, itv),
 	       NULL);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tiech6/s", NULL, NULL,
 	       NOVAL,
@@ -2270,7 +2311,7 @@ __print_funct_t render_net_icmp6_stats(struct activity *a, int isdb, char *pre,
 	       NOVAL,
 	       S_VALUE(snip->OutRouterSolicits6, snic->OutRouterSolicits6, itv),
 	       NULL);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tirtad6/s", NULL, NULL,
 	       NOVAL,
@@ -2288,7 +2329,7 @@ __print_funct_t render_net_icmp6_stats(struct activity *a, int isdb, char *pre,
 	       NOVAL,
 	       S_VALUE(snip->OutNeighborSolicits6, snic->OutNeighborSolicits6, itv),
 	       NULL);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tinbad6/s", NULL, NULL,
 	       NOVAL,
@@ -2322,7 +2363,7 @@ __print_funct_t render_net_eicmp6_stats(struct activity *a, int isdb, char *pre,
 		*sneip = (struct stats_net_eicmp6 *) a->buf[!curr];
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tierr6/s", NULL, NULL,
 	       NOVAL,
@@ -2358,7 +2399,7 @@ __print_funct_t render_net_eicmp6_stats(struct activity *a, int isdb, char *pre,
 	       NOVAL,
 	       S_VALUE(sneip->InParmProblems6, sneic->InParmProblems6, itv),
 	       NULL);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\toprmpb6/s", NULL, NULL,
 	       NOVAL,
@@ -2410,7 +2451,7 @@ __print_funct_t render_net_udp6_stats(struct activity *a, int isdb, char *pre,
 		*snup = (struct stats_net_udp6 *) a->buf[!curr];
 	int pt_newlin
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
-	
+
 	render(isdb, pre, PT_NOFLAG,
 	       "-\tidgm6/s", NULL, NULL,
 	       NOVAL,
@@ -2457,12 +2498,12 @@ __print_funct_t render_pwr_cpufreq_stats(struct activity *a, int isdb, char *pre
 		= (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN);
 
 	for (i = 0; (i < a->nr) && (i < a->bitmap->b_size + 1); i++) {
-		
+
 		spc = (struct stats_pwr_cpufreq *) ((char *) a->buf[curr] + i * a->msize);
 
 		/* Should current CPU (including CPU "all") be displayed? */
 		if (a->bitmap->b_array[i >> 3] & (1 << (i & 0x07))) {
-			
+
 			if (!i) {
 				/* This is CPU "all" */
 				render(isdb, pre, pt_newlin,
@@ -2714,7 +2755,7 @@ __print_funct_t render_pwr_wghfreq_stats(struct activity *a, int isdb, char *pre
 				           (spc_k->time_in_state - spp_k->time_in_state);
 				tis     += (spc_k->time_in_state - spp_k->time_in_state);
 			}
-			
+
 			if (!i) {
 				/* This is CPU "all" */
 				render(isdb, pre, pt_newlin,

--- a/rndr_stats.h
+++ b/rndr_stats.h
@@ -60,6 +60,8 @@ extern __print_funct_t render_io_stats
 	(struct activity *, int, char *, int, unsigned long long);
 extern __print_funct_t render_memory_stats
 	(struct activity *, int, char *, int, unsigned long long);
+extern __print_funct_t render_memory_ext0_stats
+	(struct activity *, int, char *, int, unsigned long long);
 extern __print_funct_t render_ktables_stats
 	(struct activity *, int, char *, int, unsigned long long);
 extern __print_funct_t render_queue_stats

--- a/sa.h
+++ b/sa.h
@@ -20,7 +20,7 @@
  */
 
 /* Number of activities */
-#define NR_ACT	37
+#define NR_ACT	38
 
 /* Activities */
 #define A_CPU		1
@@ -60,6 +60,7 @@
 #define A_PWR_WGHFREQ	35
 #define A_PWR_USB	36
 #define A_FILESYSTEM	37
+#define A_MEMORYEXT0	38
 
 
 /* Macro used to flag an activity that should be collected */
@@ -725,7 +726,7 @@ extern __nr_t
 	wrap_get_usb_nr(struct activity *);
 extern __nr_t
 	wrap_get_filesystem_nr(struct activity *);
-	
+
 /* Functions used to read activities statistics */
 extern __read_funct_t
 	wrap_read_stat_cpu(struct activity *);
@@ -741,6 +742,8 @@ extern __read_funct_t
 	wrap_read_io(struct activity *);
 extern __read_funct_t
 	wrap_read_meminfo(struct activity *);
+extern __read_funct_t
+	wrap_read_meminfo_ext0(struct activity *);
 extern __read_funct_t
 	wrap_read_kernel_tables(struct activity *);
 extern __read_funct_t

--- a/sa_wrap.c
+++ b/sa_wrap.c
@@ -42,10 +42,10 @@ __read_funct_t wrap_read_stat_cpu(struct activity *a)
 {
 	struct stats_cpu *st_cpu
 		= (struct stats_cpu *) a->_buf0;
-	
+
 	/* Read CPU statistics */
 	read_stat_cpu(st_cpu, a->nr, &record_hdr.uptime, &record_hdr.uptime0);
-	
+
 	return;
 }
 
@@ -67,7 +67,7 @@ __read_funct_t wrap_read_stat_pcsw(struct activity *a)
 
 	/* Read process and context switch stats */
 	read_stat_pcsw(st_pcsw);
-	
+
 	return;
 }
 
@@ -89,7 +89,7 @@ __read_funct_t wrap_read_stat_irq(struct activity *a)
 
 	/* Read interrupts stats */
 	read_stat_irq(st_irq, a->nr);
-	
+
 	return;
 }
 
@@ -111,7 +111,7 @@ __read_funct_t wrap_read_loadavg(struct activity *a)
 
 	/* Read queue and load stats */
 	read_loadavg(st_queue);
-	
+
 	return;
 }
 
@@ -133,7 +133,29 @@ __read_funct_t wrap_read_meminfo(struct activity *a)
 
 	/* Read memory stats */
 	read_meminfo(st_memory);
-	
+
+	return;
+}
+
+/*
+ ***************************************************************************
+ * Read memory extention 0 statistics.
+ *
+ * IN:
+ * @a	Activity structure.
+ *
+ * OUT:
+ * @a	Activity structure with statistics.
+ ***************************************************************************
+ */
+__read_funct_t wrap_read_meminfo_ext0(struct activity *a)
+{
+	struct stats_memory_ext0 *st_memory
+		= (struct stats_memory_ext0 *) a->_buf0;
+
+	/* Read memory stats */
+	read_meminfo_ext0(st_memory);
+
 	return;
 }
 
@@ -155,7 +177,7 @@ __read_funct_t wrap_read_swap(struct activity *a)
 
 	/* Read stats from /proc/vmstat */
 	read_vmstat_swap(st_swap);
-	
+
 	return;
 }
 
@@ -177,7 +199,7 @@ __read_funct_t wrap_read_paging(struct activity *a)
 
 	/* Read stats from /proc/vmstat */
 	read_vmstat_paging(st_paging);
-	
+
 	return;
 }
 
@@ -243,7 +265,7 @@ __read_funct_t wrap_read_tty_driver_serial(struct activity *a)
 
 	/* Read serial lines stats */
 	read_tty_driver_serial(st_serial, a->nr);
-	
+
 	return;
 }
 
@@ -265,7 +287,7 @@ __read_funct_t wrap_read_kernel_tables(struct activity *a)
 
 	/* Read kernel tables stats */
 	read_kernel_tables(st_ktables);
-	
+
 	return;
 }
 
@@ -291,10 +313,10 @@ __read_funct_t wrap_read_net_dev(struct activity *a)
 	if (!dev)
 		/* No data read. Exit */
 		return;
-	
+
 	/* Read duplex and speed info for each interface */
 	read_if_info(st_net_dev, dev);
-	
+
 	return;
 }
 
@@ -316,7 +338,7 @@ __read_funct_t wrap_read_net_edev(struct activity *a)
 
 	/* Read network interfaces errors stats */
 	read_net_edev(st_net_edev, a->nr);
-	
+
 	return;
 }
 
@@ -338,7 +360,7 @@ __read_funct_t wrap_read_net_nfs(struct activity *a)
 
 	/* Read NFS client stats */
 	read_net_nfs(st_net_nfs);
-	
+
 	return;
 }
 
@@ -360,7 +382,7 @@ __read_funct_t wrap_read_net_nfsd(struct activity *a)
 
 	/* Read NFS server stats */
 	read_net_nfsd(st_net_nfsd);
-	
+
 	return;
 }
 
@@ -382,7 +404,7 @@ __read_funct_t wrap_read_net_sock(struct activity *a)
 
 	/* Read network sockets stats */
 	read_net_sock(st_net_sock);
-	
+
 	return;
 }
 
@@ -404,7 +426,7 @@ __read_funct_t wrap_read_net_ip(struct activity *a)
 
 	/* Read IP stats */
 	read_net_ip(st_net_ip);
-	
+
 	return;
 }
 
@@ -426,7 +448,7 @@ __read_funct_t wrap_read_net_eip(struct activity *a)
 
 	/* Read IP error stats */
 	read_net_eip(st_net_eip);
-	
+
 	return;
 }
 
@@ -448,7 +470,7 @@ __read_funct_t wrap_read_net_icmp(struct activity *a)
 
 	/* Read ICMP stats */
 	read_net_icmp(st_net_icmp);
-	
+
 	return;
 }
 
@@ -470,7 +492,7 @@ __read_funct_t wrap_read_net_eicmp(struct activity *a)
 
 	/* Read ICMP error stats */
 	read_net_eicmp(st_net_eicmp);
-	
+
 	return;
 }
 
@@ -492,7 +514,7 @@ __read_funct_t wrap_read_net_tcp(struct activity *a)
 
 	/* Read TCP stats */
 	read_net_tcp(st_net_tcp);
-	
+
 	return;
 }
 
@@ -514,7 +536,7 @@ __read_funct_t wrap_read_net_etcp(struct activity *a)
 
 	/* Read TCP error stats */
 	read_net_etcp(st_net_etcp);
-	
+
 	return;
 }
 
@@ -536,7 +558,7 @@ __read_funct_t wrap_read_net_udp(struct activity *a)
 
 	/* Read UDP stats */
 	read_net_udp(st_net_udp);
-	
+
 	return;
 }
 
@@ -558,7 +580,7 @@ __read_funct_t wrap_read_net_sock6(struct activity *a)
 
 	/* Read IPv6 network sockets stats */
 	read_net_sock6(st_net_sock6);
-	
+
 	return;
 }
 
@@ -580,7 +602,7 @@ __read_funct_t wrap_read_net_ip6(struct activity *a)
 
 	/* Read IPv6 stats */
 	read_net_ip6(st_net_ip6);
-	
+
 	return;
 }
 
@@ -602,7 +624,7 @@ __read_funct_t wrap_read_net_eip6(struct activity *a)
 
 	/* Read IPv6 error stats */
 	read_net_eip6(st_net_eip6);
-	
+
 	return;
 }
 
@@ -624,7 +646,7 @@ __read_funct_t wrap_read_net_icmp6(struct activity *a)
 
 	/* Read ICMPv6 stats */
 	read_net_icmp6(st_net_icmp6);
-	
+
 	return;
 }
 
@@ -646,7 +668,7 @@ __read_funct_t wrap_read_net_eicmp6(struct activity *a)
 
 	/* Read ICMPv6 error stats */
 	read_net_eicmp6(st_net_eicmp6);
-	
+
 	return;
 }
 
@@ -668,7 +690,7 @@ __read_funct_t wrap_read_net_udp6(struct activity *a)
 
 	/* Read UDPv6 stats */
 	read_net_udp6(st_net_udp6);
-	
+
 	return;
 }
 
@@ -690,7 +712,7 @@ __read_funct_t wrap_read_cpuinfo(struct activity *a)
 
 	/* Read CPU frequency stats */
 	read_cpuinfo(st_pwr_cpufreq, a->nr);
-	
+
 	return;
 }
 
@@ -1076,7 +1098,7 @@ __nr_t wrap_get_usb_nr(struct activity *a)
 	if ((n = get_usb_nr()) >= 0)
 		/* Return a positive number even if no USB devices have been found */
 		return n + NR_USB_PREALLOC;
-	
+
 	return 0;
 }
 

--- a/xml_stats.c
+++ b/xml_stats.c
@@ -310,7 +310,7 @@ __print_funct_t xml_print_irq_stats(struct activity *a, int curr, int tab,
 
 		sic = (struct stats_irq *) ((char *) a->buf[curr]  + i * a->msize);
 		sip = (struct stats_irq *) ((char *) a->buf[!curr] + i * a->msize);
-		
+
 		/* Should current interrupt (including int "sum") be displayed? */
 		if (a->bitmap->b_array[i >> 3] & (1 << (i & 0x07))) {
 
@@ -349,7 +349,7 @@ __print_funct_t xml_print_swap_stats(struct activity *a, int curr, int tab,
 	struct stats_swap
 		*ssc = (struct stats_swap *) a->buf[curr],
 		*ssp = (struct stats_swap *) a->buf[!curr];
-	
+
 	xprintf(tab, "<swap-pages per=\"second\" "
 		"pswpin=\"%.2f\" "
 		"pswpout=\"%.2f\"/>",
@@ -486,7 +486,7 @@ __print_funct_t xml_print_memory_stats(struct activity *a, int curr, int tab,
 
 		xprintf(tab, "<inactive>%lu</inactive>",
 			smc->inactkb);
-		
+
 		xprintf(tab--, "<dirty>%lu</dirty>",
 			smc->dirtykb);
 	}
@@ -533,6 +533,43 @@ __print_funct_t xml_print_memory_stats(struct activity *a, int curr, int tab,
 
 /*
  ***************************************************************************
+ * Display memory extention 0 statistics in XML.
+ *
+ * IN:
+ * @a		Activity structure with statistics.
+ * @curr	Index in array for current sample statistics.
+ * @tab		Indentation in XML output.
+ * @itv		Interval of time in jiffies.
+ ***************************************************************************
+ */
+__print_funct_t xml_print_memory_ext0_stats(struct activity *a, int curr, int tab,
+				       unsigned long long itv)
+{
+	struct stats_memory_ext0
+		*smc = (struct stats_memory_ext0 *) a->buf[curr];
+
+	xprintf(tab, "<memory-ext0 per=\"second\" unit=\"kB\">");
+
+	xprintf(++tab, "<anonpages>%lu</anonpages>",
+		smc->anonkb);
+
+	xprintf(tab, "<slab>%lu</slab>",
+		smc->slabkb);
+
+	xprintf(tab, "<pagetables>%lu</pagetables>",
+		smc->pagetblkb);
+
+	xprintf(tab, "<vmallocused>%lu</vmallocused>",
+		smc->vmallocusedkb);
+
+	xprintf(tab--, "<kernelstack>%lu</kernelstack>",
+		smc->krnstckkb);
+
+	xprintf(tab, "</memory-ext0>");
+}
+
+/*
+ ***************************************************************************
  * Display kernel tables statistics in XML.
  *
  * IN:
@@ -547,7 +584,7 @@ __print_funct_t xml_print_ktables_stats(struct activity *a, int curr, int tab,
 {
 	struct stats_ktables
 		*skc = (struct stats_ktables *) a->buf[curr];
-	
+
 	xprintf(tab, "<kernel "
 		"dentunusd=\"%u\" "
 		"file-nr=\"%u\" "
@@ -575,7 +612,7 @@ __print_funct_t xml_print_queue_stats(struct activity *a, int curr, int tab,
 {
 	struct stats_queue
 		*sqc = (struct stats_queue *) a->buf[curr];
-	
+
 	xprintf(tab, "<queue "
 		"runq-sz=\"%lu\" "
 		"plist-sz=\"%u\" "
@@ -682,7 +719,7 @@ __print_funct_t xml_print_disk_stats(struct activity *a, int curr, int tab,
 		if (DISPLAY_PERSIST_NAME_S(flags)) {
 			persist_dev_name = get_persistent_name_from_pretty(get_devname(sdc->major, sdc->minor, TRUE));
 		}
-		
+
 		if (persist_dev_name) {
 			dev_name = persist_dev_name;
 		}
@@ -1267,7 +1304,7 @@ __print_funct_t xml_print_net_etcp_stats(struct activity *a, int curr, int tab,
 	struct stats_net_etcp
 		*snetc = (struct stats_net_etcp *) a->buf[curr],
 		*snetp = (struct stats_net_etcp *) a->buf[!curr];
-	
+
 	if (!IS_SELECTED(a->options) || (a->nr <= 0))
 		goto close_xml_markup;
 
@@ -1310,7 +1347,7 @@ __print_funct_t xml_print_net_udp_stats(struct activity *a, int curr, int tab,
 	struct stats_net_udp
 		*snuc = (struct stats_net_udp *) a->buf[curr],
 		*snup = (struct stats_net_udp *) a->buf[!curr];
-	
+
 	if (!IS_SELECTED(a->options) || (a->nr <= 0))
 		goto close_xml_markup;
 
@@ -1350,7 +1387,7 @@ __print_funct_t xml_print_net_sock6_stats(struct activity *a, int curr, int tab,
 {
 	struct stats_net_sock6
 		*snsc = (struct stats_net_sock6 *) a->buf[curr];
-	
+
 	if (!IS_SELECTED(a->options) || (a->nr <= 0))
 		goto close_xml_markup;
 
@@ -1670,7 +1707,7 @@ __print_funct_t xml_print_pwr_cpufreq_stats(struct activity *a, int curr, int ta
 	tab++;
 
 	xprintf(tab++, "<cpu-frequency unit=\"MHz\">");
-	
+
 	for (i = 0; (i < a->nr) && (i < a->bitmap->b_size + 1); i++) {
 
 		spc = (struct stats_pwr_cpufreq *) ((char *) a->buf[curr]  + i * a->msize);

--- a/xml_stats.h
+++ b/xml_stats.h
@@ -29,6 +29,8 @@ extern __print_funct_t xml_print_io_stats
 	(struct activity *, int, int, unsigned long long);
 extern __print_funct_t xml_print_memory_stats
 	(struct activity *, int, int, unsigned long long);
+extern __print_funct_t xml_print_memory_ext0_stats
+	(struct activity *, int, int, unsigned long long);
 extern __print_funct_t xml_print_ktables_stats
 	(struct activity *, int, int, unsigned long long);
 extern __print_funct_t xml_print_queue_stats


### PR DESCRIPTION
Hi Sebastien,

I was thinking of adding additional fields from /proc/meminfo. I was going to do it by modifying the existing A_MEMORY activity, but thought that by adding a new activity just for these five additional fields, we could avoid a layout format incompatible change.  What do you think?

Kind regards, -peter

We add the following fields from /proc/meminfo which will allow end
users to add them up with the rest of the reported memory data to
see where all their memory is going:

  AnonPages
  Slab
  PageTables
  VmallocUsed
  KernelStack

Adding up MemFree + Buffers + Cached + SwapCached + AnonPages +
Slab + PageTables + VmallocUsed + KernelStack ~= MemTotal. It is
not dead-on, but it is fairly close that these values become useful.
