### PR TITLE
fix 00 byte after values when --human is not set

### DIFF
--- a/common.c
+++ b/common.c
@@ -1287,7 +1287,6 @@ void cprintf_pc(int human, int num, int wi, int wd, ...)
 {
 	int i;
 	double val, lim = 0.005;
-	int print_percent = 0;
 	va_list args;
 
 	/*
@@ -1296,7 +1295,6 @@ void cprintf_pc(int human, int num, int wi, int wd, ...)
 	 */
 	if (human > 0) {
 		lim = 0.05;
-		print_percent = 1;
 		if (wi < 4) {
 			/* E.g., 100% */
 			wi = 4;
@@ -1326,7 +1324,7 @@ void cprintf_pc(int human, int num, int wi, int wd, ...)
 		}
 		printf(" %*.*f", wi, wd, val);
 		printf("%s", sc_normal);
-		if (print_percent) printf("%%");
+		if (human > 0) printf("%%");
 	}
 
 	va_end(args);

--- a/common.c
+++ b/common.c
@@ -1287,7 +1287,7 @@ void cprintf_pc(int human, int num, int wi, int wd, ...)
 {
 	int i;
 	double val, lim = 0.005;
-	char u = '\0';
+	int print_percent = 0;
 	va_list args;
 
 	/*
@@ -1296,7 +1296,7 @@ void cprintf_pc(int human, int num, int wi, int wd, ...)
 	 */
 	if (human > 0) {
 		lim = 0.05;
-		u = '%';
+		print_percent = 1;
 		if (wi < 4) {
 			/* E.g., 100% */
 			wi = 4;
@@ -1326,7 +1326,7 @@ void cprintf_pc(int human, int num, int wi, int wd, ...)
 		}
 		printf(" %*.*f", wi, wd, val);
 		printf("%s", sc_normal);
-		printf("%c", u);
+		if (print_percent) printf("%%");
 	}
 
 	va_end(args);


### PR DESCRIPTION
Since 33557c3d: Display a percent sign after the value when --human
option used in non --human mode the output has an exta spurious '0'
byte.

That is printed by the percentage unit being set to char u = '\0'.
But that is not "nothing" it is literally byte "00".

This change only calls printf with a literal % when needed.

Fixes 165

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>