### PR TITLE
sa1: fix sar error when the directory var/log/sa was removed.

### DIFF
--- a/sa1.in
+++ b/sa1.in
@@ -20,6 +20,7 @@ UMASK=0022
 umask ${UMASK}
 
 [ -d ${SA_DIR} ] || SA_DIR=@SA_DIR@
+[ -d @SA_DIR@ ] || mkdir @SA_DIR@
 
 if [ ${HISTORY} -gt 28 ]
 then


### PR DESCRIPTION
The code `[ -d ${SA_DIR} ] || SA_DIR=@SA_DIR@` in `sa1.in`,  if  ${SA_DIR} doesn`t exist, we set SA_DIR=@SA_DIR@(/var/log/sa),  but /var/log/sa could be removed in some cases. Then sysstat will write system activity daily data in /var/log/sa as a file.

```
[root@localhost ~]# ll /var/log/sa
-rw-r--r--. 1 root root 304740 Apr 28 22:30 /var/log/sa
```

Now /var/log/sa is a file instead of a directory , but the sar command without a parameter will try to find a  system activity daily data file in /var/log/sa/ .

```
[root@localhost ~]# sar
Cannot open /var/log/sa/sa28: Not a directory
```

I think the directory @SA_DIR@ should always exist. We should judge if the directory exists  or not , and mkdir when the directory doesn`t exist.