### PR TITLE
Update iostat man page with IOPS and throughput

### DIFF
--- a/man/iostat.in
+++ b/man/iostat.in
@@ -208,22 +208,22 @@ The number of write requests merged per second that were queued to the device.
 .RE
 .B r/s
 .RS
-The number (after merges) of read requests completed per second for the device.
+The number (after merges) of read requests completed per second (read IOPS) for the device.
 
 .RE
 .B w/s
 .RS
-The number (after merges) of write requests completed per second for the device.
+The number (after merges) of write requests completed per second (write IOPS) for the device.
 
 .RE
 .B rsec/s (rkB/s, rMB/s)
 .RS
-The number of sectors (kilobytes, megabytes) read from the device per second.
+The number of sectors (kilobytes, megabytes) read from the device per second (read throughput).
 
 .RE
 .B wsec/s (wkB/s, wMB/s)
 .RS
-The number of sectors (kilobytes, megabytes) written to the device per second.
+The number of sectors (kilobytes, megabytes) written to the device per second (write throughput).
 
 .RE
 .B avgrq-sz


### PR DESCRIPTION
r/s, the number of read I/O requests completed per second is otherwise known as Read IOPS.
w/s, the number of write I/O requests completed per second is also known as Write IOPS.

the other fields, such as rkB/s and wkB/s represent throughput.