### PR TITLE
Fix sa2 script, so it wont complain about "unrecognized archive format"

### DIFF
--- a/sa2.in
+++ b/sa2.in
@@ -65,7 +65,6 @@ UNCOMPRESSED_SAFILES_REGEX='/sar?[0-9]{2,8}$'
 
 find "${SA_DIR}" -type f -mtime +${COMPRESSAFTER} \
 	| egrep "${UNCOMPRESSED_SAFILES_REGEX}" \
-	| xargs   "${ZIP}" > /dev/null
+	| xargs -r "${ZIP}" > /dev/null
 
 exit 0
-


### PR DESCRIPTION
Fix `sa2` script, so it wont complain about "unrecognized archive format" on empty list for compress program.

if last find (in sa2 shell script), wont find any files
```
find "${SA_DIR}" -type f -mtime +${COMPRESSAFTER} \
        | egrep "${UNCOMPRESSED_SAFILES_REGEX}" \
        | xargs  "${ZIP}" > /dev/null
```
there would be a warning produced:
```
# bash -x /usr/lib/sysstat/sa2 -A
...
+ UNCOMPRESSED_SAFILES_REGEX='/sar?[0-9]{2,8}$'
+ find /var/log/sysstat -type f -mtime +10
+ egrep '/sar?[0-9]{2,8}$'
+ xargs pixz
Unrecognized archive format
Error reading archive entry
+ exit 0
```

(and mail is sent , if run from cron via /etc/cron.daily/sysstat (in debian))