### PR TITLE
Print time in the ISO format if S_TIME_FORMAT=ISO in sar

### DIFF
--- a/common.c
+++ b/common.c
@@ -331,6 +331,21 @@ unsigned int get_devmap_major(void)
 
 /*
  ***************************************************************************
+ * Returns whether S_TIME_FORMAT is set to ISO.
+ *
+ * RETURNS:
+ * TRUE if S_TIME_FORMAT is set to ISO, or FALSE otherwise.
+ ***************************************************************************
+ */
+int is_iso_time_fmt(void)
+{
+	char *e;
+
+	return ((e = getenv(ENV_TIME_FMT)) != NULL) && !strcmp(e, K_ISO);
+}
+
+/*
+ ***************************************************************************
  * Print banner.
  *
  * IN:
@@ -349,13 +364,12 @@ int print_gal_header(struct tm *rectime, char *sysname, char *release,
 		     char *nodename, char *machine, int cpu_nr)
 {
 	char cur_date[64];
-	char *e;
 	int rc = 0;
 
 	if (rectime == NULL) {
 		strcpy(cur_date, "?/?/?");
 	}
-	else if (((e = getenv(ENV_TIME_FMT)) != NULL) && !strcmp(e, K_ISO)) {
+	else if (is_iso_time_fmt()) {
 		strftime(cur_date, sizeof(cur_date), "%Y-%m-%d", rectime);
 		rc = 1;
 	}

--- a/common.h
+++ b/common.h
@@ -259,6 +259,8 @@ int is_device
 	(char *, int);
 double ll_sp_value
 	(unsigned long long, unsigned long long, unsigned long long);
+int is_iso_time_fmt
+	(void);
 int print_gal_header
 	(struct tm *, char *, char *, char *, char *, int);
 void print_version

--- a/man/sar.in
+++ b/man/sar.in
@@ -2274,6 +2274,7 @@ then the current locale will be ignored when printing the date in the report hea
 The
 .B sar
 command will use the ISO 8601 format (YYYY-MM-DD) instead.
+The timestamp will also be compliant with ISO 8601 format.
 .SH EXAMPLES
 .B sar -u 2 5
 .RS

--- a/sar.c
+++ b/sar.c
@@ -441,18 +441,21 @@ int write_stats(int curr, int read_from_file, long *cnt, int use_tm_start,
 			return 0;
 	}
 
+	if (!is_iso_time_fmt())
+		flags |= S_F_PREFD_TIME_OUTPUT;
+
 	/* Get then set previous timestamp */
 	if (sa_get_record_timestamp_struct(flags + S_F_LOCAL_TIME, &record_hdr[!curr],
 					   &rectime, NULL))
 		return 0;
-	set_record_timestamp_string(S_F_PREFD_TIME_OUTPUT, &record_hdr[!curr],
+	set_record_timestamp_string(flags, &record_hdr[!curr],
 				    NULL, timestamp[!curr], 16, &rectime);
 
 	/* Get then set current timestamp */
 	if (sa_get_record_timestamp_struct(flags + S_F_LOCAL_TIME, &record_hdr[curr],
 					   &rectime, NULL))
 		return 0;
-	set_record_timestamp_string(S_F_PREFD_TIME_OUTPUT, &record_hdr[curr],
+	set_record_timestamp_string(flags, &record_hdr[curr],
 				    NULL, timestamp[curr], 16, &rectime);
 
 	/* Check if we are beginning a new day */


### PR DESCRIPTION
sar command prints the date in the header in the ISO 8601 format (YYYY-MM-DD) when environment variable S_TIME_FORMAT is "ISO". Even with the configuration, the time printed with stats is still locale depended.

```
# LC_ALL="ja_JP.UTF-8" S_TIME_FORMAT=ISO sar
Linux 3.10.0-327.el7.x86_64 (host.example.com)       2016-02-24      _x86_64_
        (48 CPU)

00時00分01秒     CPU     %user     %nice   %system   %iowait    %steal     %idle
00時10分01秒     all      0.32      0.00      0.13      0.01      0.00     99.54
...
```

With this patch, the time is also printed in the ISO format:

```
# LC_ALL="ja_JP.UTF-8" S_TIME_FORMAT=ISO sar
Linux 3.10.0-327.el7.x86_64 (host.example.com)       2016-02-24      _x86_64_
        (48 CPU)

14:25:17        CPU     %user     %nice   %system   %iowait    %steal     %idle
14:25:52        all      1.77      0.00      0.36      0.01      0.00     97.85
...
```
