### PR TITLE
fix mpstat SCPU alignment output

### DIFF
--- a/mpstat.c
+++ b/mpstat.c
@@ -218,8 +218,9 @@ void write_irqcpu_stats(struct stats_irqcpu *st_ic[], int ic_nr, int dis,
 			char *prev_string, char *curr_string)
 {
 	struct stats_cpu *scc;
-	int j = 0, offset, cpu;
+	int j = 0, offset, cpu, colwidth;
 	struct stats_irqcpu *p, *q, *p0, *q0;
+	char fmtspec[MAX_IRQ_LEN];
 
 	/*
 	* Check if number of interrupts has changed.
@@ -305,7 +306,14 @@ void write_irqcpu_stats(struct stats_irqcpu *st_ic[], int ic_nr, int dis,
 				if (!strcmp(p0->irq_name, q0->irq_name) || !interval) {
 					p = st_ic[curr] + (cpu - 1) * ic_nr + j;
 					q = st_ic[prev] + (cpu - 1) * ic_nr + offset;
-					printf(" %10.2f",
+					/* Width is IRQ name + 2 for the /s */
+					colwidth=strlen(p0->irq_name)+2;
+					/* normal space for printing a number is 14 chars 
+					 * (space + 10 digits + period + mantissa) */
+					if(colwidth<14)
+						colwidth=10;
+					sprintf(fmtspec," %%%d.2f",colwidth);
+					printf(fmtspec,
 					       S_VALUE(q->interrupt, p->interrupt, itv));
 				}
 				else

--- a/mpstat.c
+++ b/mpstat.c
@@ -218,7 +218,7 @@ void write_irqcpu_stats(struct stats_irqcpu *st_ic[], int ic_nr, int dis,
 			char *prev_string, char *curr_string)
 {
 	struct stats_cpu *scc;
-	int j = 0, offset, cpu, colwidth;
+	int j = 0, offset, cpu, colwidth[NR_IRQS];
 	struct stats_irqcpu *p, *q, *p0, *q0;
 	char fmtspec[MAX_IRQ_LEN];
 
@@ -252,6 +252,19 @@ void write_irqcpu_stats(struct stats_irqcpu *st_ic[], int ic_nr, int dis,
 			}
 		}
 		printf("\n");
+	}
+
+	/* Calculate column widths */
+	for (j = 0; j < ic_nr; j++) {
+		p0 = st_ic[curr] + j;
+		if (p0->irq_name[0] != '\0') { /* Nb of irq per proc may have varied... */
+			/* Width is IRQ name + 2 for the trailing "/s" */
+			colwidth[j] = strlen(p0->irq_name) + 2;
+			/* normal space for printing a number is 14 chars 
+			 * (space + 10 digits + period + mantissa) */
+			if (colwidth[j] < 14)
+				colwidth[j] = 10;
+		}
 	}
 
 	for (cpu = 1; cpu <= cpu_nr; cpu++) {
@@ -306,13 +319,7 @@ void write_irqcpu_stats(struct stats_irqcpu *st_ic[], int ic_nr, int dis,
 				if (!strcmp(p0->irq_name, q0->irq_name) || !interval) {
 					p = st_ic[curr] + (cpu - 1) * ic_nr + j;
 					q = st_ic[prev] + (cpu - 1) * ic_nr + offset;
-					/* Width is IRQ name + 2 for the /s */
-					colwidth=strlen(p0->irq_name)+2;
-					/* normal space for printing a number is 14 chars 
-					 * (space + 10 digits + period + mantissa) */
-					if(colwidth<14)
-						colwidth=10;
-					sprintf(fmtspec," %%%d.2f",colwidth);
+					snprintf(fmtspec, sizeof(fmtspec), " %%%d.2f", colwidth[j]);
 					printf(fmtspec,
 					       S_VALUE(q->interrupt, p->interrupt, itv));
 				}


### PR DESCRIPTION
mpstat gave misaligned columns when some longer labels came along (e.g. BLOCK_IOPOLL). 

Original:

    $ mpstat -I SCPU 1 1
    Linux 3.18.7-100.fc20.x86_64 (localhost.localdomain)    03/12/2015      _x86_64_        (2 CPU)
    
    04:12:40 PM  CPU       HI/s    TIMER/s   NET_TX/s   NET_RX/s    BLOCK/s BLOCK_IOPOLL/s  TASKLET/s    SCHED/s  HRTIMER/s      RCU/s
    04:12:41 PM    0       0.00      12.87       0.00       0.00       0.00       0.00       0.00       8.91       0.00       4.95
    04:12:41 PM    1       0.00       6.93       0.00       0.99       0.00       0.00       0.00       6.93       0.00       2.97
    Average:       0       0.00      12.87       0.00       0.00       0.00       0.00       0.00       8.91       0.00       4.95
    Average:       1       0.00       6.93       0.00       0.99       0.00       0.00       0.00       6.93       0.00       2.97

New:

    $ ./mpstat -I SCPU 1 1
    Linux 3.18.7-100.fc20.x86_64 (localhost.localdomain)    03/12/2015      _x86_64_        (2 CPU)
    
    04:12:44 PM  CPU       HI/s    TIMER/s   NET_TX/s   NET_RX/s    BLOCK/s BLOCK_IOPOLL/s  TASKLET/s    SCHED/s  HRTIMER/s      RCU/s
    04:12:45 PM    0       0.00       2.97       0.00       0.00       0.00           0.00       0.00       1.98       0.00       0.99
    04:12:45 PM    1       0.00       8.91       0.00       0.99       0.00           0.00       0.00       7.92       0.00       0.99
    Average:       0       0.00       2.97       0.00       0.00       0.00           0.00       0.00       1.98       0.00       0.99
    Average:       1       0.00       8.91       0.00       0.99       0.00           0.00       0.00       7.92       0.00       0.99
    $
