### PR TITLE
Check for InCsumErrors for EICMP as well

### DIFF
--- a/rd_stats.c
+++ b/rd_stats.c
@@ -1545,6 +1545,7 @@ __nr_t read_net_eicmp(struct stats_net_eicmp *st_net_eicmp)
 {
 	FILE *fp;
 	char line[1024];
+	static char format[256] = "";
 	int sw = FALSE;
 
 	if ((fp = fopen(NET_SNMP, "r")) == NULL)
@@ -1554,8 +1555,7 @@ __nr_t read_net_eicmp(struct stats_net_eicmp *st_net_eicmp)
 
 		if (!strncmp(line, "Icmp:", 5)) {
 			if (sw) {
-				sscanf(line + 5, "%*u %lu %lu %lu %lu %lu %lu %*u %*u "
-				       "%*u %*u %*u %*u %*u %lu %lu %lu %lu %lu %lu",
+				sscanf(line + 5, format,
 				       &st_net_eicmp->InErrors,
 				       &st_net_eicmp->InDestUnreachs,
 				       &st_net_eicmp->InTimeExcds,
@@ -1572,6 +1572,25 @@ __nr_t read_net_eicmp(struct stats_net_eicmp *st_net_eicmp)
 				break;
 			}
 			else {
+				if (!strlen(format)) {
+					if (strstr(line, "InCsumErrors")) {
+						/*
+						 * New format: InCsumErrors field exists at position #3.
+						 * Capture: 2,4,5,6,7,8,16,17,18,19,20,21
+						 */
+						strcpy(format, "%*u %lu %*u %lu %lu %lu %lu %lu %*u %*u "
+							       "%*u %*u %*u %*u %*u %lu %lu %lu %lu %lu %lu");
+					}
+					else {
+						/*
+						 * Old format: InCsumErrors field doesn't exist.
+						 * Capture: 2,3,4,5,6,7,15,16,17,18,19,20
+						 */
+						strcpy(format, "%*u %lu %lu %lu %lu %lu %lu %*u %*u "
+							       "%*u %*u %*u %*u %*u %lu %lu %lu %lu %lu %lu");
+
+					}
+				}
 				sw = TRUE;
 			}
 		}

--- a/tests/expected.sadf-r
+++ b/tests/expected.sadf-r
@@ -2247,13 +2247,13 @@
 # A_NET_ICMP: 1/1 (1)
 13:20:49 UTC; imsg/s; 7; 7; omsg/s; 0; 0; iech/s; 0; 0; iechr/s; 0; 0; oech/s; 0; 0; oechr/s; 0; 0; itm/s; 0; 0; itmr/s; 0; 0; otm/s; 0; 0; otmr/s; 0; 0; iadrmk/s; 0; 0; iadrmkr/s; 0; 0; oadrmk/s; 0; 0; oadrmkr/s; 0; 0;
 # A_NET_EICMP: 1/1 (1)
-13:20:19 UTC; ierr/s; 0; 0; oerr/s; 0; 0; idstunr/s; 0; 0; odstunr/s; 0; 0; itmex/s; 7; 7; otmex/s; 0; 0; iparmpb/s; 0; 0; oparmpb/s; 0; 0; isrcq/s; 0; 0; osrcq/s; 0; 0; iredir/s; 0; 0; oredir/s; 0; 0;
+13:20:19 UTC; ierr/s; 0; 0; oerr/s; 0; 0; idstunr/s; 7; 7; odstunr/s; 0; 0; itmex/s; 0; 0; otmex/s; 0; 0; iparmpb/s; 0; 0; oparmpb/s; 0; 0; isrcq/s; 0; 0; osrcq/s; 0; 0; iredir/s; 0; 0; oredir/s; 0; 0;
 # A_NET_EICMP: 1/1 (1)
-13:20:29 UTC; ierr/s; 0; 0; oerr/s; 0; 0; idstunr/s; 0; 0; odstunr/s; 0; 0; itmex/s; 7; 7; otmex/s; 0; 0; iparmpb/s; 0; 0; oparmpb/s; 0; 0; isrcq/s; 0; 0; osrcq/s; 0; 0; iredir/s; 0; 0; oredir/s; 0; 0;
+13:20:29 UTC; ierr/s; 0; 0; oerr/s; 0; 0; idstunr/s; 7; 7; odstunr/s; 0; 0; itmex/s; 0; 0; otmex/s; 0; 0; iparmpb/s; 0; 0; oparmpb/s; 0; 0; isrcq/s; 0; 0; osrcq/s; 0; 0; iredir/s; 0; 0; oredir/s; 0; 0;
 # A_NET_EICMP: 1/1 (1)
-13:20:39 UTC; ierr/s; 0; 0; oerr/s; 0; 0; idstunr/s; 0; 0; odstunr/s; 0; 0; itmex/s; 7; 7; otmex/s; 0; 0; iparmpb/s; 0; 0; oparmpb/s; 0; 0; isrcq/s; 0; 0; osrcq/s; 0; 0; iredir/s; 0; 0; oredir/s; 0; 0;
+13:20:39 UTC; ierr/s; 0; 0; oerr/s; 0; 0; idstunr/s; 7; 7; odstunr/s; 0; 0; itmex/s; 0; 0; otmex/s; 0; 0; iparmpb/s; 0; 0; oparmpb/s; 0; 0; isrcq/s; 0; 0; osrcq/s; 0; 0; iredir/s; 0; 0; oredir/s; 0; 0;
 # A_NET_EICMP: 1/1 (1)
-13:20:49 UTC; ierr/s; 0; 0; oerr/s; 0; 0; idstunr/s; 0; 0; odstunr/s; 0; 0; itmex/s; 7; 7; otmex/s; 0; 0; iparmpb/s; 0; 0; oparmpb/s; 0; 0; isrcq/s; 0; 0; osrcq/s; 0; 0; iredir/s; 0; 0; oredir/s; 0; 0;
+13:20:49 UTC; ierr/s; 0; 0; oerr/s; 0; 0; idstunr/s; 7; 7; odstunr/s; 0; 0; itmex/s; 0; 0; otmex/s; 0; 0; iparmpb/s; 0; 0; oparmpb/s; 0; 0; isrcq/s; 0; 0; osrcq/s; 0; 0; iredir/s; 0; 0; oredir/s; 0; 0;
 # A_NET_TCP: 1/1 (1)
 13:20:19 UTC; active/s; 1516; 1516; passive/s; 1; 1; iseg/s; 148044; 148044; oseg/s; 145504; 145504;
 # A_NET_TCP: 1/1 (1)
@@ -3004,7 +3004,7 @@
 # A_NET_ICMP: 1/1 (1)
 13:54:35 UTC; imsg/s; 7; 7; omsg/s; 0; 0; iech/s; 0; 0; iechr/s; 0; 0; oech/s; 0; 0; oechr/s; 0; 0; itm/s; 0; 0; itmr/s; 0; 0; otm/s; 0; 0; otmr/s; 0; 0; iadrmk/s; 0; 0; iadrmkr/s; 0; 0; oadrmk/s; 0; 0; oadrmkr/s; 0; 0;
 # A_NET_EICMP: 1/1 (1)
-13:54:35 UTC; ierr/s; 0; 0; oerr/s; 0; 0; idstunr/s; 0; 0; odstunr/s; 0; 0; itmex/s; 7; 7; otmex/s; 0; 0; iparmpb/s; 0; 0; oparmpb/s; 0; 0; isrcq/s; 0; 0; osrcq/s; 0; 0; iredir/s; 0; 0; oredir/s; 0; 0;
+13:54:35 UTC; ierr/s; 0; 0; oerr/s; 0; 0; idstunr/s; 7; 7; odstunr/s; 0; 0; itmex/s; 0; 0; otmex/s; 0; 0; iparmpb/s; 0; 0; oparmpb/s; 0; 0; isrcq/s; 0; 0; osrcq/s; 0; 0; iredir/s; 0; 0; oredir/s; 0; 0;
 # A_NET_TCP: 1/1 (1)
 13:54:35 UTC; active/s; 1516; 1516; passive/s; 1; 1; iseg/s; 148044; 148044; oseg/s; 145504; 145504;
 # A_NET_ETCP: 1/1 (1)


### PR DESCRIPTION
In 789cd86fb0, read_net_icmp() obtained code to differentiate between
the old and new format of /proc/net/snmp, which differ by the addition
of "InCsumErrors" in the 3rd position. Add the exact same handling logic
to read_net_eicmp() as well

Signed-off-by: Alexandros Kosiaris <akosiaris@gmail.com>