### PR TITLE
Missing empty line

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -359,6 +359,7 @@ Another possible crontab would be:
 50 23 * * * /usr/lib/sa/sa1 600 2
 10,20,30,40,50 0 * * * /usr/lib/sa/sa1 1 1
 ```
+
 ---
 2.13. The sar command complains with the following message:
 ```


### PR DESCRIPTION
A very minor improvement. The github markdown interprets the `---` directly after the backticks correctly, but other markdown interpreters see it as an indication for a new section.
Problem can be overcome by an empty line and is also consistent with the other usages in the FAQ.md