### PR TITLE
Fixes minor typo where attribute value was not surrounded by quotes

### DIFF
--- a/svg_stats.c
+++ b/svg_stats.c
@@ -498,7 +498,7 @@ void draw_activity_graphs(struct activity *a, char *title[], char *g_title[], ch
 			stamp.ust_time += k;
 		}
 		if (!PRINT_LOCAL_TIME(flags)) {
-			printf("<text x=-10 y=\"30\" style=\"fill: yellow; stroke: none; font-size: 12px; "
+			printf("<text x=\"-10\" y=\"30\" style=\"fill: yellow; stroke: none; font-size: 12px; "
 			       "text-anchor: end\">UTC</text>\n");
 		}
 


### PR DESCRIPTION
html file generated for SVG would read

    <text x=-10 y="30"

instead of

    <text x="-10" y="30"