### PR TITLE
#174: Support CSV output from `pidstat`.

### DIFF
--- a/common.h
+++ b/common.h
@@ -298,6 +298,8 @@ void xprintf
 	(int, const char *, ...);
 void xprintf0
 	(int, const char *, ...);
+void efprintf(FILE *, const char *, const char *, ...);
+void csv_efprintf_s(FILE *, const char *, const char *, ...);
 
 #endif /* SOURCE_SADC undefined */
 #endif  /* _COMMON_H */

--- a/pidstat.c
+++ b/pidstat.c
@@ -32,6 +32,7 @@
 #include <sys/utsname.h>
 #include <regex.h>
 #include <linux/sched.h>
+#include <stdio.h>
 
 #include "version.h"
 #include "pidstat.h"
@@ -62,6 +63,8 @@ char commstr[MAX_COMM_LEN];
 char userstr[MAX_USER_LEN];
 char procstr[MAX_COMM_LEN];
 int show_threads = FALSE;
+char *csv_file_path = NULL;
+FILE *csv_file = NULL;
 
 unsigned int pid_nr = 0;	/* Nb of PID to display */
 unsigned int pid_array_nr = 0;
@@ -92,6 +95,7 @@ void usage(char *progname)
 	fprintf(stderr, _("Options are:\n"
 			  "[ -d ] [ -H ] [ -h ] [ -I ] [ -l ] [ -R ] [ -r ] [ -s ] [ -t ] [ -U [ <username> ] ]\n"
 			  "[ -u ] [ -V ] [ -v ] [ -w ] [ -C <command> ] [ -G <process_name> ] [ --human ]\n"
+			  "[ --csv <file_path> ]\n"
 			  "[ -p { <pid> [,...] | SELF | ALL } ] [ -T { TASK | CHILD | ALL } ]\n"));
 	exit(1);
 }
@@ -911,6 +915,42 @@ unsigned int count_tid_in_list(void)
 
 /*
  ***************************************************************************
+ * Write column names for all fields that would be output as CSVs.
+ ***************************************************************************
+ */
+void csv_write_header(void)
+{
+	efprintf(csv_file, csv_file_path,
+		"timestamp,interval_ticks,interval_all_cpu_ticks,User,UID,TGID,TID,PID");
+	if (DISPLAY_CPU(actflag)) {
+		efprintf(csv_file, csv_file_path,
+			",user_ticks,system_ticks,guest_ticks,wait_ticks,%%CPU,CPU,ticks/s");
+	}
+	if (DISPLAY_MEM(actflag)) {
+		efprintf(csv_file, csv_file_path,
+			",minflt,majflt,VSZ_kb,RSS_kb,total_mem_kb,%%mem");
+	}
+	if (DISPLAY_STACK(actflag)) {
+		efprintf(csv_file, csv_file_path, ",StkSize_kb,StkRef_kb");
+	}
+	if (DISPLAY_IO(actflag)) {
+		efprintf(csv_file, csv_file_path,
+			",B_rd,B_wr,B_ccwr,IOdelay_ticks");
+	}
+	if (DISPLAY_CTXSW(actflag)) {
+		efprintf(csv_file, csv_file_path, ",cswch,nvcswch");
+	}
+	if (DISPLAY_KTAB(actflag)) {
+		efprintf(csv_file, csv_file_path, ",thread_count,fd_count");
+	}
+	if (DISPLAY_RT(actflag)) {
+		efprintf(csv_file, csv_file_path, ",prio,policy");
+	}
+	efprintf(csv_file, csv_file_path, ",Command\n");
+}
+
+/*
+ ***************************************************************************
  * Allocate and init structures according to system state.
  ***************************************************************************
  */
@@ -935,6 +975,16 @@ void pid_sys_init(void)
 	else {
 		pid_nr = pid_array_nr;
 		salloc_pid(pid_nr);
+	}
+
+	/* Open output files: */
+	if (OUTPUT_CSV(pidflag)) {
+		csv_file = fopen(csv_file_path, "w");
+		if (csv_file == NULL) {
+			perror("Opening CSV output file");
+			exit(4);
+		}
+		csv_write_header();
 	}
 }
 
