### PR TITLE
Pidstat outputs values > 100% for %CPU

### DIFF
--- a/pidstat.c
+++ b/pidstat.c
@@ -881,23 +881,22 @@ void read_task_stats(int curr, unsigned int pid, unsigned int *index)
 	if ((dir = opendir(filename)) == NULL)
 		return;
 
-	while (*index < pid_nr) {
-
-		while ((drp = readdir(dir)) != NULL) {
-			if (isdigit(drp->d_name[0]))
-				break;
+	while ((drp = readdir(dir)) != NULL) {
+		if (!isdigit(drp->d_name[0])) {
+			continue;
 		}
 
-		if (drp) {
-			pst = st_pid_list[curr] + (*index)++;
-			if (read_pid_stats(atoi(drp->d_name), pst, &thr_nr, pid)) {
-				/* Thread no longer exists */
-				pst->pid = 0;
-			}
+		pst = st_pid_list[curr] + (*index)++;
+		if (read_pid_stats(atoi(drp->d_name), pst, &thr_nr, pid)) {
+			/* Thread no longer exists */
+			pst->pid = 0;
 		}
-		else
-			break;
+
+		if (*index >= pid_nr) {
+			realloc_pid();
+		}
 	}
+
 	closedir(dir);
 }
 

--- a/pidstat.h
+++ b/pidstat.h
@@ -13,7 +13,7 @@
 #define K_P_CHILD	"CHILD"
 #define K_P_ALL		"ALL"
 
-#define NR_PID_PREALLOC	10
+#define NR_PID_PREALLOC	100
 
 #define MAX_COMM_LEN	128
 #define MAX_CMDLINE_LEN	128


### PR DESCRIPTION
On systems with many short living processes pidstat could run out of
pre-allocated space for PIDs. This patch increases NR_PID_PREALLOC constant so
more space for PIDs is pre-allocated, but also adds possibility to re-allocate
this space if needed.

Resolves #73