### PR TITLE
Introduce new SP_VALUE_100() macro and use it in pidstat

### DIFF
--- a/common.h
+++ b/common.h
@@ -124,9 +124,12 @@
  *
  * NB: Define SP_VALUE() to normalize to %;
  * HZ is 1024 on IA64 and % should be normalized to 100.
+ * SP_VALUE_100() will not output value bigger than 100; this is needed for some
+ *     corner cases, should be used with care.
  */
 #define S_VALUE(m,n,p)	(((double) ((n) - (m))) / (p) * HZ)
 #define SP_VALUE(m,n,p)	(((double) ((n) - (m))) / (p) * 100)
+#define SP_VALUE_100(m,n,p)	MINIMUM((((double) ((n) - (m))) / (p) * 100),100)
 
 /*
  * Under very special circumstances, STDOUT may become unavailable.

--- a/pidstat.c
+++ b/pidstat.c
@@ -1360,15 +1360,15 @@ int write_pid_task_all_stats(int prev, int curr, int dis,
 			cprintf_pc(4, 7, 2,
 				   (pstc->utime - pstc->gtime) < (pstp->utime - pstp->gtime) ?
 				   0.0 :
-				   SP_VALUE(pstp->utime - pstp->gtime,
+				   SP_VALUE_100(pstp->utime - pstp->gtime,
 					    pstc->utime - pstc->gtime, itv),
-				   SP_VALUE(pstp->stime,  pstc->stime, itv),
-				   SP_VALUE(pstp->gtime,  pstc->gtime, itv),
+				   SP_VALUE_100(pstp->stime,  pstc->stime, itv),
+				   SP_VALUE_100(pstp->gtime,  pstc->gtime, itv),
 				   /* User time already includes guest time */
 				   IRIX_MODE_OFF(pidflag) ?
-				   SP_VALUE(pstp->utime + pstp->stime,
+				   SP_VALUE_100(pstp->utime + pstp->stime,
 					    pstc->utime + pstc->stime, g_itv) :
-				   SP_VALUE(pstp->utime + pstp->stime,
+				   SP_VALUE_100(pstp->utime + pstp->stime,
 					    pstc->utime + pstc->stime, itv));
 
 			cprintf_in(IS_INT, "   %3d", "", pstc->processor);
@@ -1560,15 +1560,15 @@ int write_pid_task_cpu_stats(int prev, int curr, int dis, int disp_avg,
 		cprintf_pc(4, 7, 2,
 			   (pstc->utime - pstc->gtime) < (pstp->utime - pstp->gtime) ?
 			   0.0 :
-			   SP_VALUE(pstp->utime - pstp->gtime,
+			   SP_VALUE_100(pstp->utime - pstp->gtime,
 				    pstc->utime - pstc->gtime, itv),
-			   SP_VALUE(pstp->stime, pstc->stime, itv),
-			   SP_VALUE(pstp->gtime, pstc->gtime, itv),
+			   SP_VALUE_100(pstp->stime, pstc->stime, itv),
+			   SP_VALUE_100(pstp->gtime, pstc->gtime, itv),
 			   /* User time already includes guest time */
 			   IRIX_MODE_OFF(pidflag) ?
-			   SP_VALUE(pstp->utime + pstp->stime,
+			   SP_VALUE_100(pstp->utime + pstp->stime,
 				    pstc->utime + pstc->stime, g_itv) :
-			   SP_VALUE(pstp->utime + pstp->stime,
+			   SP_VALUE_100(pstp->utime + pstp->stime,
 				    pstc->utime + pstc->stime, itv));
 
 		if (!disp_avg) {


### PR DESCRIPTION
Under specific loads, pidstat can output values bigger than 100% in CPU
statistics caused by inaccurate read of statistics provided by kernel.

This patch adds new SP_VALUE_100() macro which limits value to 100 for these
statistics, so the output can be correctly interpreted.