@@ -2278,6 +2328,146 @@ int write_pid_ktab_stats(int prev, int curr, int dis, int disp_avg,
  * IN:
  * @prev	Index in array where stats used as reference are.
  * @curr	Index in array for current sample statistics.
+ * @prev_tm	Pointer to a tm struct with the the timestamp of the
+ * 		previous sample.
+ * @curr_tm	Pointer to a tm struct with the timestamp of the current sample.
+ * @itv	Interval of time in jiffies.
+ * @deltot_jiffies
+ * 		Number of jiffies spent on the interval by all processors.
+ ***************************************************************************
+ */
+void csv_write_stats(int prev, int curr,
+		    struct tm *prev_tm, struct tm *curr_tm,
+			unsigned long long itv, unsigned long long deltot_jiffies)
+{
+	struct pid_stats *pstc, *pstp;
+	unsigned int p;
+	char time_buf[256];
+
+	for (p = 0; p < pid_nr; p++) {
+
+		if (get_pid_to_display(prev, curr, p, actflag, P_TASK,
+				       &pstc, &pstp) <= 0)
+			continue;
+
+		// Write timestamp,interval_ticks,interval_all_cpu_ticks:
+		if (strftime(time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M:%S", curr_tm) < 1) {
+			perror("strftime");
+			exit(4);
+		}
+		efprintf(csv_file, csv_file_path, "%s,%llu,%llu,",
+			time_buf, itv, deltot_jiffies);
+
+		// Write user name:
+		struct passwd *pwdent;
+
+		if ((pwdent = getpwuid(pstc->uid)) != NULL) {
+			csv_efprintf_s(csv_file, csv_file_path, "%s", pwdent->pw_name);
+		}
+
+		// Write UID, TGID, TID, PID:
+		efprintf(csv_file, csv_file_path, ",%d,%d,", pstc->uid, pstc->tgid);
+		if (pstc->tgid) {
+			// pstc->pid is, actually, a TID:
+			efprintf(csv_file, csv_file_path, "%d,0,", pstc->pid);
+		}
+		else
+		{
+			efprintf(csv_file, csv_file_path, "0,%d,", pstc->pid);
+		}
+
+		if (DISPLAY_CPU(actflag)) {
+			// Write user_ticks,system_ticks,guest_ticks,wait_ticks,
+			// %CPU,CPU,ticks/s:
+			efprintf(csv_file, csv_file_path,
+				"%llu,%llu,%llu,%llu,%f,%u,%lu,",
+				pstc->utime, pstc->stime, pstc->gtime, pstc->wtime,
+				/* User time already includes guest time */
+				IRIX_MODE_OFF(pidflag) ?
+				   SP_VALUE_100(pstp->utime + pstp->stime,
+					    pstc->utime + pstc->stime, deltot_jiffies) :
+				   SP_VALUE_100(pstp->utime + pstp->stime,
+					    pstc->utime + pstc->stime, itv * HZ / 100),
+				pstc->processor, HZ);
+		}
+
+		if (DISPLAY_MEM(actflag)) {
+			// Write minflt,majflt,VSZ_kb,RSS_kb,total_mem_kb,%mem:
+			efprintf(csv_file, csv_file_path,
+				"%llu,%llu,%llu,%llu,%lu,%f,",
+				pstc->minflt - pstp->minflt,
+				pstc->majflt - pstp->majflt,
+				pstc->vsz,
+				pstc->rss,
+				tlmkb,
+				tlmkb ? SP_VALUE(0, pstc->rss, tlmkb) : 0.0);
+		}
+
+		if (DISPLAY_STACK(actflag)) {
+			// Write StkSize_kb,StkRef_kb:
+			efprintf(csv_file, csv_file_path, "%lu,%lu,",
+				pstc->stack_size, pstc->stack_ref);
+		}
+
+		if (DISPLAY_IO(actflag)) {
+			// Write B_rd,B_wr,B_ccwr,IOdelay_ticks:
+			if (!NO_PID_IO(pstc->flags))
+			{
+				efprintf(csv_file, csv_file_path, "%llu,%llu,%llu,",
+					pstc->read_bytes, pstc->write_bytes,
+					pstp->cancelled_write_bytes);
+			}
+			else {
+				/*
+				 * Keep the layout even though this task has no I/O
+				 * typically threads with no I/O measurements.
+				 */
+				efprintf(csv_file, csv_file_path, "-1,-1,-1,");
+			}
+			/* I/O delays come from another file (/proc/#/stat) */
+			efprintf(csv_file, csv_file_path, "%llu,",
+				(unsigned long long) (pstc->blkio_swapin_delays - pstp->blkio_swapin_delays));
+		}
+
+		if (DISPLAY_CTXSW(actflag)) {
+			// Write cswch,nvcswch:
+			efprintf(csv_file, csv_file_path, "%lu,%lu,",
+				  pstc->nvcsw - pstp->nvcsw,
+				  pstc->nivcsw - pstp->nivcsw);
+		}
+
+		if (DISPLAY_KTAB(actflag)) {
+			// Write thread_count,fd_count:
+			efprintf(csv_file, csv_file_path, "%lu,", pstc->threads);
+			if (NO_PID_FD(pstc->flags)) {
+				/* /proc/#/fd directory not readable */
+				efprintf(csv_file, csv_file_path, "-1,");
+			}
+			else {
+				efprintf(csv_file, csv_file_path, "%lu,", pstc->fd_nr);
+			}
+		}
+
+		if (DISPLAY_RT(actflag)) {
+			// Write prio,policy:
+			efprintf(csv_file, csv_file_path, "%lu,%s,",
+				pstc->priority, GET_POLICY(pstc->policy));
+		}
+
+		// Write Command:
+		csv_efprintf_s(csv_file, csv_file_path, "%s", get_tcmd(pstc));
+
+		efprintf(csv_file, csv_file_path, "\n");
+	}
+}
+
+/*
+ ***************************************************************************
+ * Display statistics.
+ *
+ * IN:
+ * @prev	Index in array where stats used as reference are.
+ * @curr	Index in array for current sample statistics.
  * @dis		TRUE if a header line must be printed.
  * @disp_avg	TRUE if average stats are displayed.
  * @prev_string	String displayed at the beginning of a header line. This is
@@ -2380,6 +2570,11 @@ int write_stats_core(int prev, int curr, int dis, int disp_avg,
 
 	if (DISPLAY_ALL_PID(pidflag)) {
 		again = 1;
+	}
+
+	if (!disp_avg && OUTPUT_CSV(pidflag)) {
+		csv_write_stats(!curr, curr, &ps_tstamp[!curr], &ps_tstamp[curr],
+			itv, deltot_jiffies);
 	}
 
 	return again;
@@ -2744,6 +2939,15 @@ int main(int argc, char **argv)
 			opt++;
 		}
 
+		else if (!strcmp(argv[opt], "--csv")) {
+			if (!argv[++opt]) {
+				usage(argv[0]);
+			}
+			pidflag |= P_O_CSV;
+			csv_file_path = argv[opt];
+			opt++;
+		}
+
 		/* Option used individually. See below for grouped option */
 		else if (!strcmp(argv[opt], "-U")) {
 			/* Display username instead of UID */
@@ -2913,5 +3117,15 @@ int main(int argc, char **argv)
 	free(pid_array);
 	sfree_pid();
 
-	return 0;
+	int exit_status = 0;
+
+	/* Close streams: */
+	if (csv_file != NULL) {
+		if (fclose(csv_file)) {
+			perror("Closing output CSV file");
+			exit_status = 4;
+		}
+	}
+
+	return exit_status;
 }

--- a/pidstat.h
+++ b/pidstat.h
@@ -71,6 +71,7 @@
 #define P_F_PROCSTR	0x0400
 #define P_D_UNIT	0x0800
 #define P_D_SEC_EPOCH	0x1000
+#define P_O_CSV	0x2000
 
 #define DISPLAY_PID(m)		(((m) & P_D_PID) == P_D_PID)
 #define DISPLAY_ALL_PID(m)	(((m) & P_D_ALL_PID) == P_D_ALL_PID)
@@ -85,6 +86,7 @@
 #define PROCESS_STRING(m)	(((m) & P_F_PROCSTR) == P_F_PROCSTR)
 #define DISPLAY_UNIT(m)		(((m) & P_D_UNIT) == P_D_UNIT)
 #define PRINT_SEC_EPOCH(m)	(((m) & P_D_SEC_EPOCH) == P_D_SEC_EPOCH)
+#define OUTPUT_CSV(m)		(((m) & P_O_CSV) == P_O_CSV)
 
 /* Per-process flags */
 #define F_NO_PID_IO	0x01


### PR DESCRIPTION
* Added a `--csv <file_path>` option to `pidstat` for enabling CSV output to a file.
* Added a `P_O_CSV` flag that can be added to `pidflag` to indicate CSV should be output.
* Added `csv_write_header` and `csv_write_stats` functions to `pidstat.c` for outputting CSV.
* Added helper functions `efprintf` and `csv_efprintf_s` to `common.c` for writing a formatted string to a file stream with error reporting, and for writing a CSV string quoted according to RFC 4180 respectively.

Fixes #174.