### PR TITLE
Fixes for installation of systemd / cron files

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -95,7 +95,7 @@ ifeq ($(NLS),y)
 REQUIRE_NLS = -DUSE_NLS -DPACKAGE=\"$(PACKAGE)\" -DLOCALEDIR=\"$(NLS_DIR)\"
 endif
 ifdef REQUIRE_NLS
-   DFLAGS += $(REQUIRE_NLS)
+	DFLAGS += $(REQUIRE_NLS)
 endif
 INSTALL_CRON = @INSTALL_CRON@
 CRON_OWNER = @CRON_OWNER@
@@ -372,54 +372,54 @@ ifneq ($(IGNORE_FILE_ATTRIBUTES),y)
 	$(CHOWN) $(CRON_OWNER) $(DESTDIR)$(SA_DIR)
 endif
 	if [ ! -d "$(DESTDIR)$(SYSTEMD_UNIT_DIR)" ]; then \
-	   if [ -d $(DESTDIR)/etc/cron.d ]; then \
-	      $(INSTALL_DATA) cron/sysstat.crond $(DESTDIR)/etc/cron.d/sysstat; \
-	   elif [ -d $(DESTDIR)/etc/cron.hourly -a -d $(DESTDIR)/etc/cron.daily ]; then \
-	      $(INSTALL_BIN) cron/sysstat.cron.hourly $(DESTDIR)/etc/cron.hourly/sysstat; \
-	      $(INSTALL_BIN) cron/sysstat.cron.daily $(DESTDIR)/etc/cron.daily/sysstat; \
-	   fi \
+		if [ -d $(DESTDIR)/etc/cron.d ]; then \
+			$(INSTALL_DATA) cron/sysstat.crond $(DESTDIR)/etc/cron.d/sysstat; \
+		elif [ -d $(DESTDIR)/etc/cron.hourly -a -d $(DESTDIR)/etc/cron.daily ]; then \
+			$(INSTALL_BIN) cron/sysstat.cron.hourly $(DESTDIR)/etc/cron.hourly/sysstat; \
+			$(INSTALL_BIN) cron/sysstat.cron.daily $(DESTDIR)/etc/cron.daily/sysstat; \
+		fi \
 	fi
 ifeq ($(COPY_ONLY),n)
 	if [ ! -d "$(DESTDIR)$(SYSTEMD_UNIT_DIR)" -a ! -d $(DESTDIR)/etc/cron.d ]; then \
-	   if [ ! -d $(DESTDIR)/etc/cron.hourly -o ! -d $(DESTDIR)/etc/cron.daily ]; then \
-	      su $(CRON_OWNER) -c "crontab -l > /tmp/crontab-$(CRON_OWNER).save"; \
-	      $(CP) -a /tmp/crontab-$(CRON_OWNER).save ./crontab-$(CRON_OWNER).`date '+%Y%m%d.%H%M%S'`.save; \
-	      echo "USER'S PREVIOUS CRONTAB SAVED IN CURRENT DIRECTORY (USING .save SUFFIX)."; \
-	      su $(CRON_OWNER) -c "crontab cron/crontab"; \
-	   fi \
+		if [ ! -d $(DESTDIR)/etc/cron.hourly -o ! -d $(DESTDIR)/etc/cron.daily ]; then \
+			su $(CRON_OWNER) -c "crontab -l > /tmp/crontab-$(CRON_OWNER).save"; \
+			$(CP) -a /tmp/crontab-$(CRON_OWNER).save ./crontab-$(CRON_OWNER).`date '+%Y%m%d.%H%M%S'`.save; \
+			echo "USER'S PREVIOUS CRONTAB SAVED IN CURRENT DIRECTORY (USING .save SUFFIX)."; \
+			su $(CRON_OWNER) -c "crontab cron/crontab"; \
+		fi \
 	fi
 endif
 	if [ -d "$(DESTDIR)$(SYSTEMD_UNIT_DIR)" ]; then \
