### PR TITLE
By default sa2 now generates summary for YESTERDAY

### DIFF
--- a/build/yesterday
+++ b/build/yesterday
@@ -1,8 +1,0 @@
-
-The sa2 shell script uses a daily data file to create a daily report.
-By default it uses current daily data file (that is to say
-the daily data file created today).
-Yet it may be sometimes useful to tell it to use the daily data file
-of the day before (that is to say the one created yesterday), for
-example if sa2 is started at, say, 02:00 AM. In this case, answer y.
-

--- a/configure
+++ b/configure
@@ -651,7 +651,6 @@ COMPRESSAFTER
 compressafter
 HISTORY
 history
-YESTERDAY
 NLS
 SYSCONFIG_DIR
 conf_dir
@@ -737,7 +736,6 @@ with_systemdsystemunitdir
 enable_sensors
 enable_largefile
 enable_nls
-enable_yesterday
 enable_file_attr
 enable_compress_manpg
 enable_install_isag
@@ -1381,7 +1379,6 @@ Optional Features:
   --disable-sensors       disable sensors support
   --disable-largefile     omit support for large files
   --disable-nls           disable National Language Support
-  --enable-yesterday      tell sa2 to use data file of the day before
   --disable-file-attr     do not set attributes on files being installed
   --enable-compress-manpg compress sysstat manual pages
   --enable-install-isag   install isag script
@@ -4835,7 +4832,6 @@ echo .
 #  --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
 #  --disable-largefile     omit support for large files
 #  --disable-nls           disable National Language Support
-#  --enable-yesterday      tell sa2 to use "yesterday" data files
 #  --disable-file-attr     don't set attributes on files being installed
 #  --enable-install-cron   tell sysstat to install cron scripts
 #  --collect-all           tell sadc to collect all possible data
@@ -5010,27 +5006,6 @@ fi
 if test $AUX_NLS = "yes" &&  test x$MSGMERGE != x"msgmerge"; then
    echo "WARNING: msgmerge command not found!"
 fi
-
-# Check whether sa2 should process data file of the day before
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether sa2 should process data file of the day before" >&5
-$as_echo_n "checking whether sa2 should process data file of the day before... " >&6; }
-# Check whether --enable-yesterday was given.
-if test "${enable_yesterday+set}" = set; then :
-  enableval=$enable_yesterday; AUX_YESTERDAY=$enableval
-else
-  AUX_YESTERDAY=no
-fi
-
-if test $AUX_YESTERDAY = "yes"; then
-   YESTERDAY="--date=yesterday"
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-   YESTERDAY=""
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
 
 # Data history to keep by sa2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking number of daily data files to keep" >&5

--- a/configure.in
+++ b/configure.in
@@ -128,7 +128,6 @@ echo .
 #  --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
 #  --disable-largefile     omit support for large files
 #  --disable-nls           disable National Language Support
-#  --enable-yesterday      tell sa2 to use "yesterday" data files
 #  --disable-file-attr     don't set attributes on files being installed
 #  --enable-install-cron   tell sysstat to install cron scripts
 #  --collect-all           tell sadc to collect all possible data    
@@ -290,21 +289,6 @@ fi
 if test $AUX_NLS = "yes" &&  test x$MSGMERGE != x"msgmerge"; then 
    echo "WARNING: msgmerge command not found!"
 fi
-
-# Check whether sa2 should process data file of the day before
-AC_MSG_CHECKING(whether sa2 should process data file of the day before)
-AC_ARG_ENABLE(yesterday,
-	      AC_HELP_STRING([--enable-yesterday],
-			     [tell sa2 to use data file of the day before]),
-			     AUX_YESTERDAY=$enableval,AUX_YESTERDAY=no)
-if test $AUX_YESTERDAY = "yes"; then
-   YESTERDAY="--date=yesterday"
-   AC_MSG_RESULT(yes)
-else
-   YESTERDAY=""
-   AC_MSG_RESULT(no)
-fi
-AC_SUBST(YESTERDAY)
 
 # Data history to keep by sa2
 AC_MSG_CHECKING(number of daily data files to keep)

--- a/cron/crontab.sample
+++ b/cron/crontab.sample
@@ -14,6 +14,6 @@
 # 7pm-8am activity reports every an hour during weekdays.
 # 0 19-7 * * 1-5 @SA_LIB_DIR@/sa1 &
 #
-# Daily summary prepared at 19:05.
-# 5 19 * * 1-5 @SA_LIB_DIR@/sa2 -A &
-5 19 * * * @SA_LIB_DIR@/sa2 -A &
+# Previous day summary prepared at 00:07.
+# 7 0 * * 1-5 @SA_LIB_DIR@/sa2 -A &
+7 0 * * * @SA_LIB_DIR@/sa2 -A &

--- a/cron/sysstat-summary.timer.in
+++ b/cron/sysstat-summary.timer.in
@@ -6,10 +6,10 @@
 #        Activates sysstat-summary.service
 
 [Unit]
-Description=Generate a daily summary of process accounting at 23:53
+Description=Generate summary of yesterday's process accounting
 
 [Timer]
-OnCalendar=23:53:00
+OnCalendar=00:07:00
 
 [Install]
 WantedBy=sysstat.service

--- a/cron/sysstat.crond.in
+++ b/cron/sysstat.crond.in
@@ -1,6 +1,6 @@
 # Run system activity accounting tool every @CRON_INTERVAL@ minutes
 */@CRON_INTERVAL@ * * * * @CRON_OWNER@ @SA_LIB_DIR@/sa1 1 1
 # 0 * * * * @CRON_OWNER@ @SA_LIB_DIR@/sa1 @CRON_INTERVAL_SEC@ @CRON_COUNT@ &
