### PR TITLE
Link with -lintl if needed

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -117,6 +117,7 @@ ifeq ($(SYSPARAM),y)
 	DFLAGS += -DHAVE_SYS_PARAM_H
 endif
 NLS = @NLS@
+LFLAGS += @LFINTL@
 ifeq ($(NLS),y)
 REQUIRE_NLS = -DUSE_NLS -DPACKAGE=\"$(PACKAGE)\" -DLOCALEDIR=\"$(NLS_DIR)\"
 endif

--- a/configure.in
+++ b/configure.in
@@ -389,6 +389,8 @@ else
    NLS="n"
 fi
 AC_MSG_RESULT($AUX_NLS)
+AC_CHECK_LIB(intl, gettext, LFINTL="-lintl")
+AC_SUBST(LFINTL)
 LACKING_GETTEXT="n"
 if test $AUX_NLS = "yes" &&  test x$MSGFMT != x"msgfmt"; then 
    echo "WARNING: msgfmt command not found!"


### PR DESCRIPTION
Some libc implementations like uclibc or musl provides
gettext stubs via libintl library. Without it, build will fail on:

```
/home/fabrice/buildroot/output/host/bin/arm-linux-gcc -o cifsiostat -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os   -Wall -Wstrict-prototypes -pipe -O2 cifsiostat.o librdstats_light.a libsyscom.a -s
/home/fabrice/buildroot/output/host/opt/ext-toolchain/bin/../lib/gcc/arm-buildroot-linux-musleabihf/8.3.0/../../../../arm-buildroot-linux-musleabihf/bin/ld: tapestat.o: in function `usage':
tapestat.c:(.text+0x44c): undefined reference to `libintl_gettext'
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>