### PR TITLE
Add a JSON parse test

### DIFF
--- a/tests/0230
+++ b/tests/0230
@@ -1,0 +1,1 @@
+./sadf -j tests/data.tmp -C -- -A | json_pp >/dev/null


### PR DESCRIPTION
Best I can tell, it's been a good while since `sadf` last produced malformatted JSON (`v11.2.0`, Dec 2015), so, awesome!

Looking at the CI tests, any thoughts on including a test for validating the format of `sadf`'s JSON?

This pull request includes an example of a test that covers all of my practical use-cases. 
 Similar to `tests/0104`, but using `json_pp` to validate the resulting JSON.  I picked `json_pp` because it comes standard with Perl.