### PR TITLE
Fibre Channel HBA activity reporting

### DIFF
--- a/activity.c
+++ b/activity.c
@@ -1226,6 +1226,37 @@ struct activity filesystem_act = {
 	.bitmap		= NULL
 };
 
+/* Fibre Channel HBA usage activity */
+struct activity fc_act = {
+	.id		= A_FC,
+	.options	= AO_NULL,
+	.magic		= ACTIVITY_MAGIC_BASE,
+	.group		= G_DISK,
+#ifdef SOURCE_SADC
+	.f_count_index	= 10,	/* wrap_get_hba_nr() */
+	.f_count2	= NULL,
+	.f_read		= wrap_read_hba,
+#endif
+#ifdef SOURCE_SAR
+	.f_print	= print_fc_stats,
+	.f_print_avg	= print_avg_hba_stats,
+#endif
+#ifdef SOURCE_SADF
+	.f_render	= render_hba_stats,
+	.f_xml_print	= xml_print_fc_stats,
+	.f_json_print	= json_print_fc_stats,
+	.hdr_line	= "FCHBA;hba_rxf/s;hba_txf/s;hba_rxw/s;hba_txw/s",
+	.name		= "A_FC",
+#endif
+	.nr		= -1,
+	.nr2		= 1,
+	.fsize		= STATS_FC_SIZE,
+	.msize		= STATS_FC_SIZE,
+	.opt_flags	= 0,
+	.buf		= {NULL, NULL, NULL},
+	.bitmap		= NULL
+};
+
 #ifdef SOURCE_SADC
 /*
  * Array of functions used to count number of items.
@@ -1240,7 +1271,8 @@ __nr_t (*f_count[NR_F_COUNT]) (struct activity *) = {
 	wrap_get_temp_nr,
 	wrap_get_in_nr,
 	wrap_get_usb_nr,
-	wrap_get_filesystem_nr
+	wrap_get_filesystem_nr,
+	wrap_get_hba_nr
 };
 #endif
 
@@ -1289,5 +1321,6 @@ struct activity *act[NR_ACT] = {
 	&pwr_wghfreq_act,
 	&pwr_usb_act,		/* AO_CLOSE_MARKUP */
 	/* </power-management> */
-	&filesystem_act
+	&filesystem_act,
+	&fc_act
 };

--- a/common.h
+++ b/common.h
@@ -65,6 +65,7 @@
 #define SYSFS_BMAXPOWER		"bMaxPower"
 #define SYSFS_MANUFACTURER	"manufacturer"
 #define SYSFS_PRODUCT		"product"
+#define SYSFS_FCHBA		"/sys/class/fc_host"
 
 #define MAX_FILE_LEN		256
 #define MAX_PF_NAME		1024

--- a/json_stats.c
+++ b/json_stats.c
@@ -2159,3 +2159,48 @@ __print_funct_t json_print_filesystem_stats(struct activity *a, int curr, int ta
 	printf("\n");
 	xprintf0(--tab, "]");
 }
+
+/*
+ ***************************************************************************
+ * Display Fibre Channel HBA statistics in JSON.
+ *
+ * IN:
+ * @a		Activity structure with statistics.
+ * @curr	Index in array for current sample statistics.
+ * @tab		Indentation in output.
+ * @itv		Interval of time in jiffies.
+ ***************************************************************************
+ */
+__print_funct_t json_print_fc_stats(struct activity *a, int curr, int tab,
+				    unsigned long long itv)
+{
+	int i;
+	struct stats_fc *sfcc, *sfcp;
+	int sep = FALSE;
+
+	xprintf(tab++, "\"fc\": [");
+
+	for (i = 0; i < a->nr; i++) {
+		sfcc = (struct stats_fc *) ((char *) a->buf[curr]  + i * a->msize);
+		sfcp = (struct stats_fc *) ((char *) a->buf[!curr]  + i * a->msize);
+
+		if (sep)
+			printf(",\n");
+
+		sep = TRUE;
+
+		xprintf0(tab, "{\"hba\": \"%s\", "
+			 "\"hba_rxf\": %.2f, "
+			 "\"hba_txf\": %.2f, "
+			 "\"hba_rxw\": %.2f, "
+			 "\"hba_txw\": %.2f}",
+			 sfcc->hba_name,
+			 S_VALUE(sfcp->f_rxframes, sfcc->f_rxframes, itv),
+			 S_VALUE(sfcp->f_txframes, sfcc->f_txframes, itv),
+			 S_VALUE(sfcp->f_rxwords,  sfcc->f_rxwords,  itv),
+			 S_VALUE(sfcp->f_txwords,  sfcc->f_txwords,  itv));
+	}
+
+	printf("\n");
+	xprintf0(--tab, "]");
+}

