### PR TITLE
Only permit printable characters in comments

### DIFF
--- a/sa.h
+++ b/sa.h
@@ -917,6 +917,8 @@ extern __nr_t
 			        unsigned int);
 extern int
 	reallocate_vol_act_structures(struct activity * [], unsigned int, unsigned int);
+extern void
+	replace_nonprintable_char(int, char *);
 extern int
 	sa_fread(int, void *, int, int);
 extern int

--- a/sa_common.c
+++ b/sa_common.c
@@ -30,6 +30,7 @@
 #include <libgen.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <ctype.h>
 
 #include "version.h"
 #include "sa.h"
@@ -2068,4 +2069,24 @@ void enum_version_nr(struct file_magic *fm)
 	if ((v = strtok(NULL, ".")) == NULL)
 		return;
 	fm->sysstat_extraversion = atoi(v) & 0xff;
+}
+
+/*
+ ***************************************************************************
+ * Replace unprintable characters in comment with "."
+ *
+ * IN:
+ * @ifd		Input file descriptor.
+ * @comment	Comment.
+ ***************************************************************************
+ */
+void replace_nonprintable_char(int ifd, char *comment)
+{
+	int i;
+	sa_fread(ifd, comment, MAX_COMMENT_LEN, HARD_SIZE);
+	comment[MAX_COMMENT_LEN - 1] = '\0';
+	for (i = 0; i < strlen(comment); i++) {
+		if (!isprint(comment[i]))
+			comment[i]='.';
+	}
 }

--- a/sadc.c
+++ b/sadc.c
@@ -1197,6 +1197,7 @@ int main(int argc, char **argv)
 	int stdfd = 0, ofd = -1;
 	int restart_mark;
 	long count = 0;
+	int comment_cnt;
 
 	/* Get HZ */
 	get_HZ();
@@ -1255,6 +1256,11 @@ int main(int argc, char **argv)
 			if (argv[++opt]) {
 				strncpy(comment, argv[opt], MAX_COMMENT_LEN);
 				comment[MAX_COMMENT_LEN - 1] = '\0';
+				for (comment_cnt=0;comment_cnt<strlen(comment);comment_cnt++) {
+					if(!isprint(comment[comment_cnt])) {
+						comment[comment_cnt]='.';
+					}
+				}
 				if (!strlen(comment)) {
 					usage(argv[0]);
 				}

--- a/sadc.c
+++ b/sadc.c
@@ -1197,7 +1197,6 @@ int main(int argc, char **argv)
 	int stdfd = 0, ofd = -1;
 	int restart_mark;
 	long count = 0;
-	int comment_cnt;
 
 	/* Get HZ */
 	get_HZ();
@@ -1256,11 +1255,6 @@ int main(int argc, char **argv)
 			if (argv[++opt]) {
 				strncpy(comment, argv[opt], MAX_COMMENT_LEN);
 				comment[MAX_COMMENT_LEN - 1] = '\0';
-				for (comment_cnt=0;comment_cnt<strlen(comment);comment_cnt++) {
-					if(!isprint(comment[comment_cnt])) {
-						comment[comment_cnt]='.';
-					}
-				}
 				if (!strlen(comment)) {
 					usage(argv[0]);
 				}

--- a/sadf.c
+++ b/sadf.c
@@ -403,8 +403,7 @@ void write_textual_comments(int curr, int use_tm_start, int use_tm_end, int tab,
 	char cur_date[32], cur_time[32];
 	char file_comment[MAX_COMMENT_LEN];
 
-	sa_fread(ifd, file_comment, MAX_COMMENT_LEN, HARD_SIZE);
-	file_comment[MAX_COMMENT_LEN - 1] = '\0';
+	replace_nonprintable_char(ifd, file_comment);
 
 	/* Fill timestamp structure for current record */
 	sadf_get_record_timestamp_struct(curr, rectime, loctime);
@@ -850,8 +849,7 @@ void sadf_print_special(int curr, int use_tm_start, int use_tm_end, int rtype, i
 	else if (rtype == R_COMMENT) {
 		char file_comment[MAX_COMMENT_LEN];
 
-		sa_fread(ifd, file_comment, MAX_COMMENT_LEN, HARD_SIZE);
-		file_comment[MAX_COMMENT_LEN - 1] = '\0';
+		replace_nonprintable_char(ifd, file_comment);
 
 		if (!dp || !DISPLAY_COMMENT(flags))
 			return;

--- a/sar.c
+++ b/sar.c
@@ -689,8 +689,7 @@ int sar_print_special(int curr, int use_tm_start, int use_tm_end, int rtype,
 		char file_comment[MAX_COMMENT_LEN];
 
 		/* Don't forget to read comment record even if it won't be displayed... */
-		sa_fread(ifd, file_comment, MAX_COMMENT_LEN, HARD_SIZE);
-		file_comment[MAX_COMMENT_LEN - 1] = '\0';
+		replace_nonprintable_char(ifd, file_comment);
 
 		if (dp && DISPLAY_COMMENT(flags)) {
 			printf("%-11s  COM %s\n", cur_time, file_comment);


### PR DESCRIPTION
The "-C" add comment feature permits non-printable characters to be entered.  Example below, showing a "fake" entry being created this way (^H is actually control-V control-H in shell)

    $ ./sadc 1 2 /tmp/foo
    $ ./sadc -C "^H^H^H^H    9.00      3.55" /tmp/foo
    $ ./sar -W -C -f /tmp/foo
    Linux 3.18.7-100.fc20.x86_64 (localhost.localdomain)    06/07/2015      _x86_64_        (2 CPU)
    
    03:20:27 PM  pswpin/s pswpout/s
    03:20:28 PM      0.00      0.00
    03:20:31 PM      9.00      3.55
    Average:         0.00      0.00
    $

This very minor change replaces nonprintable characters with a ".".  Example below.

    $ ./sadc 1 2 /tmp/foo
    $ ./sadc -C "^H^H^H^H    9.00      3.55" /tmp/foo
    $ ./sar -W -C -f /tmp/foo
    Linux 3.18.7-100.fc20.x86_64 (localhost.localdomain)    06/07/2015      _x86_64_        (2 CPU)
    
    03:17:39 PM  pswpin/s pswpout/s
    03:17:40 PM      0.00      0.00
    03:17:51 PM  COM ....    9.00      3.55
    Average:         0.00      0.00
    $