### PR TITLE
[RFC] Workaround mpstat overflow

### DIFF
--- a/common.c
+++ b/common.c
@@ -504,13 +504,23 @@ void get_HZ(void)
 double ll_sp_value(unsigned long long value1, unsigned long long value2,
 		   unsigned long long itv)
 {
-	return SP_VALUE(value1, value2, itv);
+	/* Workaround: dyn-tick kernel has a race issue and /proc/stat values
+	   could be backward. */
+	if (value2 < value1)
+		return 0;
+	else
+		return SP_VALUE(value1, value2, itv);
 }
 
 double ll_s_value(unsigned long long value1, unsigned long long value2,
 		  unsigned long long itv)
 {
-	return S_VALUE(value1, value2, itv);
+	/* Workaround: dyn-tick kernel has a race issue and /proc/stat values
+	   could be backward. */
+	if (value2 < value1)
+		return 0;
+	else
+		return S_VALUE(value1, value2, itv);
 }
 
 /*


### PR DESCRIPTION
sysstat has a workaround 32bit /proc/stat, but it is outdated. More unfortunately recent /proc/stat another unreliable source and we need another workaround. 

This pull request remove a former workaround and introduce a new workaround for latter.

This is a demonstrate how ll_sp_value() make an overflow. 
https://gist.github.com/kosaki/3c3b1aff66014bac680f

Comment, feedback are welcome!
