### PR TITLE
YESTERDAY variable can now be changed in the generic configuration file.

### DIFF
--- a/sa2.in
+++ b/sa2.in
@@ -14,15 +14,19 @@ SYSCONFIG_DIR=@SYSCONFIG_DIR@
 HISTORY=@HISTORY@
 COMPRESSAFTER=@COMPRESSAFTER@
 ZIP="@ZIP@"
+# if YESTERDAY="--date=yesterday" then yesterday's summary is generated
 YESTERDAY=@YESTERDAY@
-DATE=`date ${YESTERDAY} +%d`
 
+# Read configuration file, overriding variables set above
 [ -r ${SYSCONFIG_DIR}/sysstat ] && . ${SYSCONFIG_DIR}/sysstat
+
 [ -d ${SA_DIR} ] || SA_DIR=@SA_DIR@
 
 if [ ${HISTORY} -gt 28 ]
 then
 	DATE=`date ${YESTERDAY} +%Y%m%d`
+else
+	DATE=`date ${YESTERDAY} +%d`
 fi
 CURRENTFILE=sa${DATE}
 CURRENTRPT=sar${DATE}


### PR DESCRIPTION
For people logging every 1 min, generating the summary at 23:53 is not good
enough: 7 minutes of data points are lost. What is needed is to generate
the summary early in the next day. In order to generate yesterday's
summary without recompiling you can now add the following line in config:
YESTERDAY="--date=yesterday"