### PR TITLE
Stricter check for file_magic->header_size

### DIFF
--- a/sa.h
+++ b/sa.h
@@ -434,7 +434,8 @@ struct file_header {
 };
 
 #define FILE_HEADER_SIZE	(sizeof(struct file_header))
-/* The value below is used for sanity check */
+/* The values below are used for sanity check */
+#define MIN_FILE_HEADER_SIZE	0
 #define MAX_FILE_HEADER_SIZE	8192
 
 

--- a/sa_common.c
+++ b/sa_common.c
@@ -1274,7 +1274,8 @@ int sa_open_read_magic(int *fd, char *dfile, struct file_magic *file_magic,
 	if ((n != FILE_MAGIC_SIZE) ||
 	    (file_magic->sysstat_magic != SYSSTAT_MAGIC) ||
 	    ((file_magic->format_magic != FORMAT_MAGIC) && !ignore) ||
-	    ((file_magic->header_size > MAX_FILE_HEADER_SIZE) && !ignore) ||
+	    (file_magic->header_size < MIN_FILE_HEADER_SIZE) ||
+	    (file_magic->header_size > MAX_FILE_HEADER_SIZE) ||
 	    ((file_magic->header_size < FILE_HEADER_SIZE) && !ignore)) {
 		/* Display error message and exit */
 		handle_invalid_sa_file(fd, file_magic, dfile, n);


### PR DESCRIPTION
The file_magic->header_size should never be outside of the boundary set by
MIN_FILE_HEADER_SIZE and MAX_FILE_HEADER_SIZE.

Should resolve coverity CID 29717 and CID 29719.