### PR TITLE
typo text-anchror -> text-anchor

### DIFF
--- a/sadf_misc.c
+++ b/sadf_misc.c
@@ -844,7 +844,7 @@ __printf_funct_t print_svg_header(void *parm, int action, char *dfile,
 		printf(" width=\"%d\" height=\"%d\""
 		       " fill=\"black\" stroke=\"gray\" stroke-width=\"1\">\n",
 		       SVG_V_XSIZE, SVG_H_YSIZE + SVG_T_YSIZE * (*graph_nr));
-		printf("<text x= \"0\" y=\"30\" text-anchror=\"start\" stroke=\"brown\">");
+		printf("<text x= \"0\" y=\"30\" text-anchor=\"start\" stroke=\"brown\">");
 		print_gal_header(localtime((const time_t *) &(file_hdr->sa_ust_time)),
 				 file_hdr->sa_sysname, file_hdr->sa_release,
 				 file_hdr->sa_nodename, file_hdr->sa_machine,


### PR DESCRIPTION
Fixes minor typo in sadf_misc.c, where `text-anchror` is generated rather than `text-anchor`.