--- a/json_stats.h
+++ b/json_stats.h
@@ -89,5 +89,7 @@ extern __print_funct_t json_print_pwr_usb_stats
 	(struct activity *, int, int, unsigned long long);
 extern __print_funct_t json_print_filesystem_stats
 	(struct activity *, int, int, unsigned long long);
+extern __print_funct_t json_print_fc_stats
+	(struct activity *, int, int, unsigned long long);
 
 #endif /* _XML_STATS_H */

--- a/man/sar.in
+++ b/man/sar.in
@@ -633,9 +633,10 @@ Possible keywords are
 .BR IP6 ,
 .BR EIP6 ,
 .BR ICMP6 ,
-.BR EICMP6
+.BR EICMP6 ,
+.BR UDP6
 and
-.BR UDP6 .
+.BR FC .
 
 With the
 .B DEV
@@ -1747,6 +1748,40 @@ delivered for reasons other than the lack of an application
 at the destination port [udpInErrors].
 .RE
 
+With the
+.B FC
+keyword, statistics about fibre channel traffic are reported.
+Note that fibre channel statistics depend on
+.BR sadc 's
+option "-S DISK" to be collected.
+The following values are displayed:
+
+.B FCHBA
+.RS
+Name of the fibre channel host bus adapter (HBA) interface for which statistics are reported.
+.RE
+
+.B hba_rxf/s
+.RS
+The total number of frames received per second.
+.RE
+
+.B hba_txf/s
+.RS
+The total number of frames transmitted per second.
+.RE
+
+.B hba_rxw/s
+.RS
+The total number of words received per second.
+.RE
+
+.B hba_txw/s
+.RS
+The total number of words transmitted per second.
+.RE
+
+.RE
 The
 .B ALL
 keyword is equivalent to specifying all the keywords above and therefore all the network

