### PR TITLE
fail if NLS enabled but no gettext available

### DIFF
--- a/configure
+++ b/configure
@@ -5015,6 +5015,9 @@ else
    AUX_NLS="no"
    NLS="n"
 fi
+if test $NLS = "y" && test x$ac_cv_prog_XGETTEXT = "x"; then
+    as_fn_error $? "NLS enabled but xgettext not available"
+fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $AUX_NLS" >&5
 $as_echo "$AUX_NLS" >&6; }
 


### PR DESCRIPTION
If NLS enabled but the requisite gettext is not available, report this clearly at 'configure' time rather than reporting "make: o: Command not found" at 'make' time.

    [steve@localhost sysstat]$ ./configure
    .
    Check programs:
    .
    checking for gcc... gcc
    checking whether the C compiler works... yes
    snip
    checking system activity directory... /var/log/sa
    checking sysstat configuration directory... /etc/sysconfig
    checking National Language Support... configure: error: NLS enabled but xgettext not available
    [steve@localhost sysstat]$ 


