### PR TITLE
Portable way to detect 64 bit OS in configure script

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -210,9 +210,8 @@ fi
 
 SADC_DIR=$AuxPrefix/lib
 if test -d $AuxPrefix/lib64; then
-   # Look for lm (long mode) flag to know if CPU is 64 bit
-   grep " lm " /proc/cpuinfo >/dev/null 2>&1
-   if test $? = 0; then
+   # Verify that this OS is really 64 bit
+   if test $(getconf LONG_BIT) = 64; then
       SADC_DIR=$AuxPrefix/lib64
    fi
 fi

--- a/configure.in
+++ b/configure.in
@@ -210,10 +210,19 @@ fi
 
 SADC_DIR=$AuxPrefix/lib
 if test -d $AuxPrefix/lib64; then
-   # Verify that this OS is really 64 bit
-   if test $(getconf LONG_BIT) = 64; then
-      SADC_DIR=$AuxPrefix/lib64
-   fi
+    # Verify that this OS is really 64 bit
+    BITS=$(getconf LONG_BIT 2>/dev/null)
+    if test $? = 0; then
+        if test $BITS = 64; then
+            SADC_DIR=$AuxPrefix/lib64
+        fi
+    else
+        # Fallback: look for lm (long mode) flag to know if CPU is 64 bit
+        grep " lm " /proc/cpuinfo >/dev/null 2>&1
+        if test $? = 0; then
+            SADC_DIR=$AuxPrefix/lib64
+        fi
+    fi
 fi
 
 AC_MSG_CHECKING(sadc directory)


### PR DESCRIPTION
Different architectures have different format of /proc/cpuinfo and also, only
i386 and x86_64 archs support cpu flags. Using "getconf LONG_BIT" command it's
possible to detect 64 bit OS on multiple different architectures. This patch was
successfully tested on i386, x86_64, s390x, ppc64 and aarch64 archs.