--- a/pr_stats.c
+++ b/pr_stats.c
@@ -2582,3 +2582,75 @@ __print_funct_t print_avg_filesystem_stats(struct activity *a, int prev, int cur
 {
 	stub_print_filesystem_stats(a, 2, TRUE);
 }
+
+/*
+ ***************************************************************************
+ * Display Fibre Channel HBA statistics. This function is used to
+ * display instantaneous and average statistics.
+ *
+ * IN:
+ * @a		Activity structure with statistics.
+ * @curr	Index in array for current sample statistics.
+ * @dispavg	TRUE if displaying average statistics.
+ * @itv		Interval of time in jiffies.
+ ***************************************************************************
+ */
+__print_funct_t stub_print_fc_stats(struct activity *a, int prev, int curr, int dispavg, unsigned long long itv)
+{
+	int i;
+	struct stats_fc *sfcc,*sfcp;
+
+
+	if (dis) {
+		printf("\n%-11s      FCHBA     hba_rxf/s   hba_txf/s   hba_rxw/s   hba_txw/s\n",
+		       (dispavg ? _("Summary:") : timestamp[curr]));
+	}
+
+	for (i = 0; i < a->nr; i++) {
+		sfcc = (struct stats_fc *) ((char *) a->buf[curr] + i * a->msize);
+		sfcp = (struct stats_fc *) ((char *) a->buf[prev] + i * a->msize);
+
+		printf("%-11s %10s   %11.2f %11.2f %11.2f %11.2f\n",
+		       (dispavg ? _("Average:") : timestamp[curr]),
+		       sfcc->hba_name,
+		       S_VALUE(sfcp->f_rxframes, sfcc->f_rxframes, itv),
+		       S_VALUE(sfcp->f_txframes, sfcc->f_txframes, itv),
+		       S_VALUE(sfcp->f_rxwords,  sfcc->f_rxwords,  itv),
+		       S_VALUE(sfcp->f_txwords,  sfcc->f_txwords,  itv));
+	}
+	printf("\n");
+}
+
+/*
+ ***************************************************************************
+ * Display Fibre Channel HBA statistics.
+ *
+ * IN:
+ * @a		Activity structure with statistics.
+ * @prev	Index in array where stats used as reference are.
+ * @curr	Index in array for current sample statistics.
+ * @itv		Interval of time in jiffies.
+ ***************************************************************************
+ */
+__print_funct_t print_fc_stats(struct activity *a, int prev, int curr,
+				       unsigned long long itv)
+{
+	stub_print_fc_stats(a, prev, curr, FALSE, itv);
+}
+
+/*
+ ***************************************************************************
+ * Display average Fibre Channel HBA statistics.
+ *
+ * IN:
+ * @a		Activity structure with statistics.
+ * @prev	Index in array where stats used as reference are.
+ * @curr	Index in array for current sample statistics.
+ * @itv		Interval of time in jiffies.
+ ***************************************************************************
+ */
+__print_funct_t print_avg_hba_stats(struct activity *a, int prev, int curr,
+					   unsigned long long itv)
+{
+	stub_print_fc_stats(a, prev, curr, TRUE, itv);
+}

--- a/pr_stats.h
+++ b/pr_stats.h
@@ -90,6 +90,8 @@ extern __print_funct_t print_pwr_usb_stats
 	(struct activity *, int, int, unsigned long long);
 extern __print_funct_t print_filesystem_stats
 	(struct activity *, int, int, unsigned long long);
+extern __print_funct_t print_fc_stats
+	(struct activity *, int, int, unsigned long long);
 
 /* Functions used to display average statistics */
 extern __print_funct_t print_avg_memory_stats
@@ -115,6 +117,8 @@ extern __print_funct_t print_avg_huge_stats
 extern __print_funct_t print_avg_pwr_usb_stats
 	(struct activity *, int, int, unsigned long long);
 extern __print_funct_t print_avg_filesystem_stats
+	(struct activity *, int, int, unsigned long long);
+extern __print_funct_t print_avg_hba_stats
 	(struct activity *, int, int, unsigned long long);
 
 #endif /* _PR_STATS_H */

--- a/rd_stats.c
+++ b/rd_stats.c
@@ -2120,5 +2120,85 @@ void read_filesystem(struct stats_filesystem *st_filesystem, int nbr)
 	fclose(fp);
 }
 
+/*
+ ***************************************************************************
+ * Read Fibre Channel HBA statistics.
+ *
+ * IN:
+ * @st_fc		Structure where stats will be saved.
+ * @nbr			Total number of HBAs.
+ *
+ * OUT:
+ * @st_fc	Structure with statistics.
+ ***************************************************************************
+ */
+void read_hba(struct stats_fc *st_fc, int nbr)
+{
+	DIR *dir;
+	FILE *fp;
+	struct dirent *drd;
+	struct stats_fc *st_fc_i;
+	int hba = 0;
+	char fcstat_filename[MAX_FS_LEN];
+	char line[256];
+	unsigned long rx_frames,
+		      tx_frames,
+		      rx_words,
+		      tx_words;
+
+	/* Each HBA, if present, will have its own hostX entry within SYSFS_FCHBA */
+	if ((dir = opendir(SYSFS_FCHBA)) == NULL)
+		return; /* No HBAs */
+
+	/* Read each of the counters via sysfs, where they are
+	 * returned as hex values (e.g. 0x72400) */
+	while ((drd = readdir(dir)) != NULL) {
+		rx_frames = tx_frames = rx_words = tx_words = 0;
+
+		if (strncmp(drd->d_name,"host",4) == 0) {
+			sprintf(fcstat_filename,"%s/%s/statistics/rx_frames",
+					SYSFS_FCHBA,drd->d_name);
+			if ((fp = fopen(fcstat_filename, "r"))) {
+				if (fgets(line,sizeof(line),fp))
+					sscanf(line, "%lx",&rx_frames);
+				fclose(fp);
+			}
+
+			sprintf(fcstat_filename,"%s/%s/statistics/tx_frames",
+					SYSFS_FCHBA,drd->d_name);
+			if ((fp = fopen(fcstat_filename, "r"))) {
+				if (fgets(line,sizeof(line),fp))
+					sscanf(line, "%lx",&tx_frames);
+				fclose(fp);
+			}
+
+			sprintf(fcstat_filename,"%s/%s/statistics/rx_words",
+					SYSFS_FCHBA,drd->d_name);
+			if ((fp = fopen(fcstat_filename, "r"))) {
+				if (fgets(line,sizeof(line),fp))
+					sscanf(line, "%lx",&rx_words);
+				fclose(fp);
+			}
+
+			sprintf(fcstat_filename,"%s/%s/statistics/tx_words",
+					SYSFS_FCHBA,drd->d_name);
+			if ((fp = fopen(fcstat_filename, "r"))) {
+				if (fgets(line,sizeof(line),fp))
+					sscanf(line, "%lx",&tx_words);
+				fclose(fp);
+			}
+
+			st_fc_i = st_fc + hba++;
+			st_fc_i->f_rxframes = rx_frames;
+			st_fc_i->f_txframes = tx_frames;
+			st_fc_i->f_rxwords  = rx_words;
+			st_fc_i->f_txwords  = tx_words;
+			strcpy(st_fc_i->hba_name, drd->d_name);
+		}
+
+	}
+	closedir(dir);
+}
+
 /*------------------ END: FUNCTIONS USED BY SADC ONLY ---------------------*/
 #endif /* SOURCE_SADC */

