### PR TITLE
add missing includes for musl

### DIFF
--- a/common.c
+++ b/common.c
@@ -31,6 +31,7 @@
 #include <sys/types.h>
 #include <dirent.h>
 #include <ctype.h>
+#include <limits.h>
 #include <libgen.h>
 
 #include "version.h"

--- a/ioconf.c
+++ b/ioconf.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <errno.h>
 #include <dirent.h>
+#include <sys/types.h>
 #include <sys/stat.h>
 
 #include "ioconf.h"

--- a/sa_common.c
+++ b/sa_common.c
@@ -28,6 +28,7 @@
 #include <unistd.h>	/* For STDOUT_FILENO, among others */
 #include <dirent.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <libgen.h>
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
These are from Alpine Linux (which uses musl libc by default)