-	    $(INSTALL_DATA) sysstat.service $(DESTDIR)$(SYSTEMD_UNIT_DIR); \
-	    $(INSTALL_DATA) cron/sysstat-collect.service $(DESTDIR)$(SYSTEMD_UNIT_DIR); \
-	    $(INSTALL_DATA) cron/sysstat-collect.timer $(DESTDIR)$(SYSTEMD_UNIT_DIR); \
-	    $(INSTALL_DATA) cron/sysstat-summary.service $(DESTDIR)$(SYSTEMD_UNIT_DIR); \
-	    $(INSTALL_DATA) cron/sysstat-summary.timer $(DESTDIR)$(SYSTEMD_UNIT_DIR); \
+		$(INSTALL_DATA) sysstat.service $(DESTDIR)$(SYSTEMD_UNIT_DIR); \
+		$(INSTALL_DATA) cron/sysstat-collect.service $(DESTDIR)$(SYSTEMD_UNIT_DIR); \
+		$(INSTALL_DATA) cron/sysstat-collect.timer $(DESTDIR)$(SYSTEMD_UNIT_DIR); \
+		$(INSTALL_DATA) cron/sysstat-summary.service $(DESTDIR)$(SYSTEMD_UNIT_DIR); \
+		$(INSTALL_DATA) cron/sysstat-summary.timer $(DESTDIR)$(SYSTEMD_UNIT_DIR); \
 	elif [ -d $(DESTDIR)$(INIT_DIR) ]; then \
-	   $(INSTALL_BIN) sysstat $(DESTDIR)$(INIT_DIR)/sysstat; \
-	   if [ -x $(CHKCONFIG) ]; then \
-	      cd $(DESTDIR)$(INIT_DIR) && $(CHKCONFIG) --add sysstat; \
-	   else \
-	      cd $(DESTDIR)$(RC2_DIR) && $(LN_S) -f ../$(INITD_DIR)/sysstat S01sysstat; \
-	      cd $(DESTDIR)$(RC3_DIR) && $(LN_S) -f ../$(INITD_DIR)/sysstat S01sysstat; \
-	      cd $(DESTDIR)$(RC5_DIR) && $(LN_S) -f ../$(INITD_DIR)/sysstat S01sysstat; \
-	   fi \
+		$(INSTALL_BIN) sysstat $(DESTDIR)$(INIT_DIR)/sysstat; \
+		if [ -x $(CHKCONFIG) ]; then \
+			cd $(DESTDIR)$(INIT_DIR) && $(CHKCONFIG) --add sysstat; \
+		else \
+			cd $(DESTDIR)$(RC2_DIR) && $(LN_S) -f ../$(INITD_DIR)/sysstat S01sysstat; \
+			cd $(DESTDIR)$(RC3_DIR) && $(LN_S) -f ../$(INITD_DIR)/sysstat S01sysstat; \
+			cd $(DESTDIR)$(RC5_DIR) && $(LN_S) -f ../$(INITD_DIR)/sysstat S01sysstat; \
+		fi \
 	elif [ -d $(DESTDIR)$(RC_DIR) ]; then \
-	   $(INSTALL_BIN) sysstat $(DESTDIR)$(RC_DIR)/rc.sysstat; \
-	   if [ -x $(CHKCONFIG) ]; then \
-	      cd $(DESTDIR)$(RC_DIR) && $(CHKCONFIG) --add sysstat; \
-	   else \
-	      [ -d $(DESTDIR)$(RC2_DIR) ] || mkdir -p $(DESTDIR)$(RC2_DIR); \
-	      [ -d $(DESTDIR)$(RC3_DIR) ] || mkdir -p $(DESTDIR)$(RC3_DIR); \
-	      [ -d $(DESTDIR)$(RC5_DIR) ] || mkdir -p $(DESTDIR)$(RC5_DIR); \
-	      cd $(DESTDIR)$(RC2_DIR) && $(LN_S) -f ../rc.sysstat S01sysstat; \
-	      cd $(DESTDIR)$(RC3_DIR) && $(LN_S) -f ../rc.sysstat S01sysstat; \
-	      cd $(DESTDIR)$(RC5_DIR) && $(LN_S) -f ../rc.sysstat S01sysstat; \
-	   fi \
+		$(INSTALL_BIN) sysstat $(DESTDIR)$(RC_DIR)/rc.sysstat; \
+		if [ -x $(CHKCONFIG) ]; then \
+			cd $(DESTDIR)$(RC_DIR) && $(CHKCONFIG) --add sysstat; \
+		else \
+			[ -d $(DESTDIR)$(RC2_DIR) ] || mkdir -p $(DESTDIR)$(RC2_DIR); \
+			[ -d $(DESTDIR)$(RC3_DIR) ] || mkdir -p $(DESTDIR)$(RC3_DIR); \
+			[ -d $(DESTDIR)$(RC5_DIR) ] || mkdir -p $(DESTDIR)$(RC5_DIR); \
+			cd $(DESTDIR)$(RC2_DIR) && $(LN_S) -f ../rc.sysstat S01sysstat; \
+			cd $(DESTDIR)$(RC3_DIR) && $(LN_S) -f ../rc.sysstat S01sysstat; \
+			cd $(DESTDIR)$(RC5_DIR) && $(LN_S) -f ../rc.sysstat S01sysstat; \
+		fi \
 	fi
 ifeq ($(COPY_ONLY),n)
 	if [ -x $(SYSTEMCTL) ]; then \
