### PR TITLE
Replace index() call with strchr() call

### DIFF
--- a/common.c
+++ b/common.c
@@ -1478,7 +1478,7 @@ int parse_values(char *strargv, unsigned char bitmap[], int max_val, const char 
 			strncpy(range, t, 16);
 			range[15] = '\0';
 			valstr = t;
-			if ((s = index(range, '-')) != NULL) {
+			if ((s = strchr(range, '-')) != NULL) {
 				/* Possible range of values */
 				*s = '\0';
 				if (parse_valstr(range, max_val, &val_low) || (val_low < 0))

--- a/tests/12.0.1/common.c
+++ b/tests/12.0.1/common.c
@@ -1403,7 +1403,7 @@ int parse_values(char *strargv, unsigned char bitmap[], int max_val, const char 
 			strncpy(range, t, 16);
 			range[15] = '\0';
 			valstr = t;
-			if ((s = index(range, '-')) != NULL) {
+			if ((s = strchr(range, '-')) != NULL) {
 				/* Possible range of values */
 				*s = '\0';
 				if (parse_valstr(range, max_val, &val_low) || (val_low < 0))


### PR DESCRIPTION
According to [glibc documentation][1], "index is another name for strchr; they are exactly the same. New code should always use strchr." The use of `index()` breaks compilation for Android targets, which use Bionic instead of glibc and don't have `index()`.

[1]: https://www.gnu.org/software/libc/manual/html_node/Search-Functions.html#index-index