### PR TITLE
#217: add umask sysconfig variable for sa1 and sa2

### DIFF
--- a/sa1.in
+++ b/sa1.in
@@ -12,9 +12,12 @@ HISTORY=0
 SADC_OPTIONS=""
 SA_DIR=@SA_DIR@
 SYSCONFIG_DIR=@SYSCONFIG_DIR@
-umask 0022
+UMASK=0022
 
 [ -r ${SYSCONFIG_DIR}/sysstat ] && . ${SYSCONFIG_DIR}/sysstat
+
+umask ${UMASK}
+
 [ -d ${SA_DIR} ] || SA_DIR=@SA_DIR@
 
 if [ ${HISTORY} -gt 28 ]

--- a/sa2.in
+++ b/sa2.in
@@ -6,7 +6,6 @@
 #@(#) sa2: Write a daily report
 #
 S_TIME_FORMAT=ISO ; export S_TIME_FORMAT
-umask 0022
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 SA_DIR=@SA_DIR@
@@ -14,9 +13,12 @@ SYSCONFIG_DIR=@SYSCONFIG_DIR@
 HISTORY=@HISTORY@
 COMPRESSAFTER=@COMPRESSAFTER@
 ZIP="@ZIP@"
+UMASK=0022
 
 # Read configuration file, overriding variables set above
 [ -r ${SYSCONFIG_DIR}/sysstat ] && . ${SYSCONFIG_DIR}/sysstat
+
+umask ${UMASK}
 
 [ -d ${SA_DIR} ] || SA_DIR=@SA_DIR@
 

--- a/sysstat.sysconfig.in
+++ b/sysstat.sysconfig.in
@@ -26,3 +26,10 @@ ZIP="@ZIP@"
 # By default sa2 script generates reports files (the so called sarDD files).
 # Set this variable to false to disable reports generation.
 #REPORTS=false
+
+# The sa1 and sa2 scripts generate system activity data and report files in
+# the @SA_DIR@ directory. By default the files are created with umask 0022
+# and are therefore readable for all users. Change this variable to restrict
+# the permissions on the files (e.g. use 0027 to adhere to more strict
+# security standards).
+UMASK=0022


### PR DESCRIPTION
- Added sysconfig variable UMASK=0022 with by default the current umask value
- Updated sa1 and sa2 to use the UMASK variable, just after the sysconfig file is sourced.
- Added a default UMASK variable in sa1 and sa2 to support absence of the new variable in the sysconfig file