### PR TITLE
Add option to display mountpoint names instead of filesystem names.

### DIFF
--- a/man/sar.in
+++ b/man/sar.in
@@ -348,16 +348,21 @@ Set the ending time of the report. The default ending time is
 18:00:00. Hours must be given in 24-hour format.
 This option can be used when data are read from
 or written to a file (options -f or -o).
-.IP -F
+.IP "-F [ MOUNT ]"
 Display statistics for currently mounted filesystems. Pseudo-filesystems are
-ignored. At the end of the report,
-.B sar
+ignored.  At the end of the report, 
+.B sar 
 will display a summary of all those filesystems.
 Note that filesystems statistics depend on
 .B sadc
 option
 .B "-S XDISK"
 to be collected.
+Use of the 
+.B MOUNT
+parameter keyword indicates that mountpoint will be reported instead of 
+filesystem device.
+
 The following values are displayed:
 
 .B MBfsfree

--- a/pr_stats.c
+++ b/pr_stats.c
@@ -2500,11 +2500,11 @@ __print_funct_t stub_print_filesystem_stats(struct activity *a, int curr, int di
 	int i, j;
 	struct stats_filesystem *sfc, *sfm;
 
-
 	if (dis) {
 		printf("\n%-11s  MBfsfree  MBfsused   %%fsused  %%ufsused"
-		       "     Ifree     Iused    %%Iused FILESYSTEM\n",
-		       (dispavg ? _("Summary:") : timestamp[!curr]));
+		       "     Ifree     Iused    %%Iused %s\n",
+		       (dispavg ? _("Summary:") : timestamp[!curr]),
+		       DISPLAY_MOUNT(a->opt_flags) ? _("MOUNTPOINT") : _("FILESYSTEM"));
 	}
 
 	for (i = 0; i < a->nr; i++) {
@@ -2528,7 +2528,7 @@ __print_funct_t stub_print_filesystem_stats(struct activity *a, int curr, int di
 		       sfc->f_files - sfc->f_ffree,
 		       sfc->f_files ? SP_VALUE(sfc->f_ffree, sfc->f_files, sfc->f_files)
 				    : 0.0,
-		       sfc->fs_name);
+		       DISPLAY_MOUNT(a->opt_flags) ? sfc->mountp : sfc->fs_name);
 
 		if (!dispavg) {
 			/* Save current filesystem in summary list */

--- a/rd_stats.c
+++ b/rd_stats.c
@@ -2098,6 +2098,7 @@ void read_filesystem(struct stats_filesystem *st_filesystem, int nbr)
 			st_filesystem_i->f_files  = buf.f_files;
 			st_filesystem_i->f_ffree  = buf.f_ffree;
 			strcpy(st_filesystem_i->fs_name, fs_name);
+			strcpy(st_filesystem_i->mountp, mountp);
 		}
 	}
 

--- a/rd_stats.h
+++ b/rd_stats.h
@@ -543,6 +543,7 @@ struct stats_filesystem {
 	unsigned long long f_files		__attribute__ ((aligned (16)));
 	unsigned long long f_ffree		__attribute__ ((aligned (16)));
 	char 		   fs_name[MAX_FS_LEN]	__attribute__ ((aligned (16)));
+	char 		   mountp[MAX_FS_LEN]	__attribute__ ((aligned (16)));
 };
 
 #define STATS_FILESYSTEM_SIZE	(sizeof(struct stats_filesystem))

--- a/sa.h
+++ b/sa.h
@@ -136,6 +136,11 @@
 
 #define COLLECT_PARTITIONS(m)	(((m) & AO_F_DISK_PART)   == AO_F_DISK_PART)
 
