### PR TITLE
Configure LGTM to exclude python code: declare as docs

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,3 @@
+path_classifiers:
+    docs:
+        - contrib

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,3 +1,3 @@
 path_classifiers:
-    docs:
+    library:
         - contrib


### PR DESCRIPTION
Salut Sebastien
As promised, the configuration file that will exclude the contrib directory from the evaluation