### PR TITLE
iostat: Add flush I/O statistics

### DIFF
--- a/iostat.h
+++ b/iostat.h
@@ -92,12 +92,16 @@ struct io_stats {
 	unsigned long dc_ios		__attribute__ ((packed));
 	/* # of discard requests merged */
 	unsigned long dc_merges		__attribute__ ((packed));
+	/* # of flush requests issued to the device */
+	unsigned long fl_ios		__attribute__ ((packed));
 	/* Time of read requests in queue */
 	unsigned int  rd_ticks		__attribute__ ((packed));
 	/* Time of write requests in queue */
 	unsigned int  wr_ticks		__attribute__ ((packed));
 	/* Time of discard requests in queue */
 	unsigned int  dc_ticks		__attribute__ ((packed));
+	/* Time of flush requests in queue */
+	unsigned int  fl_ticks		__attribute__ ((packed));
 	/* # of I/Os in progress */
 	unsigned int  ios_pgr		__attribute__ ((packed));
 	/* # of ticks total (for this device) for I/O */
@@ -133,6 +137,8 @@ struct ext_io_stats {
 	double w_await;
 	/* d_await */
 	double d_await;
+	/* f_await */
+	double f_await;
 	/* rsec/s */
 	double rsectors;
 	/* wsec/s */

--- a/man/iostat.in
+++ b/man/iostat.in
@@ -217,6 +217,12 @@ The number (after merges) of write requests completed per second for the device.
 The number (after merges) of discard requests completed per second for the device.
 
 .RE
+.B f/s
+.RS
+The number (after merges) of flush requests completed per second for the device.
+Origin (unmerged) flush operations are counted as writes (likely with zero size).
+
+.RE
 .B sec/s (kB/s, MB/s)
 .RS
 The number of sectors (kilobytes, megabytes) read from, written to or
@@ -325,6 +331,13 @@ the time spent servicing them.
 The average time (in milliseconds) for discard requests issued to the device
 to be served. This includes the time spent by the requests in queue and
 the time spent servicing them.
+
+.RE
+.B f_await
+.RS
+The average time (in milliseconds) for flush requests issued to the device
+to be served. Flush requests are issued one at a time, thus flush operation
+could be twice longer: wait current flush request, then issue and wait next.
 
 .RE
 .B aqu-sz


### PR DESCRIPTION
Statistics for flush operations have been added into Linux 5.5

Signed-off-by: Konstantin Khlebnikov <khlebnikov@yandex-team.ru>
Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=b6866318657717c8914673a6394894d12bc9ff5e
Fixes #240