+/* Output flags for option -F */
+#define AO_F_MOUNT		0x00000001
+
+#define DISPLAY_MOUNT(m)	(((m) & AO_F_MOUNT)       == AO_F_MOUNT)
+
 /*
  ***************************************************************************
  * Various keywords and constants.

--- a/sa_common.c
+++ b/sa_common.c
@@ -1585,6 +1585,12 @@ int parse_sar_opt(char *argv[], int *opt, struct activity *act[],
 
 		case 'F':
 			SELECT_ACTIVITY(A_FILESYSTEM);
+			p = get_activity_position(act, A_FILESYSTEM, EXIT_IF_NOT_FOUND);
+			if (!*(argv[*opt] + i + 1) && argv[*opt + 1] && !strcmp(argv[*opt + 1], "MOUNT")) {
+				(*opt)++;
+				act[p]->opt_flags |= AO_F_MOUNT;
+				return 0;
+			}
 			break;
 
 		case 'H':

--- a/sar.c
+++ b/sar.c
@@ -107,9 +107,9 @@ void usage(char *progname)
 {
 	print_usage_title(stderr, progname);
 	fprintf(stderr, _("Options are:\n"
-			  "[ -A ] [ -B ] [ -b ] [ -C ] [ -D ] [ -d ] [ -F ] [ -H ] [ -h ] [ -p ] [ -q ]\n"
-			  "[ -R ] [ -r [ ALL ] ] [ -S ] [ -t ] [ -u [ ALL ] ] [ -V ] [ -v ] [ -W ]\n"
-			  "[ -w ] [ -y ]\n"
+			  "[ -A ] [ -B ] [ -b ] [ -C ] [ -D ] [ -d ] [ -F [ MOUNTS ] ] [ -H ] [ -h ]\n"
+			  "[ -p ] [ -q ] [ -R ] [ -r [ ALL ] ] [ -S ] [ -t ] [ -u [ ALL ] ] [ -V ]\n"
+			  "[ -v ] [ -W ] [ -w ] [ -y ]\n"
 			  "[ -I { <int> [,...] | SUM | ALL | XALL } ] [ -P { <cpu> [,...] | ALL } ]\n"
 			  "[ -m { <keyword> [,...] | ALL } ] [ -n { <keyword> [,...] | ALL } ]\n"
 			  "[ -j { ID | LABEL | PATH | UUID | ... } ]\n"
@@ -133,7 +133,8 @@ void display_help(char *progname)
 	printf(_("\t-B\tPaging statistics\n"));
 	printf(_("\t-b\tI/O and transfer rate statistics\n"));
 	printf(_("\t-d\tBlock devices statistics\n"));
-	printf(_("\t-F\tFilesystems statistics\n"));
+	printf(_("\t-F [ MOUNTS ]\n"));
+	printf(_("\t\tFilesystems statistics\n"));
 	printf(_("\t-H\tHugepages utilization statistics\n"));
 	printf(_("\t-I { <int> | SUM | ALL | XALL }\n"
 		 "\t\tInterrupts statistics\n"));
@@ -170,7 +171,7 @@ void display_help(char *progname)
 	printf(_("\t-q\tQueue length and load average statistics\n"));
 	printf(_("\t-R\tMemory statistics\n"));
 	printf(_("\t-r [ ALL ]\n"
-		 "\tMemory utilization statistics\n"));
+		 "\t\tMemory utilization statistics\n"));
 	printf(_("\t-S\tSwap space utilization statistics\n"));
 	printf(_("\t-u [ ALL ]\n"
 		 "\t\tCPU utilization statistics\n"));


### PR DESCRIPTION
Add option to show mountpoint names instead of filesystem device, via "sar -F MOUNT".  Useful when some crazy fool has used generic LV names.

Existing output as below:

    $ ./sadc -S XALL 1 2 /tmp/foo
    $ ./sar -F -f /tmp/foo
    Linux 3.18.7-100.fc20.x86_64 (localhost.localdomain)    03/13/2015      _x86_64_        (2 CPU)
    
    12:33:27 PM  MBfsfree  MBfsused   %fsused  %ufsused     Ifree     Iused    %Iused FILESYSTEM
    12:33:28 PM      6859     10857     61.28     66.49    901972    259020     22.31 /dev/sda5
    12:33:28 PM       170       113     39.88     46.61     76592       320      0.42 /dev/sda2
    12:33:28 PM        19         0      0.87      6.03      5125        11      0.21 /dev/mapper/foo-lv1
    12:33:28 PM        19         0      0.87      6.03      5125        11      0.21 /dev/mapper/foo-lv2
    12:33:28 PM        19         0      0.87      6.03      5125        11      0.21 /dev/mapper/foo-lv3
    Summary:         6859     10857     61.28     66.49    901972    259020     22.31 /dev/sda5
    Summary:          170       113     39.88     46.61     76592       320      0.42 /dev/sda2
    Summary:           19         0      0.87      6.03      5125        11      0.21 /dev/mapper/foo-lv1
    Summary:           19         0      0.87      6.03      5125        11      0.21 /dev/mapper/foo-lv2
    Summary:           19         0      0.87      6.03      5125        11      0.21 /dev/mapper/foo-lv3
    $

New option "sar -F MOUNT" gives output as below

    $ ./sar -F MOUNT -f /tmp/foo
    Linux 3.18.7-100.fc20.x86_64 (localhost.localdomain)    03/13/2015      _x86_64_        (2 CPU)
    
    12:33:27 PM  MBfsfree  MBfsused   %fsused  %ufsused     Ifree     Iused    %Iused MOUNTPOINT
    12:33:28 PM      6859     10857     61.28     66.49    901972    259020     22.31 /
    12:33:28 PM       170       113     39.88     46.61     76592       320      0.42 /boot
    12:33:28 PM        19         0      0.87      6.03      5125        11      0.21 /oracle
    12:33:28 PM        19         0      0.87      6.03      5125        11      0.21 /sybase
    12:33:28 PM        19         0      0.87      6.03      5125        11      0.21 /mysql
    Summary:         6859     10857     61.28     66.49    901972    259020     22.31 /
    Summary:          170       113     39.88     46.61     76592       320      0.42 /boot
    Summary:           19         0      0.87      6.03      5125        11      0.21 /oracle
    Summary:           19         0      0.87      6.03      5125        11      0.21 /sybase
    Summary:           19         0      0.87      6.03      5125        11      0.21 /mysql
    $