-	    $(SYSTEMCTL) enable sysstat.service; \
+		$(SYSTEMCTL) enable sysstat.service; \
 	fi
 endif
 
@@ -470,8 +470,8 @@ endif
 	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(SA_LIB_DIR)
 	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(SA_DIR)/[0-9]?????
 	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(SA_DIR)
-#       No need to keep sysstat scripts, config files and links since
-#       the binaries have been deleted.
+#		No need to keep sysstat scripts, config files and links since
+#		the binaries have been deleted.
 	rm -f $(DESTDIR)$(INIT_DIR)/sysstat
 	rm -f $(DESTDIR)$(RC_DIR)/rc.sysstat
 	rm -f $(DESTDIR)$(SYSCONFIG_DIR)/sysstat
@@ -479,14 +479,14 @@ endif
 	rm -f $(DESTDIR)$(RC2_DIR)/S??sysstat
 	rm -f $(DESTDIR)$(RC3_DIR)/S??sysstat
 	rm -f $(DESTDIR)$(RC5_DIR)/S??sysstat
-#       Delete possible kill entries installed by chkconfig
+#		Delete possible kill entries installed by chkconfig
 	rm -f $(DESTDIR)$(RC0_DIR)/K??sysstat
 	rm -f $(DESTDIR)$(RC1_DIR)/K??sysstat
 	rm -f $(DESTDIR)$(RC4_DIR)/K??sysstat
 	rm -f $(DESTDIR)$(RC6_DIR)/K??sysstat
-#       Vixie cron entries also can be safely deleted here
+#		Vixie cron entries also can be safely deleted here
 	rm -f $(DESTDIR)/etc/cron.d/sysstat
-#       Id. for Slackware cron entries
+#		Id. for Slackware cron entries
 	rm -f $(DESTDIR)/etc/cron.hourly/sysstat
 	rm -f $(DESTDIR)/etc/cron.daily/sysstat
 ifeq ($(INSTALL_DOC),y)
@@ -498,21 +498,21 @@ endif
 uninstall_all: uninstall_base
 ifeq ($(COPY_ONLY),n)
 	if [ ! -d "$(DESTDIR)$(SYSTEMD_UNIT_DIR)" ]; then \
-	   -su $(CRON_OWNER) -c "crontab -l > /tmp/crontab-$(CRON_OWNER).old" ; \
-	   -$(CP) -a /tmp/crontab-$(CRON_OWNER).old ./crontab-$(CRON_OWNER).`date '+%Y%m%d.%H%M%S'`.old ; \
-	   @echo "USER'S CRONTAB SAVED IN CURRENT DIRECTORY (USING .old SUFFIX)." ; \
-	   -su $(CRON_OWNER) -c "crontab -r" ; \
+		-su $(CRON_OWNER) -c "crontab -l > /tmp/crontab-$(CRON_OWNER).old" ; \
+		-$(CP) -a /tmp/crontab-$(CRON_OWNER).old ./crontab-$(CRON_OWNER).`date '+%Y%m%d.%H%M%S'`.old ; \
+		@echo "USER'S CRONTAB SAVED IN CURRENT DIRECTORY (USING .old SUFFIX)." ; \
+		-su $(CRON_OWNER) -c "crontab -r" ; \
 	fi
 	if [ -x $(SYSTEMCTL) ]; then \
-	    $(SYSTEMCTL) disable sysstat.service; \
+		$(SYSTEMCTL) disable sysstat.service; \
 	fi
 endif
 	if [ -d "$(DESTDIR)$(SYSTEMD_UNIT_DIR)" ]; then \
-	    rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/sysstat.service; \
-	    rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/sysstat-collect.service; \
-	    rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/sysstat-collect.timer; \
-	    rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/sysstat-summary.service; \
-	    rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/sysstat-summary.timer; \
+		rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/sysstat.service; \
+		rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/sysstat-collect.service; \
+		rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/sysstat-collect.timer; \
+		rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/sysstat-summary.service; \
+		rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/sysstat-summary.timer; \
 	fi
 
 ifeq ($(INSTALL_CRON),y)

--- a/Makefile.in
+++ b/Makefile.in
@@ -385,7 +385,7 @@ else
 		mkdir -p $(DESTDIR)$(RC_DIR); \
 	fi
 endif
