### PR TITLE
Clarify sadc(8) on using multiple -S keywords

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -536,10 +536,10 @@ the interval of time is small.
 in my binary daily data files?
 
 
-A: sadc's option -S followed by a keyword (DISK, SNMP...)  can already
-be used to specify which optional activities are to be collected.
-Without this option, sadc collects a default set of activities (CPU
-activity, memory activity, network activity, etc.)  
+A: sadc's option -S followed by one or more keywords (DISK, SNMP...)
+can already be used to specify which optional activities are to be
+collected. Without this option, sadc collects a default set of
+activities (CPU activity, memory activity, network activity, etc.)  
 Yet it is actually possible to specify explicitly which activities
 should be collected by sadc! You have to use sadc's option -S
 followed by the report name corresponding to the activity you want

--- a/man/sadc.in
+++ b/man/sadc.in
@@ -4,7 +4,7 @@ sadc \- System activity data collector.
 .SH SYNOPSIS
 .B @SA_LIB_DIR@/sadc [ -C
 .I comment
-.B ] [ -D ] [ -F ] [ -L ] [ -V ] [ -S { DISK | INT | IPV6 | POWER | SNMP | XDISK | ALL | XALL [,...] } ] [
+.B ] [ -D ] [ -F ] [ -L ] [ -V ] [ -S { keyword [,...] | ALL | XALL } ] [
 .I interval
 .B [
 .I count
@@ -124,7 +124,9 @@ If the system is under heavy load, an old
 .B sadc
 might still be running when cron starts a new one. Without locking,
 this situation can result in a corrupted system activity file.
-.IP "-S { DISK | INT | IPV6 | POWER | SNMP | XDISK | ALL | XALL [,...] }"
+.IP "-S { keyword [,...] | ALL | XALL }"
+Possible keywords are DISK, INT, IPV6, POWER, SNMP, XDISK, ALL, and XALL.
+
 Specify which optional activities should be collected by
 .BR sadc .
 Some activities are optional to prevent data files from growing too large.


### PR DESCRIPTION
I modified man/sadc.in to show the -S option being followed by
"keyword", and then listed the keywords. This allows the syntax to more
clearly show that multiple keywords can be specified by comma-separating
them. It also reflects the language used in sar(1) for the -n option.

Also, I modified the FAQ to call out that one can specify multiple
keywords for -S by comma-separating them.

Please let me know if there's anything I can do to make this pull request more helpful.