--- a/rd_stats.h
+++ b/rd_stats.h
@@ -548,6 +548,17 @@ struct stats_filesystem {
 
 #define STATS_FILESYSTEM_SIZE	(sizeof(struct stats_filesystem))
 
+/* Structure for Fibre Channel HBA statistics */
+struct stats_fc {
+	unsigned long f_rxframes	__attribute__ ((aligned (16)));
+	unsigned long f_txframes	__attribute__ ((aligned (16)));
+	unsigned long f_rxwords		__attribute__ ((aligned (16)));
+	unsigned long f_txwords		__attribute__ ((aligned (16)));
+	char	 hba_name[16]		__attribute__ ((aligned (16)));
+};
+
+#define STATS_FC_SIZE	(sizeof(struct stats_fc))
+
 /*
  ***************************************************************************
  * Prototypes for functions used to read system statistics
@@ -630,5 +641,7 @@ extern void
 	read_bus_usb_dev(struct stats_pwr_usb *, int);
 extern void
 	read_filesystem(struct stats_filesystem *, int);
+extern void
+	read_hba(struct stats_fc *, int);
 
 #endif /* _RD_STATS_H */

--- a/rndr_stats.c
+++ b/rndr_stats.c
@@ -2917,3 +2917,54 @@ __print_funct_t render_filesystem_stats(struct activity *a, int isdb, char *pre,
 		       NULL);
 	}
 }
+
+/*
+ ***************************************************************************
+ * Display Fibre Channel HBA statistics in selected format.
+ *
+ * IN:
+ * @a		Activity structure with statistics.
+ * @isdb	Flag, true if db printing, false if ppc printing.
+ * @pre		Prefix string for output entries
+ * @curr	Index in array for current sample statistics.
+ * @itv		Interval of time in jiffies.
+ ***************************************************************************
+ */
+__print_funct_t render_hba_stats(struct activity *a, int isdb, char *pre,
+					int curr, unsigned long long itv)
+{
+	int i;
+	struct stats_fc *sfcc, *sfcp;
+
+	for (i = 0; i < a->nr; i++) {
+		sfcc = (struct stats_fc *) ((char *) a->buf[curr] + i * a->msize);
+		sfcp = (struct stats_fc *) ((char *) a->buf[!curr] + i * a->msize);
+
+		render(isdb, pre, PT_NOFLAG ,
+		       "%s\thba_rxf/s",
+		       "%s",
+		       cons(sv, sfcc->hba_name, NOVAL),
+		       NOVAL,
+		       S_VALUE(sfcp->f_rxframes, sfcc->f_rxframes, itv),
+	               NULL);
+		render(isdb, pre, PT_NOFLAG,
+		       "%s\thba_txf/s", NULL,
+		       cons(sv, sfcc->hba_name, NULL),
+		       NOVAL,
+		       S_VALUE(sfcp->f_txframes, sfcc->f_txframes, itv),
+		       NULL);
+		render(isdb, pre, PT_NOFLAG,
+		       "%s\thba_rxw/s", NULL,
+		       cons(sv, sfcc->hba_name, NULL),
+		       NOVAL,
+		       S_VALUE(sfcp->f_rxwords, sfcc->f_rxwords, itv),
+		       NULL);
+		render(isdb, pre,
+		       (DISPLAY_HORIZONTALLY(flags) ? PT_NOFLAG : PT_NEWLIN),
+		       "%s\thba_txw/s", NULL,
+		       cons(sv, sfcc->hba_name, NULL),
+		       NOVAL,
+		       S_VALUE(sfcp->f_txwords, sfcc->f_txwords, itv),
+		       NULL);
+	}
+}