-	if [ ! -d "$(DESTDIR)$(SYSTEMD_UNIT_DIR)" ]; then \
+	if [ -z "$(SYSTEMD_UNIT_DIR)" -o ! -d $(DESTDIR)$(SYSTEMD_UNIT_DIR) ]; then \
 		if [ -d $(DESTDIR)/etc/cron.d ]; then \
 			$(INSTALL_DATA) cron/sysstat.crond $(DESTDIR)/etc/cron.d/sysstat; \
 		elif [ -d $(DESTDIR)/etc/cron.hourly -a -d $(DESTDIR)/etc/cron.daily ]; then \
@@ -394,7 +394,7 @@ endif
 		fi \
 	fi
 ifeq ($(COPY_ONLY),n)
-	if [ ! -d "$(DESTDIR)$(SYSTEMD_UNIT_DIR)" -a ! -d $(DESTDIR)/etc/cron.d ]; then \
+	if [ ( -z "$(SYSTEMD_UNIT_DIR)" -o ! -d $(DESTDIR)$(SYSTEMD_UNIT_DIR) ) -a ! -d $(DESTDIR)/etc/cron.d ]; then \
 		if [ ! -d $(DESTDIR)/etc/cron.hourly -o ! -d $(DESTDIR)/etc/cron.daily ]; then \
 			su $(CRON_OWNER) -c "crontab -l > /tmp/crontab-$(CRON_OWNER).save"; \
 			$(CP) -a /tmp/crontab-$(CRON_OWNER).save ./crontab-$(CRON_OWNER).`date '+%Y%m%d.%H%M%S'`.save; \
@@ -403,7 +403,7 @@ ifeq ($(COPY_ONLY),n)
 		fi \
 	fi
 endif
-	if [ -d "$(DESTDIR)$(SYSTEMD_UNIT_DIR)" ]; then \
+	if [ -n "$(SYSTEMD_UNIT_DIR)" -a -d $(DESTDIR)$(SYSTEMD_UNIT_DIR) ]; then \
 		$(INSTALL_DATA) sysstat.service $(DESTDIR)$(SYSTEMD_UNIT_DIR); \
 		$(INSTALL_DATA) cron/sysstat-collect.service $(DESTDIR)$(SYSTEMD_UNIT_DIR); \
 		$(INSTALL_DATA) cron/sysstat-collect.timer $(DESTDIR)$(SYSTEMD_UNIT_DIR); \
@@ -514,7 +514,7 @@ endif
 
 uninstall_all: uninstall_base
 ifeq ($(COPY_ONLY),n)
-	if [ ! -d "$(DESTDIR)$(SYSTEMD_UNIT_DIR)" ]; then \
+	if [ -z "$(SYSTEMD_UNIT_DIR)" -o ! -d $(DESTDIR)$(SYSTEMD_UNIT_DIR) ]; then \
 		-su $(CRON_OWNER) -c "crontab -l > /tmp/crontab-$(CRON_OWNER).old" ; \
 		-$(CP) -a /tmp/crontab-$(CRON_OWNER).old ./crontab-$(CRON_OWNER).`date '+%Y%m%d.%H%M%S'`.old ; \
 		@echo "USER'S CRONTAB SAVED IN CURRENT DIRECTORY (USING .old SUFFIX)." ; \
@@ -524,7 +524,7 @@ ifeq ($(COPY_ONLY),n)
 		$(SYSTEMCTL) disable sysstat.service; \
 	fi
 endif
-	if [ -d "$(DESTDIR)$(SYSTEMD_UNIT_DIR)" ]; then \
+	if [ -n "$(SYSTEMD_UNIT_DIR)" -a -d $(DESTDIR)$(SYSTEMD_UNIT_DIR) ]; then \
 		rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/sysstat.service; \
 		rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/sysstat-collect.service; \
 		rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/sysstat-collect.timer; \

--- a/Makefile.in
+++ b/Makefile.in
@@ -371,6 +371,20 @@ install_all: install_base cron/crontab sysstat \
 ifneq ($(IGNORE_FILE_ATTRIBUTES),y)
 	$(CHOWN) $(CRON_OWNER) $(DESTDIR)$(SA_DIR)
 endif
