### PR TITLE
docs: fix simple typo, stuctures -> structures

### DIFF
--- a/sar.c
+++ b/sar.c
@@ -1592,7 +1592,7 @@ int main(int argc, char **argv)
 		/* Read stats from file */
 		read_stats_from_file(from_file);
 
-		/* Free stuctures and activity bitmaps */
+		/* Free structures and activity bitmaps */
 		free_bitmaps(act);
 		free_structures(act);
 

--- a/tests/12.0.1/inisar.c
+++ b/tests/12.0.1/inisar.c
@@ -1077,7 +1077,7 @@ int main(int argc, char **argv)
 		/* Read stats from file */
 		read_stats_from_file(from_file);
 
-		/* Free stuctures and activity bitmaps */
+		/* Free structures and activity bitmaps */
 		free_bitmaps(act);
 		free_structures(act);
 


### PR DESCRIPTION
There is a small typo in sar.c, tests/12.0.1/inisar.c.

Should read `structures` rather than `stuctures`.