-# Generate a daily summary of process accounting at 23:53
-53 23 * * * @CRON_OWNER@ @SA_LIB_DIR@/sa2 -A
+# Generate a text summary of previous day process accounting at 00:07
+7 0 * * * @CRON_OWNER@ @SA_LIB_DIR@/sa2 -A
 

--- a/iconfig
+++ b/iconfig
@@ -67,15 +67,6 @@ else
 	echo "Parameter --disable-sensors is NOT set"
 fi
 
-# sa2 processes data file of the day before
-YESTERDAY=`${ASK} 'sa2 uses daily data file of the day before? (y/n)' "--enable-yesterday" "yesterday"`
-if [ "${YESTERDAY}" = "y" ]; then
-	YESTERDAY="--enable-yesterday "
-else
-	YESTERDAY=""
-	echo "Parameter --enable-yesterday is NOT set"
-fi
-
 # Data history to keep by sa2
 HISTORY=`${ASK} 'Number of daily data files to keep:' "history" "history"`
 if [ "${HISTORY}" != "" ]; then
@@ -220,7 +211,7 @@ fi
 
 echo
 echo -n "./configure ${PREFIX}${SA_LIB_DIR}${SA_DIR}${SYSCONFIG_DIR}${CLEAN_SA_DIR}${NLS} \
-${YESTERDAY}${HISTORY}${COMPRESSAFTER}${PREALLOC_ANSWER}${MAN}${IGNORE_FILE_ATTR}${CRON}${RCDIR}"
+${HISTORY}${COMPRESSAFTER}${PREALLOC_ANSWER}${MAN}${IGNORE_FILE_ATTR}${CRON}${RCDIR}"
 if [ "${SADC_OPT}" != "" ];
 then
 	echo -n "sadc_options=\"${SADC_OPT}\""
@@ -229,7 +220,7 @@ echo "${COMPRESSMANPG}${INSTALL_DOC}${DEBUGINFO}${INSTALL_ISAG}${SENSORS}${STRIP
 echo
 
 ./configure ${PREFIX}${SA_LIB_DIR}${SA_DIR}${SYSCONFIG_DIR}${CLEAN_SA_DIR}${NLS} \
-${YESTERDAY}${HISTORY}${COMPRESSAFTER}${PREALLOC_ANSWER}${MAN}${IGNORE_FILE_ATTR}${CRON}${RCDIR} \
+${HISTORY}${COMPRESSAFTER}${PREALLOC_ANSWER}${MAN}${IGNORE_FILE_ATTR}${CRON}${RCDIR} \
 sadc_options="${SADC_OPT}" ${COMPRESSMANPG}${INSTALL_DOC}${DEBUGINFO}${INSTALL_ISAG}${SENSORS} \
 ${STRIP}${COPY_ONLY}
 

--- a/sa2.in
+++ b/sa2.in
@@ -14,19 +14,25 @@ SYSCONFIG_DIR=@SYSCONFIG_DIR@
 HISTORY=@HISTORY@
 COMPRESSAFTER=@COMPRESSAFTER@
 ZIP="@ZIP@"
-# if YESTERDAY="--date=yesterday" then yesterday's summary is generated
-YESTERDAY=@YESTERDAY@
 
 # Read configuration file, overriding variables set above
 [ -r ${SYSCONFIG_DIR}/sysstat ] && . ${SYSCONFIG_DIR}/sysstat
 
 [ -d ${SA_DIR} ] || SA_DIR=@SA_DIR@
 
+# if YESTERDAY=no then today's summary is generated
+if [ x$YESTERDAY = xno ]
+then
+	DATE_OPTS=
+else
+	DATE_OPTS="--date=yesterday"
+fi
+
 if [ ${HISTORY} -gt 28 ]
 then
-	DATE=`date ${YESTERDAY} +%Y%m%d`
+	DATE=`date "${DATE_OPTS}" +%Y%m%d`
 else
-	DATE=`date ${YESTERDAY} +%d`
+	DATE=`date "${DATE_OPTS}" +%d`
 fi
 CURRENTFILE=sa${DATE}
 CURRENTRPT=sar${DATE}

--- a/sysstat.sysconfig.in
+++ b/sysstat.sysconfig.in
@@ -18,3 +18,7 @@ SA_DIR=@SA_DIR@
 # Compression program to use.
 ZIP="@ZIP@"
 
+# By default sa2 script generates yesterday's summary, since the cron job
+# usually runs right after midnight. If you want sa2 to generate the summary
+# of the same day (for example when cron job runs at 23:53) set this variable.
+#YESTERDAY=no


### PR DESCRIPTION
This can be overriden by setting YESTERDAY=no in the configuration.
The compile time option was removed to make it clear that this is
controlled in one place, which also led to to logic simplification
and code removal.

This change fixes the following issues:

* Previously summary was being generated at 23:53, which caused up to 7
  datapoints lost if sa1 logging was set to 1 or 5 minute intervals.

* To amend the previous problem, some distributions were compiling with
  YESTERDAY set as a compile-time option, but shipped the cron jobs
  as-is. This caused the additional issue that the report of a day was being
  delayed up to 23:53 of the next day.

* Finally there is a subtle race condition that might happen if sadc tries to
  write to the file while sar is reading it to generate the summary, which
  might cause corrupted sar summaries. This does not occur when reading
  yesterday's files, since they are not written any more.