### PR TITLE
Increase NR_CPUS to match kernel upstream

### DIFF
--- a/common.h
+++ b/common.h
@@ -35,10 +35,10 @@
 #define SEC_PER_DAY	3600 * 24
 
 /* Maximum number of CPUs */
-#if defined(__CPU_SETSIZE) && __CPU_SETSIZE > 2048
+#if defined(__CPU_SETSIZE) && __CPU_SETSIZE > 8192
 #define NR_CPUS		__CPU_SETSIZE
 #else
-#define NR_CPUS		2048
+#define NR_CPUS		8192
 #endif
 
 /* Maximum number of interrupts */


### PR DESCRIPTION
We hit current limit of 2048 CPUs defined in common.h. Kernel upstream has
currently set 8192 as maximum number of CPUs[1], so sync with them.

[1] http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=b53b5eda8194214928c8243d711a75dbf51809fc