### PR TITLE
Refactor systemd unit files to better work with suspend/resume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ sysconfig.h
 prealloc.h
 sysstat.sysconfig
 sysstat.service
+sysstat-sleep.sh
 sysstat.crond
 sysstat.cron.daily
 sysstat.cron.hourly

--- a/Makefile.in
+++ b/Makefile.in
@@ -128,6 +128,7 @@ endif
 # Systemd
 SYSTEMCTL = @SYSTEMCTL@
 SYSTEMD_UNIT_DIR = @SYSTEMD_UNIT_DIR@
+SYSTEMD_SLEEP_DIR = @SYSTEMD_SLEEP_DIR@
 
 # Run-command directories
 ifndef RC_DIR

--- a/configure
+++ b/configure
@@ -666,6 +666,7 @@ rcdir
 DFSENSORS
 LFSENSORS
 HAVE_SENSORS
+SYSTEMD_SLEEP_DIR
 SYSTEMD_UNIT_DIR
 SYSTEMCTL
 PKG_CONFIG
@@ -734,6 +735,7 @@ ac_subst_files=''
 ac_user_opts='
 enable_option_checking
 with_systemdsystemunitdir
+with_systemdsleepdir
 enable_sensors
 enable_largefile
 enable_nls
@@ -1398,6 +1400,8 @@ Optional Packages:
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-systemdsystemunitdir=DIR
                           Directory for systemd service files
+  --with-systemdsleepdir=DIR
+                          Directory for systemd suspend/resume scripts
 
 Some influential environment variables:
   CC          C compiler command
@@ -4007,8 +4011,20 @@ else
   with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)
 fi
 
+
+# Check whether --with-systemdsleepdir was given.
+if test "${with_systemdsleepdir+set}" = set; then :
+  withval=$with_systemdsleepdir;
+else
+  with_systemdsleepdir=$($PKG_CONFIG --variable=systemdsleepdir systemd)
+fi
+
 if test -n "$with_systemdsystemunitdir" -a "x$with_systemdsystemunitdir" != xno ; then
     SYSTEMD_UNIT_DIR=$with_systemdsystemunitdir
+
+fi
+if test -n "$with_systemdsleepdir" -a "x$with_systemdsleepdir" != xno ; then
+    SYSTEMD_SLEEP_DIR=$with_systemdsleepdir
 
 fi
 
@@ -5409,6 +5425,8 @@ ac_config_files="$ac_config_files sysstat"
 	# Permissions must be changed
 ac_config_files="$ac_config_files sysstat.service"
 
+ac_config_files="$ac_config_files sysstat-sleep.sh"
+
 ac_config_files="$ac_config_files cron/sysstat-collect.service"
 
 ac_config_files="$ac_config_files cron/sysstat-collect.timer"
@@ -6158,6 +6176,7 @@ do
     "cron/sysstat.crond.sample.in") CONFIG_FILES="$CONFIG_FILES cron/sysstat.crond.sample.in:cron/sysstat.crond.in" ;;
     "sysstat") CONFIG_FILES="$CONFIG_FILES sysstat" ;;
     "sysstat.service") CONFIG_FILES="$CONFIG_FILES sysstat.service" ;;
+    "sysstat-sleep.sh") CONFIG_FILES="$CONFIG_FILES sysstat-sleep.sh" ;;
     "cron/sysstat-collect.service") CONFIG_FILES="$CONFIG_FILES cron/sysstat-collect.service" ;;
     "cron/sysstat-collect.timer") CONFIG_FILES="$CONFIG_FILES cron/sysstat-collect.timer" ;;
     "cron/sysstat-summary.service") CONFIG_FILES="$CONFIG_FILES cron/sysstat-summary.service" ;;
@@ -6638,6 +6657,7 @@ echo "
    rc directory:		${RC_DIR}
    Init directory:		${INIT_DIR}
    Systemd unit dir:		${with_systemdsystemunitdir}
+   Systemd sleep dir:		${with_systemdsleepdir}
    Configuration directory:	${SYSCONFIG_DIR}
    Man pages directory:		$mandir
    Compiler:			$CC

