### PR TITLE
sar: make buffers that hold timestamps bigger

### DIFF
--- a/sa.h
+++ b/sa.h
@@ -224,7 +224,7 @@
 #define BITMAP_SIZE(m)	((((m) + 1) / 8) + 1)
 
 #define UTSNAME_LEN	65
-#define TIMESTAMP_LEN	16
+#define TIMESTAMP_LEN	64
 #define HEADER_LINE_LEN	512
 
 /*

--- a/sar.c
+++ b/sar.c
@@ -449,14 +449,14 @@ int write_stats(int curr, int read_from_file, long *cnt, int use_tm_start,
 					   &rectime, NULL))
 		return 0;
 	set_record_timestamp_string(flags, &record_hdr[!curr],
-				    NULL, timestamp[!curr], 16, &rectime);
+				    NULL, timestamp[!curr], TIMESTAMP_LEN, &rectime);
 
 	/* Get then set current timestamp */
 	if (sa_get_record_timestamp_struct(flags + S_F_LOCAL_TIME, &record_hdr[curr],
 					   &rectime, NULL))
 		return 0;
 	set_record_timestamp_string(flags, &record_hdr[curr],
-				    NULL, timestamp[curr], 16, &rectime);
+				    NULL, timestamp[curr], TIMESTAMP_LEN, &rectime);
 
 	/* Check if we are beginning a new day */
 	if (use_tm_start && record_hdr[!curr].ust_time &&


### PR DESCRIPTION
On systems that use Korean UTF-8 locale sar will not print timestamp
because there is not enough space in the buffer.

I bumped buffer size to 64 bytes because I figured out that 32 bytes is
still not enough to print out timestamp when using some glibc supported
locales.

```
$ LC_TIME=ko_KR.UTF-8 ./sar 1 1
```

Before:
```
Linux 4.7.2-201.fc24.x86_64 (morgoth.usersys.redhat.com)        2016년 09월 30일   _x86_64_        (4 CPU)

                CPU     %user     %nice   %system   %iowait    %steal     %idle
                all      4.51      0.00      2.51      0.00      0.00     92.98
Average:        all      4.51      0.00      2.51      0.00      0.00     92.98
```

After:
```
Linux 4.7.2-201.fc24.x86_64 (morgoth.usersys.redhat.com)   2016년 09월 30일   _x86_64_        (4 CPU)

18시 18분 36초     CPU     %user     %nice   %system   %iowait    %steal     %idle
18시 18분 37초     all      3.76      0.00      2.26      0.00      0.00     93.98
Average:        all      3.76      0.00      2.26      0.00      0.00     93.98
```