### PR TITLE
sar: Improve cpuinfo read for POWER architecture

### DIFF
--- a/rd_stats.c
+++ b/rd_stats.c
@@ -1826,8 +1826,14 @@ void read_cpuinfo(struct stats_pwr_cpufreq *st_pwr_cpufreq, int nbr)
 			sscanf(strchr(line, ':') + 1, "%u", &proc_nb);
 		}
 
-		else if (!strncmp(line, "cpu MHz\t", 8)) {
-			sscanf(strchr(line, ':') + 1, "%u.%u", &ifreq, &dfreq);
+		else if (!strncmp(line, "cpu MHz\t", 8) ||
+			 !strncmp(line, "clock\t", 6)) {
+
+			if (strstr(line, "MHz"))
+				sscanf(strchr(line, ':') + 1, "%u.%uMHz", &ifreq, &dfreq);
+		        else
+				sscanf(strchr(line, ':') + 1, "%u.%u", &ifreq, &dfreq);
+
 
 			if (proc_nb < (nbr - 1)) {
 				/* Save current CPU frequency */


### PR DESCRIPTION
Currently CPU frequency is not being read properly on POWER archicture.
It shows the frequency as:
  # sar -m CPU 1 5
...
  06:30:28 AM     CPU       MHz
  06:30:36 AM     all      0.00

This is caused because /proc/cpuinfo is differently between Intel and
POWER.
This patch simply fix the parsing function (read_cpuinfo).

Signed-off-by: Breno Leitao <breno.leitao@gmail.com>