--- a/configure.in
+++ b/configure.in
@@ -45,8 +45,14 @@ AC_PATH_PROG(SYSTEMCTL, systemctl)
 AC_ARG_WITH([systemdsystemunitdir],
     AS_HELP_STRING([--with-systemdsystemunitdir=DIR],[Directory for systemd service files]),
     [], [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
+AC_ARG_WITH([systemdsleepdir],
+    AS_HELP_STRING([--with-systemdsleepdir=DIR],[Directory for systemd suspend/resume scripts]),
+    [], [with_systemdsleepdir=$($PKG_CONFIG --variable=systemdsleepdir systemd)])
 if test -n "$with_systemdsystemunitdir" -a "x$with_systemdsystemunitdir" != xno ; then
     AC_SUBST([SYSTEMD_UNIT_DIR], [$with_systemdsystemunitdir])
+fi
+if test -n "$with_systemdsleepdir" -a "x$with_systemdsleepdir" != xno ; then
+    AC_SUBST([SYSTEMD_SLEEP_DIR], [$with_systemdsleepdir])
 fi
 
 # Check libraries
@@ -604,6 +610,7 @@ AC_CONFIG_FILES([cron/sysstat.crond])
 AC_CONFIG_FILES([cron/sysstat.crond.sample.in:cron/sysstat.crond.in], [sed s/^/#/ cron/sysstat.crond.sample.in > cron/sysstat.crond.sample])
 AC_CONFIG_FILES([sysstat], [chmod +x sysstat])	# Permissions must be changed
 AC_CONFIG_FILES([sysstat.service])
+AC_CONFIG_FILES([sysstat-sleep.sh])
 AC_CONFIG_FILES([cron/sysstat-collect.service])
 AC_CONFIG_FILES([cron/sysstat-collect.timer])
 AC_CONFIG_FILES([cron/sysstat-summary.service])
@@ -627,6 +634,7 @@ echo "
    rc directory:		${RC_DIR}
    Init directory:		${INIT_DIR}
    Systemd unit dir:		${with_systemdsystemunitdir}
+   Systemd sleep dir:		${with_systemdsleepdir}
    Configuration directory:	${SYSCONFIG_DIR}
    Man pages directory:		$mandir
    Compiler:			$CC

--- a/cron/sysstat-collect.service.in
+++ b/cron/sysstat-collect.service.in
@@ -8,6 +8,8 @@
 [Unit]
 Description=system activity accounting tool
 Documentation=man:sa1(8)
+# Stop this unit when stopping sysstat
+PartOf=sysstat.service
 
 [Service]
 Type=oneshot

--- a/cron/sysstat-collect.timer.in
+++ b/cron/sysstat-collect.timer.in
@@ -6,9 +6,8 @@
 
 [Unit]
 Description=Run system activity accounting tool every @CRON_INTERVAL@ minutes
+# Stop the timer unit when stopping the service itself
+PartOf=sysstat.service
 
 [Timer]
 OnCalendar=*:00/@CRON_INTERVAL@
-
-[Install]
-WantedBy=sysstat.service

--- a/sysstat-sleep.sh
+++ b/sysstat-sleep.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# System Activity Accounting Restart-on-Resume hack
+# for systemd's /usr/lib/systemd/system-sleep/ directory
+
+
+case $1 in
+	pre)  systemctl stop  sysstat ;;
+	post) systemctl start sysstat ;;
+esac

--- a/sysstat-sleep.sh.in
+++ b/sysstat-sleep.sh.in
@@ -1,6 +1,6 @@
 #!/bin/sh
 # System Activity Accounting Restart-on-Resume hack
-# for systemd's /usr/lib/systemd/system-sleep/ directory
+# for systemd's @SYSTEMD_SLEEP_DIR@ directory
 
 
 case $1 in

--- a/sysstat.service.in
+++ b/sysstat.service.in
@@ -2,20 +2,27 @@
 # (C) 2012 Peter Schiffer (pschiffe <at> redhat.com)
 #
 # @PACKAGE_NAME@-@PACKAGE_VERSION@ systemd unit file:
-#	 Insert a dummy record in current daily data file.
-#	 This indicates that the counters have restarted from 0.
+#     1. Insert a dummy record in current daily data file when starting/stopping
+#        the unit. This indicates that the counters have restarted from 0.
+#     2. This unit is automatically stopped/started on suspend/resume,
+#        see /usr/lib/systemd/system-sleep/sysstat-sleep.sh.
+#     3. Starting this unit also starts the timer unit for periodic accounting.
 
 [Unit]
-Description=Resets System Activity Logs
+Description=System Activity Accounting
+# Start the periodic accounting process
+Requires=sysstat-collect.timer
+# but make sure we finish first, because the accounting process locks the datafile
+Before=sysstat-collect.timer sysstat-collect.service
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 User=@CRON_OWNER@
-ExecStart=@SA_LIB_DIR@/sa1 --boot
+ExecStart=@SA_LIB_DIR@/sa1 --boot -C STARTED
+ExecStop=@SA_LIB_DIR@/sa1 --boot -C STOPPED
 
 [Install]
 WantedBy=multi-user.target
 Also=sysstat-collect.timer
 Also=sysstat-summary.timer
-


### PR DESCRIPTION
Previously a comment was written to the accounting log only on system boot,
which caused artifacts in generated graphs of laptops with suspend/resume
functionality. The solution is to write a similar comment both before suspend
and after resume, so that the graphing program can insert a gap in that
timeframe.

As a nice side-effect, one can now start sysstat just by doing
"systemctl start sysstat", and the timer unit will be pulled automatically
in the proper order, so that there is no contention for locking
the accounting file. Same goes for stopping.
