### PR TITLE
Add discard IO tracking support to iostat.

### DIFF
--- a/iostat.h
+++ b/iostat.h
@@ -29,6 +29,7 @@
 #define I_D_ISO			0x20000
 #define I_D_GROUP_TOTAL_ONLY	0x40000
 #define I_D_ZERO_OMIT		0x80000
+#define I_D_DISCARD		0x100000
 
 #define DISPLAY_CPU(m)			(((m) & I_D_CPU)              == I_D_CPU)
 #define DISPLAY_DISK(m)			(((m) & I_D_DISK)             == I_D_DISK)
@@ -49,6 +50,8 @@
 #define DISPLAY_ISO(m)			(((m) & I_D_ISO)              == I_D_ISO)
 #define DISPLAY_GROUP_TOTAL_ONLY(m)	(((m) & I_D_GROUP_TOTAL_ONLY) == I_D_GROUP_TOTAL_ONLY)
 #define DISPLAY_ZERO_OMIT(m)		(((m) & I_D_ZERO_OMIT)        == I_D_ZERO_OMIT)
+#define DISPLAY_DISCARD(m)		(((m) & I_D_DISCARD)          == I_D_DISCARD)
+
 
 /* Preallocation constants */
 #define NR_DEV_PREALLOC		4
@@ -72,6 +75,8 @@ struct io_stats {
 	unsigned long rd_sectors	__attribute__ ((aligned (8)));
 	/* # of sectors written */
 	unsigned long wr_sectors	__attribute__ ((packed));
+	/* # of sectors discarded */
+	unsigned long di_sectors	__attribute__ ((packed));
 	/* # of read operations issued to the device */
 	unsigned long rd_ios		__attribute__ ((packed));
 	/* # of read requests merged */
@@ -80,10 +85,16 @@ struct io_stats {
 	unsigned long wr_ios		__attribute__ ((packed));
 	/* # of write requests merged */
 	unsigned long wr_merges		__attribute__ ((packed));
+	/* # of discard operations issued to the device */
+	unsigned long di_ios		__attribute__ ((packed));
+	/* # of discard requests merged */
+	unsigned long di_merges		__attribute__ ((packed));
 	/* Time of read requests in queue */
 	unsigned int  rd_ticks		__attribute__ ((packed));
 	/* Time of write requests in queue */
 	unsigned int  wr_ticks		__attribute__ ((packed));
+	/* Time of discard requests in queue */
+	unsigned int  di_ticks		__attribute__ ((packed));
 	/* # of I/Os in progress */
 	unsigned int  ios_pgr		__attribute__ ((packed));
 	/* # of ticks total (for this device) for I/O */


### PR DESCRIPTION
There are pending patches to the linux kernel for separating out
discard IOs from write IOs in /proc/diskstats and the various
/sys/block/*/stat files.  This is done by appending four additional
fields to these files as follows:

  Field 12 -- # of discards completed
      This is the total number of discards completed successfully.
  Field 13 -- # of discards merged
      See the description of field 2
  Field 14 -- # of sectors discarded
      This is the total number of sectors discarded successfully.
  Field 15 -- # of milliseconds spent discarding
      This is the total number of milliseconds spent by all discards (as
      measured from __make_request() to end_that_request_last()).

On the iostat side this is handled via adding the corresponding four
additional fields to struct io_stats and then updating the readers and
writers to print the additional stats.  To preserve backwards
compatibility the stats only show up when a new -D option is called
from the command line.  The following are some examples of how this
looks.

bash-4.2$ ./iostat
  [clip]
Device:            tps   Blk_read/s   Blk_wrtn/s   Blk_read   Blk_wrtn
sda              19.41       341.88        74.41  800994624  174337248
dm-0             12.21        62.24        35.45  145827544   83046552
dm-1             10.51       279.63        38.96  655151186   91290560

bash-4.2$ ./iostat -D
  [clip]
Device:            tps   Blk_read/s   Blk_wrtn/s   Blk_dscd/s   Blk_read   Blk_wrtn   Blk_dscd
sda              19.41       341.88        74.41         0.00  800994640  174337248          0
dm-0             12.21        62.24        35.45         0.00  145827544   83046552          0
dm-1             10.51       279.63        38.96         0.00  655151202   91290560          0

bash-4.2$ ./iostat -x
  [clip]
Device:         rrqm/s   wrqm/s     r/s     w/s   rsec/s   wsec/s avgrq-sz avgqu-sz   await r_await w_await  svctm  %util
sda               0.84     2.46   14.34    5.07   341.88    74.41    29.04     0.17   11.62    0.18   32.33   0.19   0.28
dm-0              0.00     0.00    7.78    4.43    62.24    35.45    12.56     0.26   33.95    0.13   59.38   0.20   0.16
dm-1              0.00     0.00    7.40    3.11   279.63    38.96    43.04     0.03    3.68    0.37    7.86   0.21   0.15

bash-4.2$ ./iostat -xD
  [clip]
Device:         rrqm/s   wrqm/s   drqm/s     r/s     w/s     d/s   rsec/s   wsec/s   dsec/s avgrq-sz avgqu-sz   await r_await w_await d_await  svctm  %util
sda               0.84     2.46     0.00   14.34    5.07    0.00   341.88    74.41     0.00    29.04     0.17   11.62    0.18   32.33    0.00   0.19   0.28
dm-0              0.00     0.00     0.00    7.78    4.43    0.00    62.24    35.45     0.00    12.56     0.26   33.95    0.13   59.38    0.00   0.20   0.16
dm-1              0.00     0.00     0.00    7.40    3.11    0.00   279.63    38.96     0.00    43.04     0.03    3.68    0.37    7.86    0.00   0.21   0.15