--- a/rndr_stats.h
+++ b/rndr_stats.h
@@ -120,5 +120,7 @@ extern __print_funct_t render_pwr_usb_stats
 	(struct activity *, int, char *, int, unsigned long long);
 extern __print_funct_t render_filesystem_stats
 	(struct activity *, int, char *, int, unsigned long long);
+extern __print_funct_t render_hba_stats
+	(struct activity *, int, char *, int, unsigned long long);
 
 #endif /* _RNDR_STATS_H */

--- a/sa.h
+++ b/sa.h
@@ -20,10 +20,10 @@
  */
 
 /* Number of activities */
-#define NR_ACT	37
+#define NR_ACT	38
 
 /* Number of functions used to count items */
-#define NR_F_COUNT	10
+#define NR_F_COUNT	11
 
 /* Activities */
 #define A_CPU		1
@@ -63,6 +63,7 @@
 #define A_PWR_WGHFREQ	35
 #define A_PWR_USB	36
 #define A_FILESYSTEM	37
+#define A_FC		38
 
 
 /* Macro used to flag an activity that should be collected */
@@ -762,6 +763,8 @@ extern __nr_t
 	wrap_get_usb_nr(struct activity *);
 extern __nr_t
 	wrap_get_filesystem_nr(struct activity *);
+extern __nr_t
+	wrap_get_hba_nr(struct activity *);
 
 /* Functions used to read activities statistics */
 extern __read_funct_t
@@ -838,6 +841,8 @@ extern __read_funct_t
 	wrap_read_bus_usb_dev(struct activity *);
 extern __read_funct_t
 	wrap_read_filesystem(struct activity *);
+extern __read_funct_t
+	wrap_read_hba(struct activity *);
 
 /* Other functions */
 extern void

--- a/sa_common.c
+++ b/sa_common.c
@@ -1836,6 +1836,9 @@ int parse_sar_n_opt(char *argv[], int *opt, struct activity *act[])
 		else if (!strcmp(t, K_UDP6)) {
 			SELECT_ACTIVITY(A_NET_UDP6);
 		}
+		else if (!strcmp(t, "FC")) {
+			SELECT_ACTIVITY(A_FC);
+		}
 		else if (!strcmp(t, K_ALL)) {
 			SELECT_ACTIVITY(A_NET_DEV);
 			SELECT_ACTIVITY(A_NET_EDEV);
@@ -1855,6 +1858,7 @@ int parse_sar_n_opt(char *argv[], int *opt, struct activity *act[])
 			SELECT_ACTIVITY(A_NET_ICMP6);
 			SELECT_ACTIVITY(A_NET_EICMP6);
 			SELECT_ACTIVITY(A_NET_UDP6);
+			SELECT_ACTIVITY(A_FC);
 		}
 		else
 			return 1;

--- a/sa_wrap.c
+++ b/sa_wrap.c
@@ -19,6 +19,9 @@
  ***************************************************************************
  */
 
+#include <dirent.h>
+#include <string.h>
+
 #include "sa.h"
 #include "rd_stats.h"
 #include "count.h"
