### PR TITLE
ignoring autofs as real filesystem by counting number of valid filesy…

### DIFF
--- a/count.c
+++ b/count.c
@@ -496,7 +496,6 @@ __nr_t get_filesystem_nr(void)
 			 * read filesystem type,
 			 * if filesystem type is autofs, skip it 
 			*/
-			memset(type, 0, sizeof(type));
 			pos2 = strchr(pos + 1, ' ');
 			if (pos2 == NULL)
 				continue;

--- a/count.c
+++ b/count.c
@@ -463,8 +463,8 @@ __nr_t get_usb_nr(void)
 __nr_t get_filesystem_nr(void)
 {
 	FILE *fp;
-	char line[512], fs_name[MAX_FS_LEN], mountp[256];
-	char *pos = 0;
+	char line[512], fs_name[MAX_FS_LEN], mountp[256], type[128];
+	char *pos = 0, *pos2 = 0;
 	__nr_t fs = 0;
 	int skip = 0, skip_next = 0;
 	struct statvfs buf;
@@ -489,6 +489,20 @@ __nr_t get_filesystem_nr(void)
 			/* Find field separator position */
 			pos = strchr(line, ' ');
 			if (pos == NULL)
+				continue;
+
+			/* 	
+			 * Find second field separator position,
+			 * read filesystem type,
+			 * if filesystem type is autofs, skip it 
+			*/
+			memset(type, 0, sizeof(type));
+			pos2 = strchr(pos + 1, ' ');
+			if (pos2 == NULL)
+				continue;
+			
+			sscanf(pos2 + 1, "%127s", type);
+			if(strcmp(type, "autofs") == 0)
 				continue;
 
 			/* Read filesystem name and mount point */

--- a/rd_stats.c
+++ b/rd_stats.c
@@ -2464,10 +2464,10 @@ __nr_t read_bus_usb_dev(struct stats_pwr_usb *st_pwr_usb, __nr_t nr_alloc)
 __nr_t read_filesystem(struct stats_filesystem *st_filesystem, __nr_t nr_alloc)
 {
 	FILE *fp;
-	char line[512], fs_name[128], mountp[256];
+	char line[512], fs_name[128], mountp[256], type[128];
 	int skip = 0, skip_next = 0;
 	char *pos = 0;
-	__nr_t fs_read = 0;
+	__nr_t fs_read = 0, *pos2 = 0;
 	struct stats_filesystem *st_filesystem_i;
 	struct statvfs buf;
 
@@ -2489,6 +2489,20 @@ __nr_t read_filesystem(struct stats_filesystem *st_filesystem, __nr_t nr_alloc)
 			/* Find field separator position */
 			pos = strchr(line, ' ');
 			if (pos == NULL)
+				continue;
+
+			/* 	
+			 * Find second field separator position,
+			 * read filesystem type,
+			 * if filesystem type is autofs, skip it 
+			*/
+			memset(type, 0, sizeof(type));
+			pos2 = strchr(pos + 1, ' ');
+			if (pos2 == NULL)
+				continue;
+
+			sscanf(pos2 + 1, "%127s", type);
+			if(strcmp(type, "autofs") == 0)
 				continue;
 
 			/* Read current filesystem name */

--- a/rd_stats.c
+++ b/rd_stats.c
@@ -2496,7 +2496,6 @@ __nr_t read_filesystem(struct stats_filesystem *st_filesystem, __nr_t nr_alloc)
 			 * read filesystem type,
 			 * if filesystem type is autofs, skip it 
 			*/
-			memset(type, 0, sizeof(type));
 			pos2 = strchr(pos + 1, ' ');
 			if (pos2 == NULL)
 				continue;


### PR DESCRIPTION
…stems and getting all valid filesystems

Not mounted autofs filesystem is not a valid filesystem until it is mounted. For that reason it can not be counted as one of the valid filesystems and should not be display in system statistics.