### PR TITLE
remove superfluous '&' within crontabs

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -317,7 +317,7 @@ file. Stop all sadc instances and try again.
 ---
 2.12. I have sysstat setup to run via cron:
 ```
-0 * * * * /usr/local/lib/sa/sa1 600 6 &
+0 * * * * /usr/local/lib/sa/sa1 600 6
 ```
 so that I get an activity report every 10 minutes.  
 When I use sar to get my output, there is no reading for `00:00:00`. This
@@ -335,13 +335,13 @@ rotation. So a crontab like the following one should enable you to get the
 data for midnight at the end of each daily data file:
 ```
 # Activity reports every 10 minutes from 01:00:00 to 22:50:00
-0 1-22 * * * /usr/local/lib/sa/sa1 600 6 &
+0 1-22 * * * /usr/local/lib/sa/sa1 600 6
 # Activity reports every 10 minutes from 23:00:00 to 00:00:00
 # Reporting until 00:00:00 ensures that a file rotation will be detected
 # by sadc
-0 23 * * * /usr/local/lib/sa/sa1 600 7 &
+0 23 * * * /usr/local/lib/sa/sa1 600 7
 # Activity reports every 10 minutes from 00:10:00 to 00:50:00
-10 0 * * * /usr/local/lib/sa/sa1 600 5 &
+10 0 * * * /usr/local/lib/sa/sa1 600 5
 ```
 Another possible crontab would be:
 ```

--- a/cron/crontab.sample
+++ b/cron/crontab.sample
@@ -4,16 +4,16 @@
 # /usr/lib/sa for example).
 #
 # 8am-7pm activity reports every 20 minutes during weekdays.
-# 0 8-18 * * 1-5 @SA_LIB_DIR@/sa1 1200 3 &
+# 0 8-18 * * 1-5 @SA_LIB_DIR@/sa1 1200 3
 # activity reports every @CRON_INTERVAL@ minutes everyday.
-0 * * * * @SA_LIB_DIR@/sa1 @CRON_INTERVAL_SEC@ @CRON_COUNT@ &
+0 * * * * @SA_LIB_DIR@/sa1 @CRON_INTERVAL_SEC@ @CRON_COUNT@
 #
 # Activity reports every an hour on Saturday and Sunday.
-# 0 * * * 0,6 @SA_LIB_DIR@/sa1 &
+# 0 * * * 0,6 @SA_LIB_DIR@/sa1
 #
 # 7pm-8am activity reports every an hour during weekdays.
-# 0 19-7 * * 1-5 @SA_LIB_DIR@/sa1 &
+# 0 19-7 * * 1-5 @SA_LIB_DIR@/sa1
 #
 # Previous day summary prepared at 00:07.
-# 7 0 * * 1-5 @SA_LIB_DIR@/sa2 -A &
-7 0 * * * @SA_LIB_DIR@/sa2 -A &
+# 7 0 * * 1-5 @SA_LIB_DIR@/sa2 -A
+7 0 * * * @SA_LIB_DIR@/sa2 -A

--- a/cron/sysstat.cron.daily.in
+++ b/cron/sysstat.cron.daily.in
@@ -2,4 +2,4 @@
 # Generate a daily summary of process accounting.  Since this will probably
 # get kicked off in the morning, it would probably be better to run against
 # the previous days data.
-@SA_LIB_DIR@/sa2 -A &
+@SA_LIB_DIR@/sa2 -A

--- a/cron/sysstat.cron.hourly.in
+++ b/cron/sysstat.cron.hourly.in
@@ -1,3 +1,3 @@
 #!/bin/sh
 # Run system activity accounting tool every @CRON_INTERVAL@ minutes
-@SA_LIB_DIR@/sa1 @CRON_INTERVAL_SEC@ @CRON_COUNT@ &
+@SA_LIB_DIR@/sa1 @CRON_INTERVAL_SEC@ @CRON_COUNT@

--- a/cron/sysstat.crond.in
+++ b/cron/sysstat.crond.in
@@ -1,6 +1,6 @@
 # Run system activity accounting tool every @CRON_INTERVAL@ minutes
 */@CRON_INTERVAL@ * * * * @CRON_OWNER@ @SA_LIB_DIR@/sa1 1 1
-# 0 * * * * @CRON_OWNER@ @SA_LIB_DIR@/sa1 @CRON_INTERVAL_SEC@ @CRON_COUNT@ &
+# 0 * * * * @CRON_OWNER@ @SA_LIB_DIR@/sa1 @CRON_INTERVAL_SEC@ @CRON_COUNT@
 # Generate a text summary of previous day process accounting at 00:07
 7 0 * * * @CRON_OWNER@ @SA_LIB_DIR@/sa2 -A
 

--- a/man/sa2.in
+++ b/man/sa2.in
@@ -42,7 +42,7 @@ To run the
 .B sa2
 command daily, place the following entry in your root crontab file:
 
-.B 5 19 * * 1-5 @SA_LIB_DIR@/sa2 -A &
+.B 5 19 * * 1-5 @SA_LIB_DIR@/sa2 -A
 
 This will generate by default a daily report called
 .I sarDD


### PR DESCRIPTION
Crontab entries within sysstat in some cases make use of "&" to background the job.  Use of "&" is not required and is therefore irrelevant and only serves to introduce a degree of inconsistency.  See typical example below, where an install has create an example entry referencing "&" but an actual entry lacking it.

Example

    [root@localhost ~]# grep sa1 /etc/cron.d/sysstat
    */10 * * * * root /usr/lib64/sa/sa1 1 1
    # 0 * * * * root /usr/lib64/sa/sa1 600 6 &
    [root@localhost ~]#

This PR removes use of "&" from code, from man pages and from the FAQ.