@@ -879,6 +882,28 @@ __read_funct_t wrap_read_filesystem(struct activity *a)
 
 /*
  ***************************************************************************
+ * Read Fibre Channel HBA statistics.
+ *
+ * IN:
+ * @a	Activity structure.
+ *
+ * OUT:
+ * @a	Activity structure with statistics.
+ ***************************************************************************
+ */
+__read_funct_t wrap_read_hba(struct activity *a)
+{
+	struct stats_fc *st_fc
+		= (struct stats_fc *) a->_buf0;
+
+	read_hba(st_fc, a->nr);
+
+	return;
+}
+
+
+/*
+ ***************************************************************************
  * Count number of interrupts that are in /proc/stat file.
  * Truncate the number of different individual interrupts to NR_IRQS.
  *
@@ -1100,4 +1125,34 @@ __nr_t wrap_get_filesystem_nr(struct activity *a)
 		return n + NR_FILESYSTEM_PREALLOC;
 
 	return 0;
+}
+
+/*
+ ***************************************************************************
+ * Get number of HBAs
+ *
+ * IN:
+ * @a	Activity structure.
+ *
+ * RETURNS:
+ * Number of HBAs + a pre-allocation constant.
+ ***************************************************************************
+ */
+__nr_t wrap_get_hba_nr(struct activity *a)
+{
+	DIR *dir;
+	struct dirent *drd;
+	__nr_t n = 0;
+
+	if ((dir = opendir(SYSFS_FCHBA)) == NULL) {
+		return 0;
+	}
+
+	while ((drd = readdir(dir)) != NULL)
+		if (strncmp(drd->d_name,"host",4)==0)
+			n++;
+
+	closedir(dir);
+
+	return n;
 }

--- a/sar.c
+++ b/sar.c
@@ -167,7 +167,8 @@ void display_help(char *progname)
 		 "\t\tEIP6\tIP traffic\t(v6) (errors)\n"
 		 "\t\tICMP6\tICMP traffic\t(v6)\n"
 		 "\t\tEICMP6\tICMP traffic\t(v6) (errors)\n"