+ifdef SYSTEMD_UNIT_DIR
+	mkdir -p $(DESTDIR)$(SYSTEMD_UNIT_DIR)
+else
+	if [ -d /etc/cron.d ]; then \
+		mkdir -p $(DESTDIR)/etc/cron.d; \
+	elif [ -d /etc/cron.hourly -a -d /etc/cron.daily ]; then \
+		mkdir -p $(DESTDIR)/etc/cron.hourly $(DESTDIR)/etc/cron.daily; \
+	fi
+	if [ -d $(INIT_DIR) ]; then \
+		mkdir -p $(DESTDIR)$(INIT_DIR); \
+	elif [ -d $(RC_DIR) ]; then \
+		mkdir -p $(DESTDIR)$(RC_DIR); \
+	fi
+endif
 	if [ ! -d "$(DESTDIR)$(SYSTEMD_UNIT_DIR)" ]; then \
 		if [ -d $(DESTDIR)/etc/cron.d ]; then \
 			$(INSTALL_DATA) cron/sysstat.crond $(DESTDIR)/etc/cron.d/sysstat; \
@@ -400,6 +414,9 @@ endif
 		if [ -x $(CHKCONFIG) ]; then \
 			cd $(DESTDIR)$(INIT_DIR) && $(CHKCONFIG) --add sysstat; \
 		else \
+			[ -d $(DESTDIR)$(RC2_DIR) ] || mkdir -p $(DESTDIR)$(RC2_DIR); \
+			[ -d $(DESTDIR)$(RC3_DIR) ] || mkdir -p $(DESTDIR)$(RC3_DIR); \
+			[ -d $(DESTDIR)$(RC5_DIR) ] || mkdir -p $(DESTDIR)$(RC5_DIR); \
 			cd $(DESTDIR)$(RC2_DIR) && $(LN_S) -f ../$(INITD_DIR)/sysstat S01sysstat; \
 			cd $(DESTDIR)$(RC3_DIR) && $(LN_S) -f ../$(INITD_DIR)/sysstat S01sysstat; \
 			cd $(DESTDIR)$(RC5_DIR) && $(LN_S) -f ../$(INITD_DIR)/sysstat S01sysstat; \

--- a/configure.in
+++ b/configure.in
@@ -30,18 +30,18 @@ AC_CHECK_PROG(INSTALL, install, install)
 AC_CHECK_PROG(MSGFMT, msgfmt, msgfmt)
 AC_CHECK_PROG(XGETTEXT, xgettext, xgettext)
 AC_CHECK_PROG(MSGMERGE, msgmerge, msgmerge)
-AC_CHECK_PROGS(ZIP, xz bzip2 gzip, gzip, /bin /etc /sbin /usr/bin /usr/etc /usr/sbin /usr/ucb /usr/local/bin /usr/local/etc /usr/local/sbin)
+AC_CHECK_PROGS(ZIP, xz bzip2 gzip, gzip)
 INSTALL_DATA="\${INSTALL} -m 644"
 AC_SUBST(INSTALL_DATA)
 INSTALL_BIN="\${INSTALL} -m 755"
 AC_SUBST(INSTALL_BIN)
 
-AC_PATH_PROGS(PATH_CP, cp, cp, /bin /etc /sbin /usr/bin /usr/etc /usr/sbin /usr/ucb /usr/local/bin /usr/local/etc /usr/local/sbin)
-AC_PATH_PROGS(PATH_CHKCONFIG, chkconfig, chkconfig, /bin /etc /sbin /usr/bin /usr/etc /usr/sbin /usr/ucb /usr/local/bin /usr/local/etc /usr/local/sbin)
+AC_PATH_PROG(PATH_CP, cp)
+AC_PATH_PROG(PATH_CHKCONFIG, chkconfig)
 
 # Check for systemd
 AC_CHECK_PROG(PKG_CONFIG, pkg-config, pkg-config)
-AC_PATH_PROGS(SYSTEMCTL, systemctl, systemctl, /bin /etc /sbin /usr/bin /usr/etc /usr/sbin /usr/ucb /usr/local/bin /usr/local/etc /usr/local/sbin)
+AC_PATH_PROG(SYSTEMCTL, systemctl)
 AC_ARG_WITH([systemdsystemunitdir],
     AS_HELP_STRING([--with-systemdsystemunitdir=DIR],[Directory for systemd service files]),
     [], [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])


### PR DESCRIPTION
This pull request fixes 2 issues:

* when using --enable-install-cron option with configure, and DESTDIR is not empty, some required directories are missing in the DESTDIR, and this can negatively affects installation of systemd or cron files. Commit included in this pull request creates required directories according to their existence outside of DESTDIR.

* there were issues with --enable-install-cron configure option when used on systems without systemd. This should be also fixed.

Last commit slightly modifies checking for programs in configure script: don't look for programs in weird places - if they don't exist within PATH, they are unusable anyway. Also don't pretend that programs exist on the system if they are not found (AC_CHECK_PROG(S) have slightly different arguments compared to AC_PATH_PROG(S)).