### PR TITLE
Permit times passed from command line to be in hh:mm as well as hh:mm:ss  

### DIFF
--- a/man/sadf.in
+++ b/man/sadf.in
@@ -5,9 +5,9 @@ sadf \- Display data collected by sar in multiple formats.
 .B sadf [ -C ] [ -c | -d | -j | -p | -x ] [ -H ] [ -h ] [ -T | -t | -U ] [ -V ] [ -P {
 .I cpu
 .B [,...] | ALL } ] [ -s [
-.I hh:mm:ss
+.I hh:mm[:ss]
 .B ] ] [ -e [
-.I hh:mm:ss
+.I hh:mm[:ss]
 .B ] ] [ --
 .I sar_options
 .B ] [
@@ -116,7 +116,7 @@ by
 .I sar_options
 command line options.
 Note that timestamp output can be controlled by options -T, -t and -U.
-.IP "-e [ hh:mm:ss ]"
+.IP "-e [ hh:mm[:ss] ]"
 Set the ending time of the report, given in local time. The default ending
 time is 18:00:00. Hours must be given in 24-hour format.
 .IP -H
@@ -145,7 +145,7 @@ hostname of the host where the file was created, the interval value
 the device name (or - if not applicable),
 the field name and its value.
 Note that timestamp output can be controlled by options -T, -t and -U.
-.IP "-s [ hh:mm:ss ]"
+.IP "-s [ hh:mm[:ss] ]"
 Set the starting time of the data (given in local time), causing the
 .B sadf
 command to extract records time-tagged at, or following, the time

--- a/man/sar.in
+++ b/man/sar.in
@@ -24,9 +24,9 @@ sar \- Collect, report, or save system activity information.
 .B [ -i
 .I interval
 .B ] [ -s [
-.I hh:mm:ss
+.I hh:mm[:ss]
 .B ] ] [ -e [
-.I hh:mm:ss
+.I hh:mm[:ss]
 .B ] ] [
 .I interval
 .B [
@@ -343,7 +343,7 @@ devices serving requests in parallel, such as RAID arrays and modern SSDs,
 this number does not reflect their performance limits.
 .RE
 .RE
-.IP "-e [ hh:mm:ss ]"
+.IP "-e [ hh:mm[:ss] ]"
 Set the ending time of the report. The default ending time is
 18:00:00. Hours must be given in 24-hour format.
 This option can be used when data are read from
@@ -1962,7 +1962,7 @@ saves I/O).
 Percentage of cached swap memory in relation to the amount of used swap space.
 .RE
 .RE
-.IP "-s [ hh:mm:ss ]"
+.IP "-s [ hh:mm[:ss] ]"
 Set the starting time of the data, causing the
 .B sar
 command to extract records time-tagged at, or following, the time

--- a/sa_common.c
+++ b/sa_common.c
@@ -314,7 +314,7 @@ int datecmp(struct tm *rectime, struct tstamp *tse)
 
 /*
  ***************************************************************************
- * Parse a timestamp entered on the command line (hh:mm:ss) and decode it.
+ * Parse a timestamp entered on the command line (hh:mm[:ss]) and decode it.
  *
  * IN:
  * @argv		Arguments list.
@@ -333,10 +333,23 @@ int parse_timestamp(char *argv[], int *opt, struct tstamp *tse,
 {
 	char timestamp[9];
 
-	if ((argv[++(*opt)]) && (strlen(argv[*opt]) == 8)) {
-		strncpy(timestamp, argv[(*opt)++], 8);
-	}
-	else {
+	if (argv[++(*opt)]) {
+		switch (strlen(argv[*opt])) {
+
+			case 5:
+				strncpy(timestamp, argv[(*opt)++], 5);
+				strcat(timestamp,":00");
+				break;
+
+			case 8:
+				strncpy(timestamp, argv[(*opt)++], 8);
+				break;
+
+			default:
+				strncpy(timestamp, def_timestamp, 8);
+				break;
+		}
+	} else {
 		strncpy(timestamp, def_timestamp, 8);
 	}
 	timestamp[8] = '\0';

--- a/sadf.c
+++ b/sadf.c
@@ -88,7 +88,7 @@ void usage(char *progname)
 
 	fprintf(stderr, _("Options are:\n"
 			  "[ -C ] [ -c | -d | -j | -p | -x ] [ -H ] [ -h ] [ -T | -t | -U ] [ -V ]\n"
-			  "[ -P { <cpu> [,...] | ALL } ] [ -s [ <hh:mm:ss> ] ] [ -e [ <hh:mm:ss> ] ]\n"
+			  "[ -P { <cpu> [,...] | ALL } ] [ -s [ <hh:mm[:ss]> ] ] [ -e [ <hh:mm[:ss]> ] ]\n"
 			  "[ -- <sar_options> ]\n"));
 	exit(1);
 }

--- a/sar.c
+++ b/sar.c
@@ -114,7 +114,7 @@ void usage(char *progname)
 			  "[ -m { <keyword> [,...] | ALL } ] [ -n { <keyword> [,...] | ALL } ]\n"
 			  "[ -j { ID | LABEL | PATH | UUID | ... } ]\n"
 			  "[ -f [ <filename> ] | -o [ <filename> ] | -[0-9]+ ]\n"
-			  "[ -i <interval> ] [ -s [ <hh:mm:ss> ] ] [ -e [ <hh:mm:ss> ] ]\n"));
+			  "[ -i <interval> ] [ -s [ <hh:mm[:ss]> ] ] [ -e [ <hh:mm[:ss]> ] ]\n"));
 	exit(1);
 }
 


### PR DESCRIPTION
This achieves a level of consistency with the other platforms (e.g. Solaris and AIX) where their sar commands support hh:mm.

(New pull request, without the NLS files)