-		 "\t\tUDP6\tUDP traffic\t(v6)\n"));
+		 "\t\tUDP6\tUDP traffic\t(v6)\n"
+		 "\t\tFC\tFibre channel HBAs\n"));
 	printf(_("\t-q\tQueue length and load average statistics\n"));
 	printf(_("\t-R\tMemory statistics\n"));
 	printf(_("\t-r [ ALL ]\n"

--- a/xml_stats.c
+++ b/xml_stats.c
@@ -2058,3 +2058,43 @@ __print_funct_t xml_print_filesystem_stats(struct activity *a, int curr, int tab
 
 	xprintf(--tab, "</filesystems>");
 }
+
+/*
+ ***************************************************************************
+ * Display Fibre Channel HBA statistics in XML.
+ *
+ * IN:
+ * @a		Activity structure with statistics.
+ * @curr	Index in array for current sample statistics.
+ * @tab		Indentation in XML output.
+ * @itv		Interval of time in jiffies.
+ ***************************************************************************
+ */
+__print_funct_t xml_print_fc_stats(struct activity *a, int curr, int tab,
+					   unsigned long long itv)
+{
+	int i;
+	struct stats_fc *sfcc, *sfcp;
+
+	xprintf(tab, "<fc>");
+	tab++;
+
+	for (i = 0; i < a->nr; i++) {
+
+		sfcc = (struct stats_fc *) ((char *) a->buf[curr] + i * a->msize);
+		sfcp = (struct stats_fc *) ((char *) a->buf[!curr] + i * a->msize);
+
+		xprintf(tab, "<hba name=\"%s\" "
+			"rxframes=\"%.2f\" "
+			"txframes=\"%.2f\" "
+			"rxwords=\"%.2f\" "
+			"txwords=\"%.2f\"/>",
+			sfcc->hba_name,
+			S_VALUE(sfcp->f_rxframes, sfcc->f_rxframes, itv),
+			S_VALUE(sfcp->f_txframes, sfcc->f_txframes, itv),
+			S_VALUE(sfcp->f_rxwords,  sfcc->f_rxwords,  itv),
+			S_VALUE(sfcp->f_txwords,  sfcc->f_rxwords,  itv));
+	}
+
+	xprintf(--tab, "</fc>");
+}

--- a/xml_stats.h
+++ b/xml_stats.h
@@ -89,5 +89,7 @@ extern __print_funct_t xml_print_pwr_usb_stats
 	(struct activity *, int, int, unsigned long long);
 extern __print_funct_t xml_print_filesystem_stats
 	(struct activity *, int, int, unsigned long long);
+extern __print_funct_t xml_print_fc_stats
+	(struct activity *, int, int, unsigned long long);
 
 #endif /* _XML_STATS_H */


### PR DESCRIPTION
Disk I/O is often a bottleneck, so to supplement the existing "sar -d" reporting, the reporting of Fibre Channel HBA statistics is added.

New "sar" man page section reads as below:

              With the FC keyword, statistics about fibre channel traffic are reported.  Note that fibre channel statistics depend on sadc's option "-S DISK" to be collected.  The following values are displayed:

              FCHBA
                     Name of the fibre channel host bus adapter (HBA) interface for which statistics are reported.

              hba_rxf/s
                     The total number of frames received per second.

              hba_txf/s
                     The total number of frames transmitted per second.

              hba_rxw/s
                     The total number of words received per second.

              hba_txw/s
                     The total number of words transmitted per second.

Typical example usage:

    $ ./sar -n FC -f /var/tmp/skfoo
    Linux 3.18.7-100.fc20.x86_64 (localhost.localdomain)    04/05/2015      _x86_64_        (2 CPU)
    
    02:18:50 PM      FCHBA     hba_rxf/s   hba_txf/s   hba_rxw/s   hba_txw/s
    02:18:50 PM      host0       8110.89     4055.45    16221.78    12166.34
    02:18:50 PM      host1      12166.34    12166.34    20277.23    20277.23
    02:18:50 PM      host2          0.00        0.00        0.00        0.00
    
    02:18:51 PM      host0       4055.45     4055.45     4055.45     4055.45
    02:18:51 PM      host1       8110.89     8110.89     8110.89     8110.89
    02:18:51 PM      host2          0.00        0.00        0.00        0.00
    
    02:18:52 PM      host0       4015.69     4015.69     4015.69     4015.69
    02:18:52 PM      host1      20078.43    20078.43    32125.49    32125.49
    02:18:52 PM      host2          0.00        0.00        0.00        0.00
    
    Average:         host0       5389.47     4042.11     8084.21     6736.84
    Average:         host1      13473.68    13473.68    20210.53    20210.53
    Average:         host2          0.00        0.00        0.00        0.00
    
    $ 

For info, the complete list of statistics presented by the kernel within /sys/class/fc_host/hostX/statistics are below.  This pull request covers a subset (received frames, transmitted frames, received words, transmitted words).

    -r--r--r-- 1 root root 4096 2015-04-05 04:41 dumped_frames 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 error_frames 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 fcp_control_requests 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 fcp_input_megabytes 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 fcp_input_requests 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 fcp_output_megabytes 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 fcp_output_requests 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 invalid_crc_count 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 invalid_tx_word_count 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 link_failure_count 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 lip_count 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 loss_of_signal_count 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 loss_of_sync_count 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 nos_count 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 prim_seq_protocol_err_count 
    --w------- 1 root root 4096 2015-04-05 04:41 reset_statistics 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 rx_frames 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 rx_words 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 seconds_since_last_reset 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 tx_frames 
    -r--r--r-- 1 root root 4096 2015-04-05 04:41 tx_words 

Typical data values below:

    $ grep . * 
    dumped_frames:0xffffffffffffffff 
    error_frames:0x0 
    fcp_control_requests:0x0 
    fcp_input_megabytes:0x0 
    fcp_input_requests:0x0 
    fcp_output_megabytes:0x0 
    fcp_output_requests:0x0 
    invalid_crc_count:0x0 
    invalid_tx_word_count:0x4 
    link_failure_count:0x0 
    lip_count:0xffffffffffffffff 
    loss_of_signal_count:0x1 
    loss_of_sync_count:0x3 
    nos_count:0x0 
    prim_seq_protocol_err_count:0x0 
    grep: reset_statistics: Permission denied 
    rx_frames:0x10ed 
    rx_words:0x14c000 
    seconds_since_last_reset:0xc8f6f 
    tx_frames:0xfbc 
    tx_words:0xb100 
    $ 

Finally, a typical "ls -lR" output of /sys/class/fc_host/host0.

    $ ls -lR 
    .: 
    total 0 
    -r--r--r-- 1 root root 4096 Apr  7 08:00 active_fc4s 
    lrwxrwxrwx 1 root root    0 Apr  7 08:00 device -> ../../../host2 
    -rw-r--r-- 1 root root 4096 Apr  7 08:00 dev_loss_tmo 
    -r--r--r-- 1 root root 4096 Apr  7 08:00 fabric_name 
    --w------- 1 root root 4096 Apr  7 08:00 issue_lip 
    -r--r--r-- 1 root root 4096 Apr  7 08:00 maxframe_size 
    -r--r--r-- 1 root root 4096 Apr  7 08:00 max_npiv_vports 
    -r--r--r-- 1 root root 4096 Apr  3 19:25 node_name 
    -r--r--r-- 1 root root 4096 Apr  7 08:00 npiv_vports_inuse 
    -r--r--r-- 1 root root 4096 Apr  7 08:00 port_id 
    -r--r--r-- 1 root root 4096 Apr  3 19:25 port_name 
    -r--r--r-- 1 root root 4096 Apr  7 08:00 port_state 
    -r--r--r-- 1 root root 4096 Apr  7 08:00 port_type 
    drwxr-xr-x 2 root root    0 Apr  3 22:31 power 
    -r--r--r-- 1 root root 4096 Apr  3 19:25 speed 
    drwxr-xr-x 2 root root    0 Apr  3 07:56 statistics 
    lrwxrwxrwx 1 root root    0 Apr  7 08:00 subsystem -> ../../../../../../../class/fc_host 
    -r--r--r-- 1 root root 4096 Apr  7 08:00 supported_classes 
    -r--r--r-- 1 root root 4096 Apr  7 08:00 supported_fc4s 
    -r--r--r-- 1 root root 4096 Apr  7 08:00 supported_speeds 
    -r--r--r-- 1 root root 4096 Apr  7 08:00 symbolic_name 
    -rw-r--r-- 1 root root 4096 Apr  7 08:00 tgtid_bind_type 
    -rw-r--r-- 1 root root 4096 Apr  7 08:00 uevent 
    --w------- 1 root root 4096 Apr  7 08:00 vport_create 
    --w------- 1 root root 4096 Apr  7 08:00 vport_delete 
    
    ./power: 
    total 0 
    -rw-r--r-- 1 root root 4096 Apr  7 08:00 wakeup 
    
    ./statistics: 
    total 0 
    -r--r--r-- 1 root root 4096 Apr  3 07:56 dumped_frames 
    -r--r--r-- 1 root root 4096 Apr  3 07:56 error_frames 
    -r--r--r-- 1 root root 4096 Apr  7 07:59 fcp_control_requests 
    -r--r--r-- 1 root root 4096 Apr  7 07:59 fcp_input_megabytes 
    -r--r--r-- 1 root root 4096 Apr  7 07:59 fcp_input_requests 
    -r--r--r-- 1 root root 4096 Apr  7 07:59 fcp_output_megabytes 
    -r--r--r-- 1 root root 4096 Apr  7 07:59 fcp_output_requests 
    -r--r--r-- 1 root root 4096 Apr  3 07:56 invalid_crc_count 
    -r--r--r-- 1 root root 4096 Apr  3 07:56 invalid_tx_word_count 
    -r--r--r-- 1 root root 4096 Apr  3 07:56 link_failure_count 
    -r--r--r-- 1 root root 4096 Apr  3 07:56 lip_count 
    -r--r--r-- 1 root root 4096 Apr  3 07:56 loss_of_signal_count 
    -r--r--r-- 1 root root 4096 Apr  3 07:56 loss_of_sync_count 
    -r--r--r-- 1 root root 4096 Apr  3 07:56 nos_count 
    -r--r--r-- 1 root root 4096 Apr  3 07:56 prim_seq_protocol_err_count 
    --w------- 1 root root 4096 Apr  7 07:59 reset_statistics 
    -r--r--r-- 1 root root 4096 Apr  3 07:56 rx_frames 
    -r--r--r-- 1 root root 4096 Apr  3 07:56 rx_words 
    -r--r--r-- 1 root root 4096 Apr  3 07:56 seconds_since_last_reset 
    -r--r--r-- 1 root root 4096 Apr  3 07:56 tx_frames 
    -r--r--r-- 1 root root 4096 Apr  3 07:56 tx_words 

(end)