### PR TITLE
Update sadf to use metadata matching the same metrics from PCP

### DIFF
--- a/pcp_def_metrics.c
+++ b/pcp_def_metrics.c
@@ -233,9 +233,9 @@ void pcp_def_pcsw_metrics(void)
 		     pmiID(60, 0, 13), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
 		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("kernel.all.nprocs",
-		     pmiID(60, 2, 3), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, 0, 0, 0, 0, 0));
+	pmiAddMetric("kernel.all.sysfork",
+		     pmiID(60, 0, 14), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
 
@@ -391,6 +391,14 @@ void pcp_def_memory_metrics(struct activity *a)
 #ifdef HAVE_PCP
 	if (DISPLAY_MEMORY(a->opt_flags)) {
 
+		pmiAddMetric("hinv.physmem",
+			     pmiID(60, 1, 9), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_DISCRETE,
+			     pmiUnits(1, 0, 0, PM_SPACE_MBYTE, 0, 0));
+
+		pmiAddMetric("mem.physmem",
+			     pmiID(60, 1, 0), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_DISCRETE,
+			     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
+
 		pmiAddMetric("mem.util.free",
 			     pmiID(60, 1, 2), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 			     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
@@ -490,7 +498,7 @@ void pcp_def_ktables_metrics(void)
 
 	pmiAddMetric("kernel.all.nptys",
 		     pmiID(60, 72, 3), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
+		     pmiUnits(0, 0, 0, 0, 0, 0));
 #endif /* HAVE_PCP */
 }
 
@@ -657,18 +665,6 @@ void pcp_def_net_dev_metrics(struct activity *a)
 		pmiAddMetric("network.interface.in.mcasts",
 			     pmiID(60, 3, 7), PM_TYPE_U64, indom, PM_SEM_COUNTER,
 			     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
-
-		pmiAddMetric("network.interface.speed",
-			     pmiID(60, 3, 22), PM_TYPE_FLOAT, indom, PM_SEM_DISCRETE,
-			     pmiUnits(1, -1, 0, PM_SPACE_MBYTE, PM_TIME_SEC, 0));
-
-		pmiAddMetric("network.interface.baudrate",
-			     pmiID(60, 3, 23), PM_TYPE_U64, indom, PM_SEM_DISCRETE,
-			     pmiUnits(1, -1, 0, PM_SPACE_BYTE, PM_TIME_SEC, 0));
-
-		pmiAddMetric("network.interface.duplex",
-			     pmiID(60, 3, 24), PM_TYPE_U32, indom, PM_SEM_DISCRETE,
-			     pmiUnits(0, 0, 0, 0, 0, 0));
 	}
 	else {
 		/* Create metrics for A_NET_EDEV */
@@ -1544,7 +1540,7 @@ void pcp_def_pwr_temp_metrics(struct activity *a)
 		}
 	}
 
-	pmiAddMetric("power.temp.celcius",
+	pmiAddMetric("power.temp.celsius",
 		     pmiID(34, 1, 0), PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 0, 0, 0, 0));
 

--- a/pcp_def_metrics.c
+++ b/pcp_def_metrics.c
@@ -61,73 +61,70 @@ void pcp_def_cpu_metrics(struct activity *a)
 			if (a->id == A_CPU) {
 				/* This is CPU "all" */
 				pmiAddMetric("kernel.all.cpu.user",
-				     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-				     pmiUnits(0, 0, 0, 0, 0, 0));
+					     pmiID(60, 0, 20), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+					     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 
 				pmiAddMetric("kernel.all.cpu.nice",
-					     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-					     pmiUnits(0, 0, 0, 0, 0, 0));
+					     pmiID(60, 0, 21), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+					     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 
 				pmiAddMetric("kernel.all.cpu.sys",
-					     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-					     pmiUnits(0, 0, 0, 0, 0, 0));
+					     pmiID(60, 0, 22), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+					     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 
 				pmiAddMetric("kernel.all.cpu.idle",
-					     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-					     pmiUnits(0, 0, 0, 0, 0, 0));
+					     pmiID(60, 0, 23), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+					     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 
-				pmiAddMetric("kernel.all.cpu.iowait",
-					     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-					     pmiUnits(0, 0, 0, 0, 0, 0));
+				pmiAddMetric("kernel.all.cpu.wait.total",
+					     pmiID(60, 0, 25), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+					     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
+
+				pmiAddMetric("kernel.all.cpu.intr",
+					     pmiID(60, 0, 34), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+					     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 
 				pmiAddMetric("kernel.all.cpu.steal",
-					     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-					     pmiUnits(0, 0, 0, 0, 0, 0));
+					     pmiID(60, 0, 55), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+					     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 
-				pmiAddMetric("kernel.all.cpu.hardirq",
-					     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-					     pmiUnits(0, 0, 0, 0, 0, 0));
+				pmiAddMetric("kernel.all.cpu.irq.hard",
+					     pmiID(60, 0, 54), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+					     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 
-				pmiAddMetric("kernel.all.cpu.softirq",
-					     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-					     pmiUnits(0, 0, 0, 0, 0, 0));
+				pmiAddMetric("kernel.all.cpu.irq.soft",
+					     pmiID(60, 0, 53), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+					     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 
 				pmiAddMetric("kernel.all.cpu.guest",
-					     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-					     pmiUnits(0, 0, 0, 0, 0, 0));
+					     pmiID(60, 0, 60), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+					     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 
 				pmiAddMetric("kernel.all.cpu.guest_nice",
-					     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-					     pmiUnits(0, 0, 0, 0, 0, 0));
-			}
-
-			else if (a->id == A_PWR_CPU) {
-				/* Create metric for A_PWR_CPU */
-				pmiAddMetric("kernel.all.cpu.freqMHz",
-					     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-					     pmiUnits(0, 0, 0, 0, 0, 0));
+					     pmiID(60, 0, 81), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+					     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 			}
 
 			else if (a->id == A_NET_SOFT) {
 				/* Create metrics for a_NET_SOFT */
-				pmiAddMetric("network.all.soft.processed",
-					     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-					     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+				pmiAddMetric("network.softnet.processed",
+					     pmiID(60, 57, 0), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+					     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-				pmiAddMetric("network.all.soft.dropped",
-					     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-					     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+				pmiAddMetric("network.softnet.dropped",
+					     pmiID(60, 57, 1), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+					     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-				pmiAddMetric("network.all.soft.time_squeeze",
-					     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-					     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+				pmiAddMetric("network.softnet.time_squeeze",
+					     pmiID(60, 57, 2), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+					     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-				pmiAddMetric("network.all.soft.received_rps",
-					     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-					     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+				pmiAddMetric("network.softnet.received_rps",
+					     pmiID(60, 57, 4), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+					     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-				pmiAddMetric("network.all.soft.flow_limit",
-					     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
+				pmiAddMetric("network.softnet.flow_limit_count",
+					     pmiID(60, 57, 5), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
 					     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
 			}
 		}
@@ -135,7 +132,7 @@ void pcp_def_cpu_metrics(struct activity *a)
 			/* This is not CPU "all" */
 			if (indom == PM_INDOM_NULL) {
 				/* Create domain */
-				indom = pmInDom_build(0, PM_INDOM_CPU);
+				indom = pmInDom_build(60, 0);
 				create = TRUE;
 			}
 			if (create) {
@@ -148,74 +145,74 @@ void pcp_def_cpu_metrics(struct activity *a)
 				if (a->id == A_CPU) {
 					/* Create metrics for A_CPU */
 					pmiAddMetric("kernel.percpu.cpu.user",
-						     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-						     pmiUnits(0, 0, 0, 0, 0, 0));
+						     pmiID(60, 0, 0), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+						     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 
 					pmiAddMetric("kernel.percpu.cpu.nice",
-						     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-						     pmiUnits(0, 0, 0, 0, 0, 0));
+						     pmiID(60, 0, 1), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+						     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 
 					pmiAddMetric("kernel.percpu.cpu.sys",
-						     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-						     pmiUnits(0, 0, 0, 0, 0, 0));
+						     pmiID(60, 0, 2), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+						     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 
 					pmiAddMetric("kernel.percpu.cpu.idle",
-						     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-						     pmiUnits(0, 0, 0, 0, 0, 0));
+						     pmiID(60, 0, 3), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+						     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 
-					pmiAddMetric("kernel.percpu.cpu.iowait",
-						     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-						     pmiUnits(0, 0, 0, 0, 0, 0));
+					pmiAddMetric("kernel.percpu.cpu.wait.total",
+						     pmiID(60, 0, 30), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+						     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 
 					pmiAddMetric("kernel.percpu.cpu.steal",
-						     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-						     pmiUnits(0, 0, 0, 0, 0, 0));
+						     pmiID(60, 0, 58), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+						     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 
-					pmiAddMetric("kernel.percpu.cpu.hardirq",
-						     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-						     pmiUnits(0, 0, 0, 0, 0, 0));
+					pmiAddMetric("kernel.percpu.cpu.irq.hard",
+						     pmiID(60, 0, 57), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+						     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 
-					pmiAddMetric("kernel.percpu.cpu.softirq",
-						     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-						     pmiUnits(0, 0, 0, 0, 0, 0));
+					pmiAddMetric("kernel.percpu.cpu.irq.soft",
+						     pmiID(60, 0, 56), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+						     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 
 					pmiAddMetric("kernel.percpu.cpu.guest",
-						     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-						     pmiUnits(0, 0, 0, 0, 0, 0));
+						     pmiID(60, 0, 61), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+						     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 
 					pmiAddMetric("kernel.percpu.cpu.guest_nice",
-						     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-						     pmiUnits(0, 0, 0, 0, 0, 0));
+						     pmiID(60, 0, 83), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+						     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 				}
 
 				else if (a->id == A_PWR_CPU) {
 					/* Create metric for A_PWR_CPU */
-					pmiAddMetric("kernel.percpu.cpu.freqMHz",
-						     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-						     pmiUnits(0, 0, 0, 0, 0, 0));
+					pmiAddMetric("hinv.cpu.clock",
+						     pmiID(60, 18, 0), PM_TYPE_FLOAT, indom, PM_SEM_DISCRETE,
+						     pmiUnits(0, -1, 0, 0, PM_TIME_USEC, 0));
 				}
 
 				else if (a->id == A_NET_SOFT) {
 					/* Create metrics for a_NET_SOFT */
-					pmiAddMetric("network.percpu.soft.processed",
-						     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-						     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+					pmiAddMetric("network.softnet.percpu.processed",
+						     pmiID(60, 57, 6), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+						     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-					pmiAddMetric("network.percpu.soft.dropped",
-						     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-						     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+					pmiAddMetric("network.softnet.percpu.dropped",
+						     pmiID(60, 57, 7), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+						     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-					pmiAddMetric("network.percpu.soft.time_squeeze",
-						     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-						     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+					pmiAddMetric("network.softnet.percpu.time_squeeze",
+						     pmiID(60, 57, 8), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+						     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-					pmiAddMetric("network.percpu.soft.received_rps",
-						     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-						     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+					pmiAddMetric("network.softnet.percpu.received_rps",
+						     pmiID(60, 57, 10), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+						     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-					pmiAddMetric("network.percpu.soft.flow_limit",
-						     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-						     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+					pmiAddMetric("network.softnet.percpu.flow_limit_count",
+						     pmiID(60, 57, 11), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+						     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 				}
 				first = FALSE;
 			}
@@ -233,12 +230,12 @@ void pcp_def_pcsw_metrics(void)
 {
 #ifdef HAVE_PCP
 	pmiAddMetric("kernel.all.pswitch",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+		     pmiID(60, 0, 13), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("kernel.all.proc",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("kernel.all.nprocs",
+		     pmiID(60, 2, 3), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
+		     pmiUnits(0, 0, 0, 0, 0, 0));
 #endif /* HAVE_PCP */
 }
 
@@ -255,7 +252,7 @@ void pcp_def_irq_metrics(struct activity *a)
 #ifdef HAVE_PCP
 	int i, first = TRUE;
 	char buf[64];
-	pmInDom indom;
+	pmInDom indom = pmiInDom(60, 4);
 
 	for (i = 0; (i < a->nr_ini) && (i < a->bitmap->b_size + 1); i++) {
 
@@ -265,19 +262,17 @@ void pcp_def_irq_metrics(struct activity *a)
 			if (!i) {
 				/* Interrupt "sum" */
 				pmiAddMetric("kernel.all.intr",
-					     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-					     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+					     pmiID(60, 0, 12), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+					     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 			}
 			else {
 				if (first) {
-					indom = pmInDom_build(0, PM_INDOM_INT);
-
-					pmiAddMetric("kernel.all.int.count",
-						     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-						     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+					pmiAddMetric("kernel.all.interrupts.total",
+						     pmiID(60, 4, 0), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+						     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 					first = FALSE;
 				}
-				sprintf(buf, "int%d", i - 1);
+				sprintf(buf, "%d", i - 1);
 				pmiAddInstance(indom, buf, i - 1);
 			}
 		}
@@ -294,12 +289,12 @@ void pcp_def_swap_metrics(void)
 {
 #ifdef HAVE_PCP
 	pmiAddMetric("swap.pagesin",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+		     pmiID(60, 0, 8), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 	pmiAddMetric("swap.pagesout",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+		     pmiID(60, 0, 9), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
 
@@ -312,36 +307,36 @@ void pcp_def_paging_metrics(void)
 {
 #ifdef HAVE_PCP
 	pmiAddMetric("mem.vmstat.pgpgin",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+		     pmiID(60, 28, 6), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 	pmiAddMetric("mem.vmstat.pgpgout",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+		     pmiID(60, 28, 7), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 	pmiAddMetric("mem.vmstat.pgfault",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+		     pmiID(60, 28, 16), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 	pmiAddMetric("mem.vmstat.pgmajfault",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+		     pmiID(60, 28, 17), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 	pmiAddMetric("mem.vmstat.pgfree",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+		     pmiID(60, 28, 13), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("mem.vmstat.pgscank",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("mem.vmstat.pgscan_kswapd_total",
+		     pmiID(60, 28, 177), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("mem.vmstat.pgscand",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("mem.vmstat.pgscan_direct_total",
+		     pmiID(60, 28, 176), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("mem.vmstat.pgsteal",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("mem.vmstat.pgsteal_total",
+		     pmiID(60, 28, 178), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
 
@@ -354,32 +349,32 @@ void pcp_def_io_metrics(void)
 {
 #ifdef HAVE_PCP
 	pmiAddMetric("disk.all.total",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+		     pmiID(60, 0, 29), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 	pmiAddMetric("disk.all.read",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+		     pmiID(60, 0, 24), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 	pmiAddMetric("disk.all.write",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+		     pmiID(60, 0, 25), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 	pmiAddMetric("disk.all.discard",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+		     pmiID(60, 0, 96), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 	pmiAddMetric("disk.all.read_bytes",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(1, -1, 0, PM_SPACE_KBYTE, PM_TIME_SEC, 0));
+		     pmiID(60, 0, 41), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
 	pmiAddMetric("disk.all.write_bytes",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(1, -1, 0, PM_SPACE_KBYTE, PM_TIME_SEC, 0));
+		     pmiID(60, 0, 42), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
 	pmiAddMetric("disk.all.discard_bytes",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(1, -1, 0, PM_SPACE_KBYTE, PM_TIME_SEC, 0));
+		     pmiID(60, 0, 98), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 #endif /* HAVE_PCP */
 }
 
@@ -397,69 +392,61 @@ void pcp_def_memory_metrics(struct activity *a)
 	if (DISPLAY_MEMORY(a->opt_flags)) {
 
 		pmiAddMetric("mem.util.free",
-			     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+			     pmiID(60, 1, 2), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 			     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
 		pmiAddMetric("mem.util.available",
-			     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+			     pmiID(60, 1, 58), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 			     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
 		pmiAddMetric("mem.util.used",
-			     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+			     pmiID(60, 1, 1), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 			     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
-		pmiAddMetric("mem.util.used_pct",
-			     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-			     pmiUnits(0, 0, 0, 0, 0, 0));
-
-		pmiAddMetric("mem.util.buffers",
-			     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+		pmiAddMetric("mem.util.bufmem",
+			     pmiID(60, 1, 4), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 			     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
 		pmiAddMetric("mem.util.cached",
-			     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+			     pmiID(60, 1, 5), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 			     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
-		pmiAddMetric("mem.util.commit",
-			     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+		pmiAddMetric("mem.util.committed_AS",
+			     pmiID(60, 1, 26), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 			     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
-
-		pmiAddMetric("mem.util.commit_pct",
-			     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-			     pmiUnits(0, 0, 0, 0, 0, 0));
 
 		pmiAddMetric("mem.util.active",
-			     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+			     pmiID(60, 1, 14), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 			     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
 		pmiAddMetric("mem.util.inactive",
-			     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+			     pmiID(60, 1, 15), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 			     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
 		pmiAddMetric("mem.util.dirty",
-			     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+			     pmiID(60, 1, 22), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 			     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
 		if (DISPLAY_MEM_ALL(a->opt_flags)) {
 
 			pmiAddMetric("mem.util.anonpages",
-				     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+				     pmiID(60, 1, 30), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 				     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
 			pmiAddMetric("mem.util.slab",
-				     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+				     pmiID(60, 1, 25), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 				     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
-			pmiAddMetric("mem.util.stack",
-				     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+			pmiAddMetric("mem.util.kernelStack",
+				     pmiID(60, 1, 43), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 				     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
 			pmiAddMetric("mem.util.pageTables",
-				     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+				     pmiID(60, 1, 27), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 				     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
-			pmiAddMetric("mem.util.vmused",
-				     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+			pmiAddMetric("mem.util.vmallocUsed",
+				     pmiID(60, 1, 51), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 				     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 		}
 	}
@@ -467,24 +454,16 @@ void pcp_def_memory_metrics(struct activity *a)
 	if (DISPLAY_SWAP(a->opt_flags)) {
 
 		pmiAddMetric("mem.util.swapFree",
-			     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+			     pmiID(60, 1, 21), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 			     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
-		pmiAddMetric("mem.util.swapUsed",
-			     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+		pmiAddMetric("mem.util.swapTotal",
+			     pmiID(60, 1, 20), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 			     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
-
-		pmiAddMetric("mem.util.swapUsed_pct",
-			     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-			     pmiUnits(0, 0, 0, 0, 0, 0));
 
 		pmiAddMetric("mem.util.swapCached",
-			     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+			     pmiID(60, 1, 13), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 			     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
-
-		pmiAddMetric("mem.util.swapCached_pct",
-			     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-			     pmiUnits(0, 0, 0, 0, 0, 0));
 	}
 #endif /* HAVE_PCP */
 }
@@ -498,19 +477,19 @@ void pcp_def_ktables_metrics(void)
 {
 #ifdef HAVE_PCP
 	pmiAddMetric("vfs.dentry.count",
-		     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
+		     pmiID(60, 27, 5), PM_TYPE_32, PM_INDOM_NULL, PM_SEM_INSTANT,
+		     pmiUnits(0, 0, 0, 0, 0, 0));
 
 	pmiAddMetric("vfs.files.count",
-		     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
+		     pmiID(60, 27, 0), PM_TYPE_32, PM_INDOM_NULL, PM_SEM_INSTANT,
+		     pmiUnits(0, 0, 0, 0, 0, 0));
 
 	pmiAddMetric("vfs.inodes.count",
-		     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
+		     pmiID(60, 27, 3), PM_TYPE_32, PM_INDOM_NULL, PM_SEM_INSTANT,
+		     pmiUnits(0, 0, 0, 0, 0, 0));
 
-	pmiAddMetric("kernel.all.pty",
-		     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+	pmiAddMetric("kernel.all.nptys",
+		     pmiID(60, 72, 3), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
@@ -525,25 +504,25 @@ void pcp_def_queue_metrics(void)
 #ifdef HAVE_PCP
 	pmInDom indom;
 
-	pmiAddMetric("proc.runq.runnable",
-		     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
-
-	pmiAddMetric("proc.nprocs",
-		     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
-
-	pmiAddMetric("proc.blocked",
-		     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
-
-	indom = pmInDom_build(0, PM_INDOM_QUEUE);
-	pmiAddMetric("kernel.all.load",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
+	pmiAddMetric("kernel.all.runnable",
+		     pmiID(60, 2, 2), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 0, 0, 0, 0));
-	pmiAddInstance(indom, "1 min", 0);
-	pmiAddInstance(indom, "5 min", 1);
-	pmiAddInstance(indom, "15 min", 2);
+
+	pmiAddMetric("kernel.all.nprocs",
+		     pmiID(60, 2, 3), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
+
+	pmiAddMetric("kernel.all.blocked",
+		     pmiID(60, 0, 16), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+		     pmiUnits(0, 0, 0, 0, 0, 0));
+
+	indom = pmiInDom(60, 2);
+	pmiAddMetric("kernel.all.load",
+		     pmiID(60, 2, 0), PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
+		     pmiUnits(0, 0, 0, 0, 0, 0));
+	pmiAddInstance(indom, "1 minute", 1);
+	pmiAddInstance(indom, "5 minute", 5);
+	pmiAddInstance(indom, "15 minute", 15);
 #endif /* HAVE_PCP */
 }
 
@@ -564,7 +543,7 @@ void pcp_def_disk_metrics(struct activity *a)
 
 	if (indom == PM_INDOM_NULL) {
 		/* Create domain */
-		indom = pmInDom_build(0, PM_INDOM_DISK);
+		indom = pmInDom_build(60, 1);
 
 		/* Create instances */
 		while (list != NULL) {
@@ -573,37 +552,53 @@ void pcp_def_disk_metrics(struct activity *a)
 		}
 	}
 
-	pmiAddMetric("disk.device.tps",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("disk.dev.read",
+		     pmiID(60, 0, 4), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("disk.device.read_bytes",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(1, -1, 0, PM_SPACE_KBYTE, PM_TIME_SEC, 0));
+	pmiAddMetric("disk.dev.write",
+		     pmiID(60, 0, 5), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("disk.device.write_bytes",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(1, -1, 0, PM_SPACE_KBYTE, PM_TIME_SEC, 0));
+	pmiAddMetric("disk.dev.total",
+		     pmiID(60, 0, 28), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("disk.device.discard_bytes",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(1, -1, 0, PM_SPACE_KBYTE, PM_TIME_SEC, 0));
-
-	pmiAddMetric("disk.device.areq_sz",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
+	pmiAddMetric("disk.dev.read_bytes",
+		     pmiID(60, 0, 38), PM_TYPE_U64, indom, PM_SEM_COUNTER,
 		     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
-	pmiAddMetric("disk.device.aqu_sz",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(0, 0, 0, 0, 0, 0));
+	pmiAddMetric("disk.dev.write_bytes",
+		     pmiID(60, 0, 39), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+		     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
-	pmiAddMetric("disk.device.await",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(0, 0, 0, 0, 0, 0));
+	pmiAddMetric("disk.dev.discard_bytes",
+		     pmiID(60, 0, 90), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+		     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
-	pmiAddMetric("disk.device.util",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(0, 0, 0, 0, 0, 0));
+	pmiAddMetric("disk.dev.read_rawactive",
+		     pmiID(60, 0, 72), PM_TYPE_U32, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
+
+	pmiAddMetric("disk.dev.write_rawactive",
+		     pmiID(60, 0, 73), PM_TYPE_U32, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
+
+	pmiAddMetric("disk.dev.total_rawactive",
+		     pmiID(60, 0, 79), PM_TYPE_U32, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
+
+	pmiAddMetric("disk.dev.discard_rawactive",
+		     pmiID(60, 0, 92), PM_TYPE_U32, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
+
+	pmiAddMetric("disk.dev.avactive",
+		     pmiID(60, 0, 46), PM_TYPE_U32, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
+
+	pmiAddMetric("disk.dev.aveq",
+		     pmiID(60, 0, 47), PM_TYPE_U32, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 1, 0, 0, PM_TIME_MSEC, 0));
 #endif /* HAVE_PCP */
 }
 
@@ -624,7 +619,7 @@ void pcp_def_net_dev_metrics(struct activity *a)
 
 	if (indom == PM_INDOM_NULL) {
 		/* Create domain */
-		indom = pmInDom_build(0, PM_INDOM_NET_DEV);
+		indom = pmInDom_build(60, 3);
 
 		/* Create instances */
 		while (list != NULL) {
@@ -636,74 +631,82 @@ void pcp_def_net_dev_metrics(struct activity *a)
 	if (a->id == A_NET_DEV) {
 		/* Create metrics for A_NET_DEV */
 		pmiAddMetric("network.interface.in.packets",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+			     pmiID(60, 3, 1), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 		pmiAddMetric("network.interface.out.packets",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+			     pmiID(60, 3, 9), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 		pmiAddMetric("network.interface.in.bytes",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(1, -1, 0, PM_SPACE_KBYTE, PM_TIME_SEC, 0));
+			     pmiID(60, 3, 0), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(1, 0, 0, PM_SPACE_BYTE, 0, 0));
 
 		pmiAddMetric("network.interface.out.bytes",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(1, -1, 0, PM_SPACE_KBYTE, PM_TIME_SEC, 0));
+			     pmiID(60, 3, 8), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(1, 0, 0, PM_SPACE_BYTE, 0, 0));
 
 		pmiAddMetric("network.interface.in.compressed",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+			     pmiID(60, 3, 6), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 		pmiAddMetric("network.interface.out.compressed",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+			     pmiID(60, 3, 15), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-		pmiAddMetric("network.interface.in.multicast",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+		pmiAddMetric("network.interface.in.mcasts",
+			     pmiID(60, 3, 7), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-		pmiAddMetric("network.interface.util",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
+		pmiAddMetric("network.interface.speed",
+			     pmiID(60, 3, 22), PM_TYPE_FLOAT, indom, PM_SEM_DISCRETE,
+			     pmiUnits(1, -1, 0, PM_SPACE_MBYTE, PM_TIME_SEC, 0));
+
+		pmiAddMetric("network.interface.baudrate",
+			     pmiID(60, 3, 23), PM_TYPE_U64, indom, PM_SEM_DISCRETE,
+			     pmiUnits(1, -1, 0, PM_SPACE_BYTE, PM_TIME_SEC, 0));
+
+		pmiAddMetric("network.interface.duplex",
+			     pmiID(60, 3, 24), PM_TYPE_U32, indom, PM_SEM_DISCRETE,
 			     pmiUnits(0, 0, 0, 0, 0, 0));
 	}
 	else {
 		/* Create metrics for A_NET_EDEV */
 		pmiAddMetric("network.interface.in.errors",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+			     pmiID(60, 3, 2), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 		pmiAddMetric("network.interface.out.errors",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+			     pmiID(60, 3, 10), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-		pmiAddMetric("network.interface.out.collisions",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+		pmiAddMetric("network.interface.collisions",
+			     pmiID(60, 3, 13), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 		pmiAddMetric("network.interface.in.drops",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+			     pmiID(60, 3, 3), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 		pmiAddMetric("network.interface.out.drops",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+			     pmiID(60, 3, 11), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 		pmiAddMetric("network.interface.out.carrier",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+			     pmiID(60, 3, 14), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 		pmiAddMetric("network.interface.in.frame",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+			     pmiID(60, 3, 5), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 		pmiAddMetric("network.interface.in.fifo",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+			     pmiID(60, 3, 4), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
 		pmiAddMetric("network.interface.out.fifo",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+			     pmiID(60, 3, 12), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 	}
 #endif /* HAVE_PCP */
 }
@@ -724,32 +727,32 @@ void pcp_def_serial_metrics(struct activity *a)
 	char buf[64];
 
 	/* Create domain */
-	indom = pmInDom_build(0, PM_INDOM_SERIAL);
+	indom = pmInDom_build(60, 35);
 
 	/* Create metrics */
-	pmiAddMetric("serial.in.interrupts",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("tty.serial.rx",
+		     pmiID(60, 74, 0), PM_TYPE_U32, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 0, 0, 0, 0));
 
-	pmiAddMetric("serial.out.interrupts",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("tty.serial.tx",
+		     pmiID(60, 74, 1), PM_TYPE_U32, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 0, 0, 0, 0));
 
-	pmiAddMetric("serial.frame",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("tty.serial.frame",
+		     pmiID(60, 74, 2), PM_TYPE_U32, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 0, 0, 0, 0));
 
-	pmiAddMetric("serial.parity",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("tty.serial.parity",
+		     pmiID(60, 74, 3), PM_TYPE_U32, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 0, 0, 0, 0));
 
-	pmiAddMetric("serial.breaks",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("tty.serial.brk",
+		     pmiID(60, 74, 4), PM_TYPE_U32, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 0, 0, 0, 0));
 
-	pmiAddMetric("serial.overrun",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("tty.serial.overrun",
+		     pmiID(60, 74, 5), PM_TYPE_U32, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 0, 0, 0, 0));
 
 	for (i = 0; i < a->nr_ini; i++) {
 		/* Create instances */
@@ -767,29 +770,25 @@ void pcp_def_serial_metrics(struct activity *a)
 void pcp_def_net_nfs_metrics(void)
 {
 #ifdef HAVE_PCP
-	pmiAddMetric("network.fs.client.call",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmInDom indom;
 
-	pmiAddMetric("network.fs.client.retrans",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("rpc.client.rpccnt",
+		     pmiID(60, 7, 20), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.fs.client.read",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("rpc.client.rpcretrans",
+		     pmiID(60, 7, 21), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.fs.client.write",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	indom = pmiInDom(60, 7);
+	pmiAddInstance(indom, "read", 6);
+	pmiAddInstance(indom, "write", 8);
+	pmiAddInstance(indom, "access", 18);
+	pmiAddInstance(indom, "lookup", 4);
 
-	pmiAddMetric("network.fs.client.access",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
-
-	pmiAddMetric("network.fs.client.getattr",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("nfs.client.reqs",
+		     pmiID(60, 7, 4), PM_TYPE_U32, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
 
@@ -801,50 +800,46 @@ void pcp_def_net_nfs_metrics(void)
 void pcp_def_net_nfsd_metrics(void)
 {
 #ifdef HAVE_PCP
-	pmiAddMetric("network.fs.server.call",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmInDom indom;
 
-	pmiAddMetric("network.fs.server.badcall",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("rpc.server.rpccnt",
+		     pmiID(60, 7, 30), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.fs.server.packets",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("rpc.server.rpcbadclnt",
+		     pmiID(60, 7, 34), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.fs.server.udp",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("rpc.server.netcnt",
+		     pmiID(60, 7, 44), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.fs.server.tcp",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("rpc.server.netudpcnt",
+		     pmiID(60, 7, 45), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.fs.server.hits",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("rpc.server.nettcpcnt",
+		     pmiID(60, 7, 46), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.fs.server.misses",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("rpc.server.rchits",
+		     pmiID(60, 7, 35), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.fs.server.read",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("rpc.server.rcmisses",
+		     pmiID(60, 7, 36), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.fs.server.write",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	indom = pmiInDom(60, 7);
+	pmiAddInstance(indom, "read", 6);
+	pmiAddInstance(indom, "write", 8);
+	pmiAddInstance(indom, "access", 18);
+	pmiAddInstance(indom, "lookup", 4);
 
-	pmiAddMetric("network.fs.server.access",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
-
-	pmiAddMetric("network.fs.server.gettattr",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
-#endif /* HAVE_PCP */
+	pmiAddMetric("nfs.server.reqs",
+		     pmiID(60, 7, 12), PM_TYPE_U32, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
+#endif
 }
 
 /*
@@ -855,28 +850,28 @@ void pcp_def_net_nfsd_metrics(void)
 void pcp_def_net_sock_metrics(void)
 {
 #ifdef HAVE_PCP
-	pmiAddMetric("network.socket.sock_inuse",
-		     PM_IN_NULL, PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
+	pmiAddMetric("network.sockstat.total",
+		     pmiID(60, 11, 9), PM_TYPE_32, PM_INDOM_NULL, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.socket.tcp_inuse",
-		     PM_IN_NULL, PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
+	pmiAddMetric("network.sockstat.tcp.inuse",
+		     pmiID(60, 11, 0), PM_TYPE_32, PM_INDOM_NULL, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.socket.udp_inuse",
-		     PM_IN_NULL, PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
+	pmiAddMetric("network.sockstat.udp.inuse",
+		     pmiID(60, 11, 3), PM_TYPE_32, PM_INDOM_NULL, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.socket.raw_inuse",
-		     PM_IN_NULL, PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
+	pmiAddMetric("network.sockstat.raw.inuse",
+		     pmiID(60, 11, 6), PM_TYPE_32, PM_INDOM_NULL, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.socket.frag_inuse",
-		     PM_IN_NULL, PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
+	pmiAddMetric("network.sockstat.frag.inuse",
+		     pmiID(60, 11, 15), PM_TYPE_32, PM_INDOM_NULL, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.socket.tcp_tw",
-		     PM_IN_NULL, PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
+	pmiAddMetric("network.sockstat.tcp.tw",
+		     pmiID(60, 11, 11), PM_TYPE_32, PM_INDOM_NULL, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
@@ -889,37 +884,37 @@ void pcp_def_net_sock_metrics(void)
 void pcp_def_net_ip_metrics(void)
 {
 #ifdef HAVE_PCP
-	pmiAddMetric("network.snmp.ip.ipInReceives",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip.inreceives",
+		     pmiID(60, 14, 2), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip.ipForwDatagrams",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip.forwdatagrams",
+		     pmiID(60, 14, 5), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip.ipInDelivers",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip.indelivers",
+		     pmiID(60, 14, 8), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip.ipOutRequests",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip.ipoutrequests",
+		     pmiID(60, 14, 9), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip.ipReasmReqds",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip.ipreasmreqds",
+		     pmiID(60, 14, 13), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip.ipReasmOKs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip.ipreasmoks",
+		     pmiID(60, 14, 14), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip.ipFragOKs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip.fragoks",
+		     pmiID(60, 14, 16), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip.ipFragCreates",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip.fragcreates",
+		     pmiID(60, 14, 18), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
 
@@ -931,37 +926,37 @@ void pcp_def_net_ip_metrics(void)
 void pcp_def_net_eip_metrics(void)
 {
 #ifdef HAVE_PCP
-	pmiAddMetric("network.snmp.ip.ipInHdrErrors",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip.inhdrerrors",
+		     pmiID(60, 14, 3), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip.ipInAddrErrors",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip.inaddrerrors",
+		     pmiID(60, 14, 4), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip.ipInUnknownProtos",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip.inunknownprotos",
+		     pmiID(60, 14, 6), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip.ipInDiscards",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip.indiscards",
+		     pmiID(60, 14, 7), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip.ipOutDiscards",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip.outdiscards",
+		     pmiID(60, 14, 10), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip.ipOutNoRoutes",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip.outnoroutes",
+		     pmiID(60, 14, 11), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip.ipReasmFails",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip.reasmfails",
+		     pmiID(60, 14, 15), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip.ipFragFails",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip.fragfails",
+		     pmiID(60, 14, 17), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
 
@@ -973,61 +968,61 @@ void pcp_def_net_eip_metrics(void)
 void pcp_def_net_icmp_metrics(void)
 {
 #ifdef HAVE_PCP
-	pmiAddMetric("network.snmp.icmp.icmpInMsgs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.inmsgs",
+		     pmiID(60, 14, 20), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpOutMsgs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.outmsgs",
+		     pmiID(60, 14, 33), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpInEchos",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.inechos",
+		     pmiID(60, 14, 27), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpInEchoReps",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.inechoreps",
+		     pmiID(60, 14, 28), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpOutEchos",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.outechos",
+		     pmiID(60, 14, 40), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpOutEchoReps",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.outechoreps",
+		     pmiID(60, 14, 41), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpInTimestamps",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.intimestamps",
+		     pmiID(60, 14, 29), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpInTimestampReps",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.intimestampreps",
+		     pmiID(60, 14, 30), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpOutTimestamps",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.outtimestamps",
+		     pmiID(60, 14, 42), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpOutTimestampReps",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.outtimestampreps",
+		     pmiID(60, 14, 43), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpInAddrMasks",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.inaddrmasks",
+		     pmiID(60, 14, 31), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpInAddrMaskReps",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.inaddrmaskreps",
+		     pmiID(60, 14, 32), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpOutAddrMasks",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.outaddrmasks",
+		     pmiID(60, 14, 44), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpOutAddrMaskReps",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.outaddrmaskreps",
+		     pmiID(60, 14, 45), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
 
@@ -1039,53 +1034,53 @@ void pcp_def_net_icmp_metrics(void)
 void pcp_def_net_eicmp_metrics(void)
 {
 #ifdef HAVE_PCP
-	pmiAddMetric("network.snmp.icmp.icmpInErrors",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.inerrors",
+		     pmiID(60, 14, 21), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpOutErrors",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.outerrors",
+		     pmiID(60, 14, 34), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpInDestUnreachs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.indestunreachs",
+		     pmiID(60, 14, 22), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpOutDestUnreachs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.outdestunreachs",
+		     pmiID(60, 14, 35), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpInTimeExcds",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.intimeexcds",
+		     pmiID(60, 14, 23), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpOutTimeExcds",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.outtimeexcds",
+		     pmiID(60, 14, 36), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpInParmProbs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.inparmprobs",
+		     pmiID(60, 14, 24), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpOutParmProbs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.outparmprobs",
+		     pmiID(60, 14, 37), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpInSrcQuenchs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.insrcquenchs",
+		     pmiID(60, 14, 25), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpOutSrcQuenchs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.outsrcquenchs",
+		     pmiID(60, 14, 38), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpInRedirects",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.inredirects",
+		     pmiID(60, 14, 27), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp.icmpOutRedirects",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp.outredirects",
+		     pmiID(60, 14, 39), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
 
@@ -1097,21 +1092,21 @@ void pcp_def_net_eicmp_metrics(void)
 void pcp_def_net_tcp_metrics(void)
 {
 #ifdef HAVE_PCP
-	pmiAddMetric("network.snmp.tcp.tcpActiveOpens",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.tcp.activeopens",
+		     pmiID(60, 14, 54), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.tcp.tcpPassiveOpens",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.tcp.passiveopens",
+		     pmiID(60, 14, 55), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.tcp.tcpInSegs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.tcp.insegs",
+		     pmiID(60, 14, 59), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.tcp.tcpOutSegs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.tcp.outsegs",
+		     pmiID(60, 14, 60), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
 
@@ -1123,25 +1118,25 @@ void pcp_def_net_tcp_metrics(void)
 void pcp_def_net_etcp_metrics(void)
 {
 #ifdef HAVE_PCP
-	pmiAddMetric("network.snmp.tcp.tcpAttemptFails",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.tcp.attemptfails",
+		     pmiID(60, 14, 56), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.tcp.tcpEstabResets",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.tcp.estabresets",
+		     pmiID(60, 14, 57), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.tcp.tcpRetransSegs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.tcp.retranssegs",
+		     pmiID(60, 14, 61), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.tcp.tcpInErrs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.tcp.inerrs",
+		     pmiID(60, 14, 62), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.tcp.tcpOutRsts",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.tcp.outrsts",
+		     pmiID(60, 14, 63), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
 
@@ -1153,21 +1148,21 @@ void pcp_def_net_etcp_metrics(void)
 void pcp_def_net_udp_metrics(void)
 {
 #ifdef HAVE_PCP
-	pmiAddMetric("network.snmp.udp.udpInDatagrams",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.udp.indatagrams",
+		     pmiID(60, 14, 70), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.udp.udpOutDatagrams",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.udp.outdatagrams",
+		     pmiID(60, 14, 74), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.udp.udpNoPorts",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.udp.noports",
+		     pmiID(60, 14, 71), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.udp.udpInErrors",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.udp.inerrors",
+		     pmiID(60, 14, 72), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
 
@@ -1179,20 +1174,20 @@ void pcp_def_net_udp_metrics(void)
 void pcp_def_net_sock6_metrics(void)
 {
 #ifdef HAVE_PCP
-	pmiAddMetric("network.socket6.tcp6_inuse",
-		     PM_IN_NULL, PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
+	pmiAddMetric("network.sockstat.tcp6.inuse",
+		     pmiID(60, 73, 0), PM_TYPE_32, PM_INDOM_NULL, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.socket6.udp6_inuse",
-		     PM_IN_NULL, PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
+	pmiAddMetric("network.sockstat.udp6.inuse",
+		     pmiID(60, 73, 1), PM_TYPE_32, PM_INDOM_NULL, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.socket6.raw6_inuse",
-		     PM_IN_NULL, PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
+	pmiAddMetric("network.sockstat.raw6.inuse",
+		     pmiID(60, 73, 3), PM_TYPE_32, PM_INDOM_NULL, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.socket6.frag6_inuse",
-		     PM_IN_NULL, PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
+	pmiAddMetric("network.sockstat.frag6.inuse",
+		     pmiID(60, 73, 4), PM_TYPE_32, PM_INDOM_NULL, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
@@ -1205,45 +1200,45 @@ void pcp_def_net_sock6_metrics(void)
 void pcp_def_net_ip6_metrics(void)
 {
 #ifdef HAVE_PCP
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsInReceives",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.inreceives",
+		     pmiID(60, 58, 0), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsOutForwDatagrams",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.outforwdatagrams",
+		     pmiID(60, 58, 9), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsInDelivers",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.indelivers",
+		     pmiID(60, 58, 8), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsOutRequests",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.outrequests",
+		     pmiID(60, 58, 10), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsReasmReqds",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.reasmreqds",
+		     pmiID(60, 58, 14), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsReasmOKs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.reasmoks",
+		     pmiID(60, 58, 15), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsInMcastPkts",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.inmcastpkts",
+		     pmiID(60, 58, 20), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsOutMcastPkts",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.outmcastpkts",
+		     pmiID(60, 58, 21), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsOutFragOKs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.fragoks",
+		     pmiID(60, 58, 17), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsOutFragCreates",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.fragcreates",
+		     pmiID(60, 58, 19), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
 
@@ -1255,49 +1250,49 @@ void pcp_def_net_ip6_metrics(void)
 void pcp_def_net_eip6_metrics(void)
 {
 #ifdef HAVE_PCP
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsInHdrErrors",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.inhdrerrors",
+		     pmiID(60, 58, 1), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsInAddrErrors",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.inaddrerrors",
+		     pmiID(60, 58, 4), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsInUnknownProtos",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.inunknownprotos",
+		     pmiID(60, 58, 5), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsInTooBigErrors",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.intoobigerrors",
+		     pmiID(60, 58, 2), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsInDiscards",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.indiscards",
+		     pmiID(60, 58, 7), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsOutDiscards",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.outdiscards",
+		     pmiID(60, 58, 11), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsInNoRoutes",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.innoroutes",
+		     pmiID(60, 58, 3), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsOutNoRoutes",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.outnoroutes",
+		     pmiID(60, 58, 12), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsReasmFails",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.reasmfails",
+		     pmiID(60, 58, 16), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsOutFragFails",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.fragfails",
+		     pmiID(60, 58, 18), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.ip6.ipv6IfStatsInTruncatedPkts",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.ip6.intruncatedpkts",
+		     pmiID(60, 58, 6), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
 
@@ -1309,73 +1304,73 @@ void pcp_def_net_eip6_metrics(void)
 void pcp_def_net_icmp6_metrics(void)
 {
 #ifdef HAVE_PCP
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpInMsgs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.inmsgs",
+		     pmiID(60, 58, 32), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpOutMsgs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.outmsgs",
+		     pmiID(60, 58, 34), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpInEchos",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.inechos",
+		     pmiID(60, 58, 41), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpInEchoReplies",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.inechoreplies",
+		     pmiID(60, 58, 42), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpOutEchoReplies",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.outechoreplies",
+		     pmiID(60, 58, 57), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpInGroupMembQueries",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.ingroupmembqueries",
+		     pmiID(60, 58, 43), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpInGroupMembResponses",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.ingroupmembresponses",
+		     pmiID(60, 58, 44), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpOutGroupMembResponses",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.outgroupmembresponses",
+		     pmiID(60, 58, 59), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpInGroupMembReductions",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.ingroupmembreductions",
+		     pmiID(60, 58, 45), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpOutGroupMembReductions",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.outgroupmembreductions",
+		     pmiID(60, 58, 60), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpInRouterSolicits",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.inroutersolicits",
+		     pmiID(60, 58, 46), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpOutRouterSolicits",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.outroutersolicits",
+		     pmiID(60, 58, 61), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpInRouterAdvertisements",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.inrouteradvertisements",
+		     pmiID(60, 58, 47), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpInNeighborSolicits",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.inneighborsolicits",
+		     pmiID(60, 58, 48), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpOutNeighborSolicits",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.outneighborsolicits",
+		     pmiID(60, 58, 63), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpInNeighborAdvertisements",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.inneighboradvertisements",
+		     pmiID(60, 58, 49), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpOutNeighborAdvertisements",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.outneighboradvertisements",
+		     pmiID(60, 58, 64), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
 
@@ -1387,49 +1382,49 @@ void pcp_def_net_icmp6_metrics(void)
 void pcp_def_net_eicmp6_metrics(void)
 {
 #ifdef HAVE_PCP
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpInErrors",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.inerrors",
+		     pmiID(60, 58, 33), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpInDestUnreachs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.indestunreachs",
+		     pmiID(60, 58, 37), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpOutDestUnreachs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.outdestunreachs",
+		     pmiID(60, 58, 52), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpInTimeExcds",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.intimeexcds",
+		     pmiID(60, 58, 39), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpOutTimeExcds",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.outtimeexcds",
+		     pmiID(60, 58, 54), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpInParmProblems",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.inparmproblems",
+		     pmiID(60, 58, 40), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpOutParmProblems",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.outparmproblems",
+		     pmiID(60, 58, 55), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpInRedirects",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.inredirects",
+		     pmiID(60, 58, 50), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpOutRedirects",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.outredirects",
+		     pmiID(60, 58, 65), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpInPktTooBigs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.inpkttoobigs",
+		     pmiID(60, 58, 38), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.icmp6.ipv6IfIcmpOutPktTooBigs",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.icmp6.outpkttoobigs",
+		     pmiID(60, 58, 53), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
 
@@ -1441,21 +1436,21 @@ void pcp_def_net_eicmp6_metrics(void)
 void pcp_def_net_udp6_metrics(void)
 {
 #ifdef HAVE_PCP
-	pmiAddMetric("network.snmp.udp6.udpInDatagrams",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.udp6.indatagrams",
+		     pmiID(60, 58, 67), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.udp6.udpOutDatagrams",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.udp6.outdatagrams",
+		     pmiID(60, 58, 70), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.udp6.udpNoPorts",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.udp6.noports",
+		     pmiID(60, 58, 68), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.snmp.udp6.udpInErrors",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("network.udp6.inerrors",
+		     pmiID(60, 58, 69), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 #endif /* HAVE_PCP */
 }
 
@@ -1467,25 +1462,21 @@ void pcp_def_net_udp6_metrics(void)
 void pcp_def_huge_metrics()
 {
 #ifdef HAVE_PCP
-	pmiAddMetric("mem.huge.free",
-		     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
+	pmiAddMetric("mem.util.hugepagesTotalBytes",
+		     pmiID(60, 1, 60), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+		     pmiUnits(1, 0, 0, PM_SPACE_BYTE, 0, 0));
 
-	pmiAddMetric("mem.huge.used",
-		     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
+	pmiAddMetric("mem.util.hugepagesFreeBytes",
+		     pmiID(60, 1, 61), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+		     pmiUnits(1, 0, 0, PM_SPACE_BYTE, 0, 0));
 
-	pmiAddMetric("mem.huge.used_pct",
-		     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(0, 0, 0, 0, 0, 0));
+	pmiAddMetric("mem.util.hugepagesRsvdBytes",
+		     pmiID(60, 1, 62), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+		     pmiUnits(1, 0, 0, PM_SPACE_BYTE, 0, 0));
 
-	pmiAddMetric("mem.huge.reserved",
-		     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
-
-	pmiAddMetric("mem.huge.surplus",
-		     PM_IN_NULL, PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
-		     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
+	pmiAddMetric("mem.util.hugepagesSurpBytes",
+		     pmiID(60, 1, 63), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
+		     pmiUnits(1, 0, 0, PM_SPACE_BYTE, 0, 0));
 #endif /* HAVE_PCP */
 }
 
@@ -1506,7 +1497,7 @@ void pcp_def_pwr_fan_metrics(struct activity *a)
 
 	if (indom == PM_INDOM_NULL) {
 		/* Create domain */
-		indom = pmInDom_build(0, PM_INDOM_FAN);
+		indom = pmInDom_build(34, 0);
 
 		for (inst = 0; inst < a->item_list_sz; inst++) {
 			sprintf(buf, "fan%d", inst + 1);
@@ -1515,15 +1506,15 @@ void pcp_def_pwr_fan_metrics(struct activity *a)
 	}
 
 	pmiAddMetric("power.fan.rpm",
-		     PM_IN_NULL, PM_TYPE_U64, indom, PM_SEM_INSTANT,
+		     pmiID(34, 0, 0), PM_TYPE_U64, indom, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 0, 0, 0, 0));
 
 	pmiAddMetric("power.fan.drpm",
-		     PM_IN_NULL, PM_TYPE_U64, indom, PM_SEM_INSTANT,
+		     pmiID(34, 0, 1), PM_TYPE_U64, indom, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 0, 0, 0, 0));
 
 	pmiAddMetric("power.fan.device",
-		     PM_IN_NULL, PM_TYPE_STRING, indom, PM_SEM_DISCRETE,
+		     pmiID(34, 0, 2), PM_TYPE_STRING, indom, PM_SEM_DISCRETE,
 		     pmiUnits(0, 0, 0, 0, 0, 0));
 #endif /* HAVE_PCP */
 }
@@ -1545,7 +1536,7 @@ void pcp_def_pwr_temp_metrics(struct activity *a)
 
 	if (indom == PM_INDOM_NULL) {
 		/* Create domain */
-		indom = pmInDom_build(0, PM_INDOM_TEMP);
+		indom = pmInDom_build(34, 1);
 
 		for (inst = 0; inst < a->item_list_sz; inst++) {
 			sprintf(buf, "temp%d", inst + 1);
@@ -1553,16 +1544,16 @@ void pcp_def_pwr_temp_metrics(struct activity *a)
 		}
 	}
 
-	pmiAddMetric("power.temp.degC",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
+	pmiAddMetric("power.temp.celcius",
+		     pmiID(34, 1, 0), PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 0, 0, 0, 0));
 
-	pmiAddMetric("power.temp.temp_pct",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
+	pmiAddMetric("power.temp.percent",
+		     pmiID(34, 1, 1), PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 0, 0, 0, 0));
 
 	pmiAddMetric("power.temp.device",
-		     PM_IN_NULL, PM_TYPE_STRING, indom, PM_SEM_DISCRETE,
+		     pmiID(34, 1, 2), PM_TYPE_STRING, indom, PM_SEM_DISCRETE,
 		     pmiUnits(0, 0, 0, 0, 0, 0));
 #endif /* HAVE_PCP */
 }
@@ -1584,7 +1575,7 @@ void pcp_def_pwr_in_metrics(struct activity *a)
 
 	if (indom == PM_INDOM_NULL) {
 		/* Create domain */
-		indom = pmInDom_build(0, PM_INDOM_IN);
+		indom = pmInDom_build(34, 2);
 
 		for (inst = 0; inst < a->item_list_sz; inst++) {
 			sprintf(buf, "in%d", inst);
@@ -1592,16 +1583,16 @@ void pcp_def_pwr_in_metrics(struct activity *a)
 		}
 	}
 
-	pmiAddMetric("power.in.inV",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
+	pmiAddMetric("power.in.voltage",
+		     pmiID(34, 2, 0), PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 0, 0, 0, 0));
 
-	pmiAddMetric("power.in.in_pct",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
+	pmiAddMetric("power.in.percent",
+		     pmiID(34, 2, 1), PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 0, 0, 0, 0));
 
 	pmiAddMetric("power.in.device",
-		     PM_IN_NULL, PM_TYPE_STRING, indom, PM_SEM_DISCRETE,
+		     pmiID(34, 2, 2), PM_TYPE_STRING, indom, PM_SEM_DISCRETE,
 		     pmiUnits(0, 0, 0, 0, 0, 0));
 #endif /* HAVE_PCP */
 }
@@ -1623,7 +1614,7 @@ void pcp_def_pwr_usb_metrics(struct activity *a)
 
 	if (indom == PM_INDOM_NULL) {
 		/* Create domain */
-		indom = pmInDom_build(0, PM_INDOM_USB);
+		indom = pmInDom_build(34, 3);
 
 		for (inst = 0; inst < a->item_list_sz; inst++) {
 			sprintf(buf, "usb%d", inst);
@@ -1632,27 +1623,27 @@ void pcp_def_pwr_usb_metrics(struct activity *a)
 	}
 
 	pmiAddMetric("power.usb.bus",
-		     PM_IN_NULL, PM_TYPE_U32, indom, PM_SEM_DISCRETE,
+		     pmiID(34, 3, 0), PM_TYPE_U32, indom, PM_SEM_DISCRETE,
 		     pmiUnits(0, 0, 0, 0, 0, 0));
 
 	pmiAddMetric("power.usb.vendorId",
-		     PM_IN_NULL, PM_TYPE_STRING, indom, PM_SEM_DISCRETE,
+		     pmiID(34, 3, 1), PM_TYPE_STRING, indom, PM_SEM_DISCRETE,
 		     pmiUnits(0, 0, 0, 0, 0, 0));
 
 	pmiAddMetric("power.usb.productId",
-		     PM_IN_NULL, PM_TYPE_STRING, indom, PM_SEM_DISCRETE,
+		     pmiID(34, 3, 2), PM_TYPE_STRING, indom, PM_SEM_DISCRETE,
 		     pmiUnits(0, 0, 0, 0, 0, 0));
 
 	pmiAddMetric("power.usb.maxpower",
-		     PM_IN_NULL, PM_TYPE_U32, indom, PM_SEM_DISCRETE,
+		     pmiID(34, 3, 3), PM_TYPE_U32, indom, PM_SEM_DISCRETE,
 		     pmiUnits(0, 0, 0, 0, 0, 0));
 
 	pmiAddMetric("power.usb.manufacturer",
-		     PM_IN_NULL, PM_TYPE_STRING, indom, PM_SEM_DISCRETE,
+		     pmiID(34, 3, 3), PM_TYPE_STRING, indom, PM_SEM_DISCRETE,
 		     pmiUnits(0, 0, 0, 0, 0, 0));
 
 	pmiAddMetric("power.usb.productName",
-		     PM_IN_NULL, PM_TYPE_STRING, indom, PM_SEM_DISCRETE,
+		     pmiID(34, 3, 3), PM_TYPE_STRING, indom, PM_SEM_DISCRETE,
 		     pmiUnits(0, 0, 0, 0, 0, 0));
 #endif /* HAVE_PCP */
 }
@@ -1674,7 +1665,7 @@ void pcp_def_filesystem_metrics(struct activity *a)
 
 	if (indom == PM_INDOM_NULL) {
 		/* Create domain */
-		indom = pmInDom_build(0, PM_INDOM_FILESYSTEM);
+		indom = pmInDom_build(60, 5);
 
 		/* Create instances */
 		while (list != NULL) {
@@ -1683,33 +1674,37 @@ void pcp_def_filesystem_metrics(struct activity *a)
 		}
 	}
 
-	pmiAddMetric("fs.util.fsfree",
-		     PM_IN_NULL, PM_TYPE_U64, indom, PM_SEM_INSTANT,
-		     pmiUnits(1, 0, 0, PM_SPACE_MBYTE, 0, 0));
+	pmiAddMetric("filesys.capacity",
+		     pmiID(60, 5, 1), PM_TYPE_U64, indom, PM_SEM_INSTANT,
+		     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
-	pmiAddMetric("fs.util.fsused",
-		     PM_IN_NULL, PM_TYPE_U64, indom, PM_SEM_INSTANT,
-		     pmiUnits(1, 0, 0, PM_SPACE_MBYTE, 0, 0));
+	pmiAddMetric("filesys.free",
+		     pmiID(60, 5, 3), PM_TYPE_U64, indom, PM_SEM_INSTANT,
+		     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 
-	pmiAddMetric("fs.util.fsused_pct",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
+	pmiAddMetric("filesys.used",
+		     pmiID(60, 5, 2), PM_TYPE_U64, indom, PM_SEM_INSTANT,
+		     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
+
+	pmiAddMetric("filesys.full",
+		     pmiID(60, 5, 8), PM_TYPE_DOUBLE, indom, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 0, 0, 0, 0));
 
-	pmiAddMetric("fs.util.ufsused_pct",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(0, 0, 0, 0, 0, 0));
-
-	pmiAddMetric("fs.util.ifree",
-		     PM_IN_NULL, PM_TYPE_U64, indom, PM_SEM_INSTANT,
+	pmiAddMetric("filesys.maxfiles",
+		     pmiID(60, 5, 4), PM_TYPE_U64, indom, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("fs.util.iused",
-		     PM_IN_NULL, PM_TYPE_U64, indom, PM_SEM_INSTANT,
+	pmiAddMetric("filesys.freefiles",
+		     pmiID(60, 5, 6), PM_TYPE_U64, indom, PM_SEM_INSTANT,
 		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("fs.util.iused_pct",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(0, 0, 0, 0, 0, 0));
+	pmiAddMetric("filesys.usedfiles",
+		     pmiID(60, 5, 5), PM_TYPE_U64, indom, PM_SEM_INSTANT,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
+
+	pmiAddMetric("filesys.avail",
+		     pmiID(60, 5, 10), PM_TYPE_U64, indom, PM_SEM_INSTANT,
+		     pmiUnits(1, 0, 0, PM_SPACE_KBYTE, 0, 0));
 #endif /* HAVE_PCP */
 }
 
@@ -1730,7 +1725,7 @@ void pcp_def_fchost_metrics(struct activity *a)
 
 	if (indom == PM_INDOM_NULL) {
 		/* Create domain */
-		indom = pmInDom_build(0, PM_INDOM_FCHOST);
+		indom = pmInDom_build(60, 39);
 
 		/* Create instances */
 		while (list != NULL) {
@@ -1739,21 +1734,21 @@ void pcp_def_fchost_metrics(struct activity *a)
 		}
 	}
 
-	pmiAddMetric("network.fchost.in.frame",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("fchost.in.frames",
+		     pmiID(60, 91, 0), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.fchost.out.frame",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("fchost.out.frames",
+		     pmiID(60, 91, 1), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+		     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
 
-	pmiAddMetric("network.fchost.in.word",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("fchost.in.bytes",
+		     pmiID(60, 91, 2), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+		     pmiUnits(1, 0, 0, PM_SPACE_BYTE, 0, 0));
 
-	pmiAddMetric("network.fchost.out.word",
-		     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-		     pmiUnits(0, -1, 1, 0, PM_TIME_SEC, PM_COUNT_ONE));
+	pmiAddMetric("fchost.out.bytes",
+		     pmiID(60, 91, 3), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+		     pmiUnits(1, 0, 0, PM_SPACE_BYTE, 0, 0));
 #endif /* HAVE_PCP */
 }
 
@@ -1772,57 +1767,57 @@ void pcp_def_psi_metrics(struct activity *a)
 
 	if (indom == PM_INDOM_NULL) {
 		/* Create domain */
-		indom = pmInDom_build(0, PM_INDOM_PSI);
+		indom = pmInDom_build(60, 37);
 
-		pmiAddInstance(indom, "10 sec", 0);
-		pmiAddInstance(indom, "60 sec", 1);
-		pmiAddInstance(indom, "300 sec", 2);
+		pmiAddInstance(indom, "10 second", 10);
+		pmiAddInstance(indom, "1 minute", 60);
+		pmiAddInstance(indom, "5 minute", 300);
 	}
 
 	if (a->id == A_PSI_CPU) {
 		/* Create metrics for A_PSI_CPU */
-		pmiAddMetric("psi.cpu.some.trends",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(0, 0, 0, 0, 0, 0));
+		pmiAddMetric("kernel.all.pressure.cpu.some.total",
+			     pmiID(60, 83, 1), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 1, 0, 0, PM_TIME_USEC, 0));
 
-		pmiAddMetric("psi.cpu.some.avg",
-			     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
+		pmiAddMetric("kernel.all.pressure.cpu.some.avg",
+			     pmiID(60, 83, 0), PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
 			     pmiUnits(0, 0, 0, 0, 0, 0));
 	}
 	else if (a->id == A_PSI_IO) {
 		/* Create metrics for A_PSI_IO */
-		pmiAddMetric("psi.io.some.trends",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
+		pmiAddMetric("kernel.all.pressure.io.some.total",
+			     pmiID(60, 85, 1), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 1, 0, 0, PM_TIME_USEC, 0));
+
+		pmiAddMetric("kernel.all.pressure.io.some.avg",
+			     pmiID(60, 85, 0), PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
 			     pmiUnits(0, 0, 0, 0, 0, 0));
 
-		pmiAddMetric("psi.io.some.avg",
-			     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-			     pmiUnits(0, 0, 0, 0, 0, 0));
+		pmiAddMetric("kernel.all.pressure.io.full.total",
+			     pmiID(60, 85, 3), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 1, 0, 0, PM_TIME_USEC, 0));
 
-		pmiAddMetric("psi.io.full.trends",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(0, 0, 0, 0, 0, 0));
-
-		pmiAddMetric("psi.io.full.avg",
-			     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
+		pmiAddMetric("kernel.all.pressure.io.full.avg",
+			     pmiID(60, 85, 2), PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
 			     pmiUnits(0, 0, 0, 0, 0, 0));
 	}
 	else {
 		/* Create metrics for A_PSI_MEM */
-		pmiAddMetric("psi.mem.some.trends",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
+		pmiAddMetric("kernel.all.pressure.memory.some.total",
+			     pmiID(60, 84, 1), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 1, 0, 0, PM_TIME_USEC, 0));
+
+		pmiAddMetric("kernel.all.pressure.memory.some.avg",
+			     pmiID(60, 84, 0), PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
 			     pmiUnits(0, 0, 0, 0, 0, 0));
 
-		pmiAddMetric("psi.mem.some.avg",
-			     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
-			     pmiUnits(0, 0, 0, 0, 0, 0));
+		pmiAddMetric("kernel.all.pressure.memory.full.total",
+			     pmiID(60, 84, 3), PM_TYPE_U64, indom, PM_SEM_COUNTER,
+			     pmiUnits(0, 1, 0, 0, PM_TIME_USEC, 0));
 
-		pmiAddMetric("psi.mem.full.trends",
-			     PM_IN_NULL, PM_TYPE_FLOAT, indom, PM_SEM_INSTANT,
-			     pmiUnits(0, 0, 0, 0, 0, 0));
-
-		pmiAddMetric("psi.mem.full.avg",
-			     PM_IN_NULL, PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
+		pmiAddMetric("kernel.all.pressure.memory.full.avg",
+			     pmiID(60, 84, 2), PM_TYPE_FLOAT, PM_INDOM_NULL, PM_SEM_INSTANT,
 			     pmiUnits(0, 0, 0, 0, 0, 0));
 	}
 #endif /* HAVE_PCP */

--- a/pcp_def_metrics.h
+++ b/pcp_def_metrics.h
@@ -49,19 +49,4 @@ void pcp_def_filesystem_metrics(struct activity *);
 void pcp_def_fchost_metrics(struct activity *);
 void pcp_def_psi_metrics(struct activity *);
 
-/* Define domains number */
-#define PM_INDOM_CPU		0
-#define PM_INDOM_QUEUE		1
-#define PM_INDOM_NET_DEV	2
-#define PM_INDOM_SERIAL		3
-#define PM_INDOM_INT		4
-#define PM_INDOM_FILESYSTEM	5
-#define PM_INDOM_FCHOST		6
-#define PM_INDOM_USB		7
-#define PM_INDOM_DISK		8
-#define PM_INDOM_FAN		9
-#define PM_INDOM_TEMP		10
-#define PM_INDOM_IN		11
-#define PM_INDOM_PSI		12
-
 #endif /* _PCP_DEF_METRICS_H */

--- a/pcp_stats.c
+++ b/pcp_stats.c
@@ -48,8 +48,7 @@ extern uint64_t flags;
  * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_cpu_stats(struct activity *a, int curr, unsigned long long itv,
-				    struct record_header *record_hdr)
+__print_funct_t pcp_print_cpu_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	int i;
@@ -130,52 +129,37 @@ __print_funct_t pcp_print_cpu_stats(struct activity *a, int curr, unsigned long 
 			}
 		}
 
-		snprintf(buf, sizeof(buf), "%f",
-			 (scc->cpu_user - scc->cpu_guest) < (scp->cpu_user - scp->cpu_guest) ?
-			 0.0 :
-			 ll_sp_value(scp->cpu_user - scp->cpu_guest,
-				     scc->cpu_user - scc->cpu_guest, deltot_jiffies));
+		snprintf(buf, sizeof(buf), "%llu", scc->cpu_user - scc->cpu_guest);
 		pmiPutValue(i ? "kernel.percpu.cpu.user" : "kernel.all.cpu.user", str, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 (scc->cpu_nice - scc->cpu_guest_nice) < (scp->cpu_nice - scp->cpu_guest_nice) ?
-			 0.0 :
-			 ll_sp_value(scp->cpu_nice - scp->cpu_guest_nice,
-				     scc->cpu_nice - scc->cpu_guest_nice, deltot_jiffies));
+		snprintf(buf, sizeof(buf), "%llu", scc->cpu_nice - scc->cpu_guest_nice);
 		pmiPutValue(i ? "kernel.percpu.cpu.nice" : "kernel.all.cpu.nice", str, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 ll_sp_value(scp->cpu_sys, scc->cpu_sys, deltot_jiffies));
+		snprintf(buf, sizeof(buf), "%llu", scc->cpu_sys);
 		pmiPutValue(i ? "kernel.percpu.cpu.sys" : "kernel.all.cpu.sys", str, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 ll_sp_value(scp->cpu_iowait, scc->cpu_iowait, deltot_jiffies));
-		pmiPutValue(i ? "kernel.percpu.cpu.iowait" : "kernel.all.cpu.iowait", str, buf);
+		snprintf(buf, sizeof(buf), "%llu", scc->cpu_iowait);
+		pmiPutValue(i ? "kernel.percpu.cpu.iowait" : "kernel.all.cpu.wait.total", str, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 ll_sp_value(scp->cpu_steal, scc->cpu_steal, deltot_jiffies));
+		snprintf(buf, sizeof(buf), "%llu", scc->cpu_steal);
 		pmiPutValue(i ? "kernel.percpu.cpu.steal" : "kernel.all.cpu.steal", str, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 ll_sp_value(scp->cpu_hardirq, scc->cpu_hardirq, deltot_jiffies));
-		pmiPutValue(i ? "kernel.percpu.cpu.hardirq" : "kernel.all.cpu.hardirq", str, buf);
+		snprintf(buf, sizeof(buf), "%llu", scc->cpu_hardirq + scc->cpu_softirq);
+		pmiPutValue(i ? "kernel.percpu.cpu.intr" : "kernel.all.cpu.intr", str, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 ll_sp_value(scp->cpu_softirq, scc->cpu_softirq, deltot_jiffies));
-		pmiPutValue(i ? "kernel.percpu.cpu.softirq" : "kernel.all.cpu.softirq", str, buf);
+		snprintf(buf, sizeof(buf), "%llu", scc->cpu_hardirq);
+		pmiPutValue(i ? "kernel.percpu.cpu.irq.hard" : "kernel.all.cpu.irq.hard", str, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 ll_sp_value(scp->cpu_guest, scc->cpu_guest, deltot_jiffies));
+		snprintf(buf, sizeof(buf), "%llu", scc->cpu_softirq);
+		pmiPutValue(i ? "kernel.percpu.cpu.irq.soft" : "kernel.all.cpu.irq.soft", str, buf);
+
+		snprintf(buf, sizeof(buf), "%llu", scc->cpu_guest);
 		pmiPutValue(i ? "kernel.percpu.cpu.guest" : "kernel.all.cpu.guest", str, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 ll_sp_value(scp->cpu_guest_nice, scc->cpu_guest_nice, deltot_jiffies));
+		snprintf(buf, sizeof(buf), "%llu", scc->cpu_guest_nice);
 		pmiPutValue(i ? "kernel.percpu.cpu.guest_nice" : "kernel.all.cpu.guest_nice", str, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 scc->cpu_idle < scp->cpu_idle ?
-			 0.0 :
-			 ll_sp_value(scp->cpu_idle, scc->cpu_idle, deltot_jiffies));
+		snprintf(buf, sizeof(buf), "%llu", scc->cpu_idle);
 		pmiPutValue(i ? "kernel.percpu.cpu.idle" : "kernel.all.cpu.idle", str, buf);
 	}
 #endif	/* HAVE_PCP */
@@ -188,26 +172,20 @@ __print_funct_t pcp_print_cpu_stats(struct activity *a, int curr, unsigned long 
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_pcsw_stats(struct activity *a, int curr, unsigned long long itv,
-				     struct record_header *record_hdr)
+__print_funct_t pcp_print_pcsw_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_pcsw
-		*spc = (struct stats_pcsw *) a->buf[curr],
-		*spp = (struct stats_pcsw *) a->buf[!curr];
+		*spc = (struct stats_pcsw *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%f",
-		 S_VALUE(spp->context_switch, spc->context_switch, itv));
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) spc->context_switch);
 	pmiPutValue("kernel.all.pswitch", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 S_VALUE(spp->processes, spc->processes, itv));
-	pmiPutValue("kernel.all.proc", NULL, buf);
+	snprintf(buf, sizeof(buf), "%lu", spc->processes);
+	pmiPutValue("kernel.all.nprocs", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -218,37 +196,31 @@ __print_funct_t pcp_print_pcsw_stats(struct activity *a, int curr, unsigned long
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_irq_stats(struct activity *a, int curr, unsigned long long itv,
-				    struct record_header *record_hdr)
+__print_funct_t pcp_print_irq_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64], intno[64];
 	int i;
-	struct stats_irq *sic, *sip;
+	struct stats_irq *sic;
 
 	for (i = 0; (i < a->nr[curr]) && (i < a->bitmap->b_size + 1); i++) {
 
 		sic = (struct stats_irq *) ((char *) a->buf[curr]  + i * a->msize);
-		sip = (struct stats_irq *) ((char *) a->buf[!curr] + i * a->msize);
 
 		/* Should current interrupt (including int "sum") be displayed? */
 		if (a->bitmap->b_array[i >> 3] & (1 << (i & 0x07))) {
 
 			if (!i) {
 				/* This is interrupt "sum" */
-				snprintf(buf, sizeof(buf), "%f",
-					 S_VALUE(sip->irq_nr, sic->irq_nr, itv));
+				snprintf(buf, sizeof(buf), "%llu", sic->irq_nr);
 				pmiPutValue("kernel.all.intr", NULL, buf);
 			}
 			else {
-				sprintf(intno, "int%d", i - 1);
-				snprintf(buf, sizeof(buf), "%f",
-					 S_VALUE(sip->irq_nr, sic->irq_nr, itv));
-				pmiPutValue("kernel.all.int.count", intno, buf);
+				snprintf(intno, sizeof(intno), "int%d", i - 1);
+				snprintf(buf, sizeof(buf), "%llu", sic->irq_nr);
+				pmiPutValue("kernel.all.interrupts.total", intno, buf);
 			}
 		}
 	}
@@ -266,21 +238,17 @@ __print_funct_t pcp_print_irq_stats(struct activity *a, int curr, unsigned long 
  * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_swap_stats(struct activity *a, int curr, unsigned long long itv,
-				     struct record_header *record_hdr)
+__print_funct_t pcp_print_swap_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_swap
-		*ssc = (struct stats_swap *) a->buf[curr],
-		*ssp = (struct stats_swap *) a->buf[!curr];
+		*ssc = (struct stats_swap *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%f",
-		 S_VALUE(ssp->pswpin, ssc->pswpin, itv));
+	snprintf(buf, sizeof(buf), "%lu", ssc->pswpin);
 	pmiPutValue("swap.pagesin", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 S_VALUE(ssp->pswpout, ssc->pswpout, itv));
+	snprintf(buf, sizeof(buf), "%lu", ssc->pswpout);
 	pmiPutValue("swap.pagesout", NULL, buf);
 #endif	/* HAVE_PCP */
 }
@@ -292,50 +260,38 @@ __print_funct_t pcp_print_swap_stats(struct activity *a, int curr, unsigned long
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_paging_stats(struct activity *a, int curr, unsigned long long itv,
-				       struct record_header *record_hdr)
+__print_funct_t pcp_print_paging_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_paging
-		*spc = (struct stats_paging *) a->buf[curr],
-		*spp = (struct stats_paging *) a->buf[!curr];
+		*spc = (struct stats_paging *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%f",
-		 S_VALUE(spp->pgpgin, spc->pgpgin, itv));
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) spc->pgpgin);
 	pmiPutValue("mem.vmstat.pgpgin", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 S_VALUE(spp->pgpgout, spc->pgpgout, itv));
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) spc->pgpgout);
 	pmiPutValue("mem.vmstat.pgpgout", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 S_VALUE(spp->pgfault, spc->pgfault, itv));
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) spc->pgfault);
 	pmiPutValue("mem.vmstat.pgfault", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 S_VALUE(spp->pgmajfault, spc->pgmajfault, itv));
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) spc->pgmajfault);
 	pmiPutValue("mem.vmstat.pgmajfault", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 S_VALUE(spp->pgfree, spc->pgfree, itv));
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) spc->pgfree);
 	pmiPutValue("mem.vmstat.pgfree", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 S_VALUE(spp->pgscan_kswapd, spc->pgscan_kswapd, itv));
-	pmiPutValue("mem.vmstat.pgscank", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) spc->pgscan_kswapd);
+	pmiPutValue("mem.vmstat.pgscan_kswapd_total", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 S_VALUE(spp->pgscan_direct, spc->pgscan_direct, itv));
-	pmiPutValue("mem.vmstat.pgscand", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) spc->pgscan_direct);
+	pmiPutValue("mem.vmstat.pgscan_direct_total", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 S_VALUE(spp->pgsteal, spc->pgsteal, itv));
-	pmiPutValue("mem.vmstat.pgsteal", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) spc->pgsteal);
+	pmiPutValue("mem.vmstat.pgsteal_total", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -346,52 +302,34 @@ __print_funct_t pcp_print_paging_stats(struct activity *a, int curr, unsigned lo
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_io_stats(struct activity *a, int curr, unsigned long long itv,
-				   struct record_header *record_hdr)
+__print_funct_t pcp_print_io_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_io
-		*sic = (struct stats_io *) a->buf[curr],
-		*sip = (struct stats_io *) a->buf[!curr];
+		*sic = (struct stats_io *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%f",
-		 sic->dk_drive < sip->dk_drive ? 0.0
-					       : S_VALUE(sip->dk_drive, sic->dk_drive, itv));
+	snprintf(buf, sizeof(buf), "%llu", sic->dk_drive);
 	pmiPutValue("disk.all.total", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 sic->dk_drive_rio < sip->dk_drive_rio ? 0.0
-						       : S_VALUE(sip->dk_drive_rio, sic->dk_drive_rio, itv));
+	snprintf(buf, sizeof(buf), "%llu", sic->dk_drive_rio);
 	pmiPutValue("disk.all.read", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 sic->dk_drive_wio < sip->dk_drive_wio ? 0.0
-						       : S_VALUE(sip->dk_drive_wio, sic->dk_drive_wio, itv));
+	snprintf(buf, sizeof(buf), "%llu",sic->dk_drive_wio);
 	pmiPutValue("disk.all.write", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 sic->dk_drive_dio < sip->dk_drive_dio ? 0.0
-						       : S_VALUE(sip->dk_drive_dio, sic->dk_drive_dio, itv));
+	snprintf(buf, sizeof(buf), "%llu", sic->dk_drive_dio);
 	pmiPutValue("disk.all.discard", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 sic->dk_drive_rblk < sip->dk_drive_rblk ? 0.0
-							 : S_VALUE(sip->dk_drive_rblk, sic->dk_drive_rblk, itv) / 2);
+	snprintf(buf, sizeof(buf), "%llu", sic->dk_drive_rblk);
 	pmiPutValue("disk.all.read_bytes", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 sic->dk_drive_wblk < sip->dk_drive_wblk ? 0.0
-							 : S_VALUE(sip->dk_drive_wblk, sic->dk_drive_wblk, itv) / 2);
+	snprintf(buf, sizeof(buf), "%llu", sic->dk_drive_wblk);
 	pmiPutValue("disk.all.write_bytes", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 sic->dk_drive_dblk < sip->dk_drive_dblk ? 0.0
-							 : S_VALUE(sip->dk_drive_dblk, sic->dk_drive_dblk, itv) / 2);
+	snprintf(buf, sizeof(buf), "%llu", sic->dk_drive_dblk);
 	pmiPutValue("disk.all.discard_bytes", NULL, buf);
 #endif	/* HAVE_PCP */
 }
@@ -403,25 +341,16 @@ __print_funct_t pcp_print_io_stats(struct activity *a, int curr, unsigned long l
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_memory_stats(struct activity *a, int curr, unsigned long long itv,
-				       struct record_header *record_hdr)
+__print_funct_t pcp_print_memory_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_memory
 		*smc = (struct stats_memory *) a->buf[curr];
-	unsigned long long nousedmem;
 
 	if (DISPLAY_MEMORY(a->opt_flags)) {
-
-		nousedmem = smc->frmkb + smc->bufkb + smc->camkb + smc->slabkb;
-		if (nousedmem > smc->tlmkb) {
-			nousedmem = smc->tlmkb;
-		}
 
 		snprintf(buf, sizeof(buf), "%llu", smc->frmkb);
 		pmiPutValue("mem.util.free", NULL, buf);
@@ -429,12 +358,8 @@ __print_funct_t pcp_print_memory_stats(struct activity *a, int curr, unsigned lo
 		snprintf(buf, sizeof(buf), "%llu", smc->availablekb);
 		pmiPutValue("mem.util.available", NULL, buf);
 
-		snprintf(buf, sizeof(buf), "%llu", smc->tlmkb - nousedmem);
+		snprintf(buf, sizeof(buf), "%llu", smc->tlmkb - smc->frmkb);
 		pmiPutValue("mem.util.used", NULL, buf);
-
-		snprintf(buf, sizeof(buf), "%f",
-			 smc->tlmkb ? SP_VALUE(nousedmem, smc->tlmkb, smc->tlmkb) : 0.0);
-		pmiPutValue("mem.util.used_pct", NULL, buf);
 
 		snprintf(buf, sizeof(buf), "%llu", smc->bufkb);
 		pmiPutValue("mem.util.buffers", NULL, buf);
@@ -443,12 +368,7 @@ __print_funct_t pcp_print_memory_stats(struct activity *a, int curr, unsigned lo
 		pmiPutValue("mem.util.cached", NULL, buf);
 
 		snprintf(buf, sizeof(buf), "%llu", smc->comkb);
-		pmiPutValue("mem.util.commit", NULL, buf);
-
-		snprintf(buf, sizeof(buf), "%f",
-			 (smc->tlmkb + smc->tlskb) ? SP_VALUE(0, smc->comkb, smc->tlmkb + smc->tlskb)
-						   : 0.0);
-		pmiPutValue("mem.util.commit_pct", NULL, buf);
+		pmiPutValue("mem.util.committed_AS", NULL, buf);
 
 		snprintf(buf, sizeof(buf), "%llu", smc->activekb);
 		pmiPutValue("mem.util.active", NULL, buf);
@@ -483,20 +403,11 @@ __print_funct_t pcp_print_memory_stats(struct activity *a, int curr, unsigned lo
 		snprintf(buf, sizeof(buf), "%llu", smc->frskb);
 		pmiPutValue("mem.util.swapFree", NULL, buf);
 
-		snprintf(buf, sizeof(buf), "%llu", smc->tlskb - smc->frskb);
-		pmiPutValue("mem.util.swapUsed", NULL, buf);
-
-		snprintf(buf, sizeof(buf), "%f",
-			 smc->tlskb ? SP_VALUE(smc->frskb, smc->tlskb, smc->tlskb) : 0.0);
-		pmiPutValue("mem.util.swapUsed_pct", NULL, buf);
+		snprintf(buf, sizeof(buf), "%llu", smc->tlskb);
+		pmiPutValue("mem.util.swapTotal", NULL, buf);
 
 		snprintf(buf, sizeof(buf), "%llu", smc->caskb);
 		pmiPutValue("mem.util.swapCached", NULL, buf);
-
-		snprintf(buf, sizeof(buf), "%f",
-			 (smc->tlskb - smc->frskb) ? SP_VALUE(0, smc->caskb, smc->tlskb - smc->frskb)
-						   : 0.0);
-		pmiPutValue("mem.util.swapCached_pct", NULL, buf);
 	}
 #endif	/* HAVE_PCP */
 }
@@ -508,29 +419,26 @@ __print_funct_t pcp_print_memory_stats(struct activity *a, int curr, unsigned lo
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_ktables_stats(struct activity *a, int curr, unsigned long long itv,
-					struct record_header *record_hdr)
+__print_funct_t pcp_print_ktables_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_ktables
 		*skc = (struct stats_ktables *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%llu", skc->dentry_stat);
+	snprintf(buf, sizeof(buf), "%lu", (unsigned long) skc->dentry_stat);
 	pmiPutValue("vfs.dentry.count", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%llu", skc->file_used);
+	snprintf(buf, sizeof(buf), "%lu", (unsigned long) skc->file_used);
 	pmiPutValue("vfs.files.count", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%llu", skc->inode_used);
+	snprintf(buf, sizeof(buf), "%lu", (unsigned long) skc->inode_used);
 	pmiPutValue("vfs.inodes.count", NULL, buf);
 
 	snprintf(buf, sizeof(buf), "%llu", skc->pty_nr);
-	pmiPutValue("kernel.all.pty", NULL, buf);
+	pmiPutValue("kernel.all.nptys", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -541,35 +449,32 @@ __print_funct_t pcp_print_ktables_stats(struct activity *a, int curr, unsigned l
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_queue_stats(struct activity *a, int curr, unsigned long long itv,
-				      struct record_header *record_hdr)
+__print_funct_t pcp_print_queue_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_queue
 		*sqc = (struct stats_queue *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%llu", sqc->nr_running);
-	pmiPutValue("proc.runq.runnable", NULL, buf);
+	snprintf(buf, sizeof(buf), "%lu", (unsigned long) sqc->nr_running);
+	pmiPutValue("kernel.all.runnable", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%llu", sqc->nr_threads);
-	pmiPutValue("proc.nprocs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%lu", (unsigned long) sqc->nr_threads);
+	pmiPutValue("kernel.all.nprocs", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%llu", sqc->procs_blocked);
-	pmiPutValue("proc.blocked", NULL, buf);
+	snprintf(buf, sizeof(buf), "%lu", (unsigned long) sqc->procs_blocked);
+	pmiPutValue("kernel.all.blocked", NULL, buf);
 
 	snprintf(buf, sizeof(buf), "%f", (double) sqc->load_avg_1 / 100);
-	pmiPutValue("kernel.all.load", "1 min", buf);
+	pmiPutValue("kernel.all.load", "1 minute", buf);
 
 	snprintf(buf, sizeof(buf), "%f", (double) sqc->load_avg_5 / 100);
-	pmiPutValue("kernel.all.load", "5 min", buf);
+	pmiPutValue("kernel.all.load", "5 minute", buf);
 
 	snprintf(buf, sizeof(buf), "%f", (double) sqc->load_avg_15 / 100);
-	pmiPutValue("kernel.all.load", "15 min", buf);
+	pmiPutValue("kernel.all.load", "15 minute", buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -580,34 +485,19 @@ __print_funct_t pcp_print_queue_stats(struct activity *a, int curr, unsigned lon
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_disk_stats(struct activity *a, int curr, unsigned long long itv,
-				     struct record_header *record_hdr)
+__print_funct_t pcp_print_disk_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
-	int i, j;
-	struct stats_disk *sdc,	*sdp, sdpzero;
-	struct ext_disk_stats xds;
+	int i;
+	struct stats_disk *sdc;
 	char *dev_name;
 	char buf[64];
-
-	memset(&sdpzero, 0, STATS_DISK_SIZE);
 
 	for (i = 0; i < a->nr[curr]; i++) {
 
 		sdc = (struct stats_disk *) ((char *) a->buf[curr] + i * a->msize);
-
-		j = check_disk_reg(a, curr, !curr, i);
-		if (j < 0) {
-			/* This is a newly registered interface. Previous stats are zero */
-			sdp = &sdpzero;
-		}
-		else {
-			sdp = (struct stats_disk *) ((char *) a->buf[!curr] + j * a->msize);
-		}
 
 		/* Get device name */
 		dev_name = get_device_name(sdc->major, sdc->minor, sdc->wwn, sdc->part_nr,
@@ -621,40 +511,38 @@ __print_funct_t pcp_print_disk_stats(struct activity *a, int curr, unsigned long
 				continue;
 		}
 
-		/* Compute extended statistics values */
-		compute_ext_disk_stats(sdc, sdp, itv, &xds);
+		snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sdc->nr_ios);
+		pmiPutValue("disk.dev.total", dev_name, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(sdp->nr_ios, sdc->nr_ios, itv));
-		pmiPutValue("disk.device.tps", dev_name, buf);
+		snprintf(buf, sizeof(buf), "%llu", (unsigned long long) (sdc->rd_sect + sdc->wr_sect) / 2);
+		pmiPutValue("disk.dev.total_bytes", dev_name, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(sdp->rd_sect, sdc->rd_sect, itv) / 2);
-		pmiPutValue("disk.device.read_bytes", dev_name, buf);
+		snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sdc->rd_sect / 2);
+		pmiPutValue("disk.dev.read_bytes", dev_name, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(sdp->wr_sect, sdc->wr_sect, itv) / 2);
-		pmiPutValue("disk.device.write_bytes", dev_name, buf);
+		snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sdc->wr_sect / 2);
+		pmiPutValue("disk.dev.write_bytes", dev_name, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(sdp->dc_sect, sdc->dc_sect, itv) / 2);
-		pmiPutValue("disk.device.discard_bytes", dev_name, buf);
+		snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sdc->dc_sect / 2);
+		pmiPutValue("disk.dev.discard_bytes", dev_name, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 xds.arqsz / 2);
-		pmiPutValue("disk.device.areq_sz", dev_name, buf);
+		snprintf(buf, sizeof(buf), "%lu", (unsigned long) sdc->rq_ticks + sdc->wr_ticks);
+		pmiPutValue("disk.dev.total_rawactive", dev_name, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(sdp->rq_ticks, sdc->rq_ticks, itv) / 1000.0);
-		pmiPutValue("disk.device.aqu_sz", dev_name, buf);
+		snprintf(buf, sizeof(buf), "%lu", (unsigned long) sdc->rq_ticks);
+		pmiPutValue("disk.dev.read_rawactive", dev_name, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 xds.await);
-		pmiPutValue("disk.device.await", dev_name, buf);
+		snprintf(buf, sizeof(buf), "%lu", (unsigned long) sdc->wr_ticks);
+		pmiPutValue("disk.dev.write_rawactive", dev_name, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 xds.util / 10.0);
-		pmiPutValue("disk.device.util", dev_name, buf);
+		snprintf(buf, sizeof(buf), "%lu", (unsigned long)sdc->dc_ticks);
+		pmiPutValue("disk.dev.discard_rawactive", dev_name, buf);
+
+		snprintf(buf, sizeof(buf), "%lu", (unsigned long)sdc->tot_ticks);
+		pmiPutValue("disk.dev.avactive", dev_name, buf);
+
+		snprintf(buf, sizeof(buf), "%lu", (unsigned long)sdc->rq_ticks);
+		pmiPutValue("disk.dev.aveq", dev_name, buf);
 	}
 #endif	/* HAVE_PCP */
 }
@@ -666,20 +554,14 @@ __print_funct_t pcp_print_disk_stats(struct activity *a, int curr, unsigned long
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_net_dev_stats(struct activity *a, int curr, unsigned long long itv,
-					struct record_header *record_hdr)
+__print_funct_t pcp_print_net_dev_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	int i, j;
-	struct stats_net_dev *sndc, *sndp, sndzero;
-	double rxkb, txkb, ifutil;
+	struct stats_net_dev *sndc;
 	char buf[64];
-
-	memset(&sndzero, 0, STATS_NET_DEV_SIZE);
 
 	for (i = 0; i < a->nr[curr]; i++) {
 
@@ -694,45 +576,30 @@ __print_funct_t pcp_print_net_dev_stats(struct activity *a, int curr, unsigned l
 
 		j = check_net_dev_reg(a, curr, !curr, i);
 		if (j < 0) {
-			/* This is a newly registered interface. Previous stats are zero */
-			sndp = &sndzero;
-		}
-		else {
-			sndp = (struct stats_net_dev *) ((char *) a->buf[!curr] + j * a->msize);
+			/* This is a newly registered interface. */
+			/* TODO: add a new instance? */
 		}
 
-		rxkb = S_VALUE(sndp->rx_bytes, sndc->rx_bytes, itv);
-		txkb = S_VALUE(sndp->tx_bytes, sndc->tx_bytes, itv);
-		ifutil = compute_ifutil(sndc, rxkb, txkb);
-
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(sndp->rx_packets, sndc->rx_packets, itv));
+		snprintf(buf, sizeof(buf), "%llu", sndc->rx_packets);
 		pmiPutValue("network.interface.in.packets", sndc->interface, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(sndp->tx_packets, sndc->tx_packets, itv));
+		snprintf(buf, sizeof(buf), "%llu", sndc->tx_packets);
 		pmiPutValue("network.interface.out.packets", sndc->interface, buf);
 
-		snprintf(buf, sizeof(buf), "%f", rxkb / 1024);
+		snprintf(buf, sizeof(buf), "%llu", sndc->rx_bytes);
 		pmiPutValue("network.interface.in.bytes", sndc->interface, buf);
 
-		snprintf(buf, sizeof(buf), "%f", txkb / 1024);
+		snprintf(buf, sizeof(buf), "%llu", sndc->tx_bytes);
 		pmiPutValue("network.interface.out.bytes", sndc->interface, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(sndp->rx_compressed, sndc->rx_compressed, itv));
+		snprintf(buf, sizeof(buf), "%llu", sndc->rx_compressed);
 		pmiPutValue("network.interface.in.compressed", sndc->interface, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(sndp->tx_compressed, sndc->tx_compressed, itv));
+		snprintf(buf, sizeof(buf), "%llu", sndc->tx_compressed);
 		pmiPutValue("network.interface.out.compressed", sndc->interface, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(sndp->multicast, sndc->multicast, itv));
-		pmiPutValue("network.interface.in.multicast", sndc->interface, buf);
-
-		snprintf(buf, sizeof(buf), "%f", ifutil);
-		pmiPutValue("network.interface.util", sndc->interface, buf);
+		snprintf(buf, sizeof(buf), "%llu", sndc->multicast);
+		pmiPutValue("network.interface.in.mcasts", sndc->interface, buf);
 	}
 #endif	/* HAVE_PCP */
 }
@@ -744,19 +611,14 @@ __print_funct_t pcp_print_net_dev_stats(struct activity *a, int curr, unsigned l
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_net_edev_stats(struct activity *a, int curr, unsigned long long itv,
-					struct record_header *record_hdr)
+__print_funct_t pcp_print_net_edev_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	int i, j;
-	struct stats_net_edev *snedc, *snedp, snedzero;
+	struct stats_net_edev *snedc;
 	char buf[64];
-
-	memset(&snedzero, 0, STATS_NET_EDEV_SIZE);
 
 	for (i = 0; i < a->nr[curr]; i++) {
 
@@ -771,47 +633,35 @@ __print_funct_t pcp_print_net_edev_stats(struct activity *a, int curr, unsigned 
 
 		j = check_net_edev_reg(a, curr, !curr, i);
 		if (j < 0) {
-			/* This is a newly registered interface. Previous stats are zero */
-			snedp = &snedzero;
-		}
-		else {
-			snedp = (struct stats_net_edev *) ((char *) a->buf[!curr] + j * a->msize);
+			/* This is a newly registered interface. */
+			/* TODO: add a new instance? */
 		}
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(snedp->rx_errors, snedc->rx_errors, itv));
+		snprintf(buf, sizeof(buf), "%llu", snedc->rx_errors);
 		pmiPutValue("network.interface.in.errors", snedc->interface, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(snedp->tx_errors, snedc->tx_errors, itv));
+		snprintf(buf, sizeof(buf), "%llu", snedc->tx_errors);
 		pmiPutValue("network.interface.out.errors", snedc->interface, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(snedp->collisions, snedc->collisions, itv));
-		pmiPutValue("network.interface.out.collisions", snedc->interface, buf);
+		snprintf(buf, sizeof(buf), "%llu", snedc->collisions);
+		pmiPutValue("network.interface.collisions", snedc->interface, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(snedp->rx_dropped, snedc->rx_dropped, itv));
+		snprintf(buf, sizeof(buf), "%llu", snedc->rx_dropped);
 		pmiPutValue("network.interface.in.drops", snedc->interface, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(snedp->tx_dropped, snedc->tx_dropped, itv));
+		snprintf(buf, sizeof(buf), "%llu", snedc->tx_dropped);
 		pmiPutValue("network.interface.out.drops", snedc->interface, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(snedp->tx_carrier_errors, snedc->tx_carrier_errors, itv));
+		snprintf(buf, sizeof(buf), "%llu", snedc->tx_carrier_errors);
 		pmiPutValue("network.interface.out.carrier", snedc->interface, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(snedp->rx_frame_errors, snedc->rx_frame_errors, itv));
+		snprintf(buf, sizeof(buf), "%llu", snedc->rx_frame_errors);
 		pmiPutValue("network.interface.in.frame", snedc->interface, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(snedp->rx_fifo_errors, snedc->rx_fifo_errors, itv));
+		snprintf(buf, sizeof(buf), "%llu", snedc->rx_fifo_errors);
 		pmiPutValue("network.interface.in.fifo", snedc->interface, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(snedp->tx_fifo_errors, snedc->tx_fifo_errors, itv));
+		snprintf(buf, sizeof(buf), "%llu", snedc->tx_fifo_errors);
 		pmiPutValue("network.interface.out.fifo", snedc->interface, buf);
 	}
 #endif	/* HAVE_PCP */
@@ -824,75 +674,38 @@ __print_funct_t pcp_print_net_edev_stats(struct activity *a, int curr, unsigned 
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_serial_stats(struct activity *a, int curr, unsigned long long itv,
-				       struct record_header *record_hdr)
+__print_funct_t pcp_print_serial_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
-	int i, j, j0, found;
+	int i;
 	char buf[64], serialno[64];
-	struct stats_serial *ssc, *ssp;
+	struct stats_serial *ssc;
 
 	for (i = 0; i < a->nr[curr]; i++) {
 
-		found = FALSE;
+		ssc = (struct stats_serial *) ((char *) a->buf[curr] + i * a->msize);
 
-		if (a->nr[!curr] > 0) {
-			ssc = (struct stats_serial *) ((char *) a->buf[curr] + i * a->msize);
+		snprintf(serialno, sizeof(serialno), "serial%u", ssc->line);
 
-			/* Look for corresponding serial line in previous iteration */
-			j = i;
+		snprintf(buf, sizeof(buf), "%u", ssc->rx);
+		pmiPutValue("tty.serial.rx", serialno, buf);
 
-			if (j >= a->nr[!curr]) {
-				j = a->nr[!curr] - 1;
-			}
+		snprintf(buf, sizeof(buf), "%u", ssc->tx);
+		pmiPutValue("tty.serial.tx", serialno, buf);
 
-			j0 = j;
+		snprintf(buf, sizeof(buf), "%u", ssc->frame);
+		pmiPutValue("tty.serial.frame", serialno, buf);
 
-			do {
-				ssp = (struct stats_serial *) ((char *) a->buf[!curr] + j * a->msize);
-				if (ssc->line == ssp->line) {
-					found = TRUE;
-					break;
-				}
-				if (++j >= a->nr[!curr]) {
-					j = 0;
-				}
-			}
-			while (j != j0);
-		}
+		snprintf(buf, sizeof(buf), "%u", ssc->parity);
+		pmiPutValue("tty.serial.parity", serialno, buf);
 
-		if (!found)
-			continue;
+		snprintf(buf, sizeof(buf), "%u", ssc->brk);
+		pmiPutValue("tty.serial.brk", serialno, buf);
 
-		sprintf(serialno, "serial%d", ssc->line);
-
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(ssp->rx, ssc->rx, itv));
-		pmiPutValue("serial.in.interrupts", serialno, buf);
-
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(ssp->tx, ssc->tx, itv));
-		pmiPutValue("serial.out.interrupts", serialno, buf);
-
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(ssp->frame, ssc->frame, itv));
-		pmiPutValue("serial.frame", serialno, buf);
-
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(ssp->parity, ssc->parity, itv));
-		pmiPutValue("serial.parity", serialno, buf);
-
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(ssp->brk, ssc->brk, itv));
-		pmiPutValue("serial.breaks", serialno, buf);
-
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(ssp->overrun, ssc->overrun, itv));
-		pmiPutValue("serial.overrun", serialno, buf);
+		snprintf(buf, sizeof(buf), "%u", ssc->overrun);
+		pmiPutValue("tty.serial.overrun", serialno, buf);
 	}
 #endif	/* HAVE_PCP */
 }
@@ -904,42 +717,32 @@ __print_funct_t pcp_print_serial_stats(struct activity *a, int curr, unsigned lo
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_net_nfs_stats(struct activity *a, int curr, unsigned long long itv,
-					struct record_header *record_hdr)
+__print_funct_t pcp_print_net_nfs_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_net_nfs
-		*snnc = (struct stats_net_nfs *) a->buf[curr],
-		*snnp = (struct stats_net_nfs *) a->buf[!curr];
+		*snnc = (struct stats_net_nfs *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snnp->nfs_rpccnt, snnc->nfs_rpccnt, itv));
-	pmiPutValue("network.fs.client.call", NULL, buf);
+	snprintf(buf, sizeof(buf), "%u", snnc->nfs_rpccnt);
+	pmiPutValue("rpc.client.rpccnt", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snnp->nfs_rpcretrans, snnc->nfs_rpcretrans, itv));
-	pmiPutValue("network.fs.client.retrans", NULL, buf);
+	snprintf(buf, sizeof(buf), "%u", snnc->nfs_rpcretrans);
+	pmiPutValue("rpc.client.rpcretrans", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snnp->nfs_readcnt, snnc->nfs_readcnt, itv));
-	pmiPutValue("network.fs.client.read", NULL, buf);
+	snprintf(buf, sizeof(buf), "%u", snnc->nfs_readcnt);
+	pmiPutValue("nfs.client.reqs", "read", buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snnp->nfs_writecnt, snnc->nfs_writecnt, itv));
-	pmiPutValue("network.fs.client.write", NULL, buf);
+	snprintf(buf, sizeof(buf), "%u", snnc->nfs_writecnt);
+	pmiPutValue("nfs.client.reqs", "write", buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snnp->nfs_accesscnt, snnc->nfs_accesscnt, itv));
-	pmiPutValue("network.fs.client.access", NULL, buf);
+	snprintf(buf, sizeof(buf), "%u", snnc->nfs_accesscnt);
+	pmiPutValue("nfs.client.reqs", "access", buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snnp->nfs_getattcnt, snnc->nfs_getattcnt, itv));
-	pmiPutValue("network.fs.client.getattr", NULL, buf);
+	snprintf(buf, sizeof(buf), "%u", snnc->nfs_getattcnt);
+	pmiPutValue("nfs.client.reqs", "getattr", buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -950,62 +753,47 @@ __print_funct_t pcp_print_net_nfs_stats(struct activity *a, int curr, unsigned l
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_net_nfsd_stats(struct activity *a, int curr, unsigned long long itv,
-					 struct record_header *record_hdr)
+__print_funct_t pcp_print_net_nfsd_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_net_nfsd
-		*snndc = (struct stats_net_nfsd *) a->buf[curr],
-		*snndp = (struct stats_net_nfsd *) a->buf[!curr];
+		*snndc = (struct stats_net_nfsd *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snndp->nfsd_rpccnt, snndc->nfsd_rpccnt, itv));
-	pmiPutValue("network.fs.server.call", NULL, buf);
+	snprintf(buf, sizeof(buf), "%u", snndc->nfsd_rpccnt);
+	pmiPutValue("rpc.server.rpccnt", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snndp->nfsd_rpcbad, snndc->nfsd_rpcbad, itv));
-	pmiPutValue("network.fs.server.badcall", NULL, buf);
+	snprintf(buf, sizeof(buf), "%u", snndc->nfsd_rpcbad);
+	pmiPutValue("rpc.server.rpcbadclnt", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snndp->nfsd_netcnt, snndc->nfsd_netcnt, itv));
-	pmiPutValue("network.fs.server.packets", NULL, buf);
+	snprintf(buf, sizeof(buf), "%u", snndc->nfsd_netcnt);
+	pmiPutValue("rpc.server.netcnt", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snndp->nfsd_netudpcnt, snndc->nfsd_netudpcnt, itv));
-	pmiPutValue("network.fs.server.udp", NULL, buf);
+	snprintf(buf, sizeof(buf), "%u", snndc->nfsd_netudpcnt);
+	pmiPutValue("rpc.server.netudpcnt", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snndp->nfsd_nettcpcnt, snndc->nfsd_nettcpcnt, itv));
-	pmiPutValue("network.fs.server.tcp", NULL, buf);
+	snprintf(buf, sizeof(buf), "%u", snndc->nfsd_nettcpcnt);
+	pmiPutValue("rpc.server.nettcpcnt", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snndp->nfsd_rchits, snndc->nfsd_rchits, itv));
-	pmiPutValue("network.fs.server.hits", NULL, buf);
+	snprintf(buf, sizeof(buf), "%u", snndc->nfsd_rchits);
+	pmiPutValue("rpc.server.rchits", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snndp->nfsd_rcmisses, snndc->nfsd_rcmisses, itv));
-	pmiPutValue("network.fs.server.misses", NULL, buf);
+	snprintf(buf, sizeof(buf), "%u", snndc->nfsd_rcmisses);
+	pmiPutValue("rpc.server.rcmisses", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snndp->nfsd_readcnt, snndc->nfsd_readcnt, itv));
-	pmiPutValue("network.fs.server.read", NULL, buf);
+	snprintf(buf, sizeof(buf), "%u", snndc->nfsd_readcnt);
+	pmiPutValue("nfs.server.reqs", "read", buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snndp->nfsd_writecnt, snndc->nfsd_writecnt, itv));
-	pmiPutValue("network.fs.server.write", NULL, buf);
+	snprintf(buf, sizeof(buf), "%u", snndc->nfsd_writecnt);
+	pmiPutValue("nfs.server.reqs", "write", buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snndp->nfsd_accesscnt, snndc->nfsd_accesscnt, itv));
-	pmiPutValue("network.fs.server.access", NULL, buf);
+	snprintf(buf, sizeof(buf), "%u", snndc->nfsd_accesscnt);
+	pmiPutValue("nfs.server.reqs", "access", buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snndp->nfsd_getattcnt, snndc->nfsd_getattcnt, itv));
-	pmiPutValue("network.fs.server.getattr", NULL, buf);
+	snprintf(buf, sizeof(buf), "%u", snndc->nfsd_getattcnt);
+	pmiPutValue("nfs.server.reqs", "getattr", buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -1016,12 +804,9 @@ __print_funct_t pcp_print_net_nfsd_stats(struct activity *a, int curr, unsigned 
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_net_sock_stats(struct activity *a, int curr, unsigned long long itv,
-					 struct record_header *record_hdr)
+__print_funct_t pcp_print_net_sock_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
@@ -1029,22 +814,22 @@ __print_funct_t pcp_print_net_sock_stats(struct activity *a, int curr, unsigned 
 		*snsc = (struct stats_net_sock *) a->buf[curr];
 
 	snprintf(buf, sizeof(buf), "%u", snsc->sock_inuse);
-	pmiPutValue("network.socket.sock_inuse", NULL, buf);
+	pmiPutValue("network.sockstat.total", NULL, buf);
 
 	snprintf(buf, sizeof(buf), "%u", snsc->tcp_inuse);
-	pmiPutValue("network.socket.tcp_inuse", NULL, buf);
+	pmiPutValue("network.sockstat.tcp.inuse", NULL, buf);
 
 	snprintf(buf, sizeof(buf), "%u", snsc->udp_inuse);
-	pmiPutValue("network.socket.udp_inuse", NULL, buf);
+	pmiPutValue("network.sockstat.udp.inuse", NULL, buf);
 
 	snprintf(buf, sizeof(buf), "%u", snsc->raw_inuse);
-	pmiPutValue("network.socket.raw_inuse", NULL, buf);
+	pmiPutValue("network.sockstat.raw.inuse", NULL, buf);
 
 	snprintf(buf, sizeof(buf), "%u", snsc->frag_inuse);
-	pmiPutValue("network.socket.frag_inuse", NULL, buf);
+	pmiPutValue("network.sockstat.frag.inuse", NULL, buf);
 
 	snprintf(buf, sizeof(buf), "%u", snsc->tcp_tw);
-	pmiPutValue("network.socket.tcp_tw", NULL, buf);
+	pmiPutValue("network.sockstat.tcp.tw", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -1059,46 +844,36 @@ __print_funct_t pcp_print_net_sock_stats(struct activity *a, int curr, unsigned 
  * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_net_ip_stats(struct activity *a, int curr, unsigned long long itv,
-				       struct record_header *record_hdr)
+__print_funct_t pcp_print_net_ip_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_net_ip
-		*snic = (struct stats_net_ip *) a->buf[curr],
-		*snip = (struct stats_net_ip *) a->buf[!curr];
+		*snic = (struct stats_net_ip *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InReceives, snic->InReceives, itv));
-	pmiPutValue("network.snmp.ip.ipInReceives", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", snic->InReceives);
+	pmiPutValue("network.ip.inreceives", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->ForwDatagrams, snic->ForwDatagrams, itv));
-	pmiPutValue("network.snmp.ip.ipForwDatagrams", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", snic->ForwDatagrams);
+	pmiPutValue("network.ip.forwdatagrams", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InDelivers, snic->InDelivers, itv));
-	pmiPutValue("network.snmp.ip.ipInDelivers", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", snic->InDelivers);
+	pmiPutValue("network.ip.indelivers", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->OutRequests, snic->OutRequests, itv));
-	pmiPutValue("network.snmp.ip.ipOutRequests", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", snic->OutRequests);
+	pmiPutValue("network.ip.outrequests", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->ReasmReqds, snic->ReasmReqds, itv));
-	pmiPutValue("network.snmp.ip.ipReasmReqds", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", snic->ReasmReqds);
+	pmiPutValue("network.ip.reasmreqds", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->ReasmOKs, snic->ReasmOKs, itv));
-	pmiPutValue("network.snmp.ip.ipReasmOKs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", snic->ReasmOKs);
+	pmiPutValue("network.ip.reasmoks", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->FragOKs, snic->FragOKs, itv));
-	pmiPutValue("network.snmp.ip.ipFragOKs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", snic->FragOKs);
+	pmiPutValue("network.ip.fragoks", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->FragCreates, snic->FragCreates, itv));
-	pmiPutValue("network.snmp.ip.ipFragCreates", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", snic->FragCreates);
+	pmiPutValue("network.ip.fragcreates", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -1109,50 +884,38 @@ __print_funct_t pcp_print_net_ip_stats(struct activity *a, int curr, unsigned lo
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_net_eip_stats(struct activity *a, int curr, unsigned long long itv,
-				        struct record_header *record_hdr)
+__print_funct_t pcp_print_net_eip_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_net_eip
-		*sneic = (struct stats_net_eip *) a->buf[curr],
-		*sneip = (struct stats_net_eip *) a->buf[!curr];
+		*sneic = (struct stats_net_eip *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InHdrErrors, sneic->InHdrErrors, itv));
-	pmiPutValue("network.snmp.ip.ipInHdrErrors", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->InHdrErrors);
+	pmiPutValue("network.ip.inhdrerrors", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InAddrErrors, sneic->InAddrErrors, itv));
-	pmiPutValue("network.snmp.ip.ipInAddrErrors", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->InAddrErrors);
+	pmiPutValue("network.ip.inaddrerrors", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InUnknownProtos, sneic->InUnknownProtos, itv));
-	pmiPutValue("network.snmp.ip.ipInUnknownProtos", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->InUnknownProtos);
+	pmiPutValue("network.ip.inunknownprotos", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InDiscards, sneic->InDiscards, itv));
-	pmiPutValue("network.snmp.ip.ipInDiscards", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->InDiscards);
+	pmiPutValue("network.ip.indiscards", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->OutDiscards, sneic->OutDiscards, itv));
-	pmiPutValue("network.snmp.ip.ipOutDiscards", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->OutDiscards);
+	pmiPutValue("network.ip.outdiscards", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->OutNoRoutes, sneic->OutNoRoutes, itv));
-	pmiPutValue("network.snmp.ip.ipOutNoRoutes", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->OutNoRoutes);
+	pmiPutValue("network.ip.outnoroutes", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->ReasmFails, sneic->ReasmFails, itv));
-	pmiPutValue("network.snmp.ip.ipReasmFails", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->ReasmFails);
+	pmiPutValue("network.ip.reasmfails", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->FragFails, sneic->FragFails, itv));
-	pmiPutValue("network.snmp.ip.ipFragFails", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->FragFails);
+	pmiPutValue("network.ip.fragfails", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -1163,74 +926,56 @@ __print_funct_t pcp_print_net_eip_stats(struct activity *a, int curr, unsigned l
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_net_icmp_stats(struct activity *a, int curr, unsigned long long itv,
-					 struct record_header *record_hdr)
+__print_funct_t pcp_print_net_icmp_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_net_icmp
-		*snic = (struct stats_net_icmp *) a->buf[curr],
-		*snip = (struct stats_net_icmp *) a->buf[!curr];
+		*snic = (struct stats_net_icmp *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InMsgs, snic->InMsgs, itv));
-	pmiPutValue("network.snmp.icmp.icmpInMsgs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->InMsgs);
+	pmiPutValue("network.icmp.inmsgs", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->OutMsgs, snic->OutMsgs, itv));
-	pmiPutValue("network.snmp.icmp.icmpOutMsgs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->OutMsgs);
+	pmiPutValue("network.icmp.outmsgs", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InEchos, snic->InEchos, itv));
-	pmiPutValue("network.snmp.icmp.icmpInEchos", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->InEchos);
+	pmiPutValue("network.icmp.inechos", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InEchoReps, snic->InEchoReps, itv));
-	pmiPutValue("network.snmp.icmp.icmpInEchoReps", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->InEchoReps);
+	pmiPutValue("network.icmp.inechoreps", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->OutEchos, snic->OutEchos, itv));
-	pmiPutValue("network.snmp.icmp.icmpOutEchos", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->OutEchos);
+	pmiPutValue("network.icmp.outechos", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->OutEchoReps, snic->OutEchoReps, itv));
-	pmiPutValue("network.snmp.icmp.icmpOutEchoReps", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->OutEchoReps);
+	pmiPutValue("network.icmp.outechoreps", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InTimestamps, snic->InTimestamps, itv));
-	pmiPutValue("network.snmp.icmp.icmpInTimestamps", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->InTimestamps);
+	pmiPutValue("network.icmp.intimestamps", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InTimestampReps, snic->InTimestampReps, itv));
-	pmiPutValue("network.snmp.icmp.icmpInTimestampReps", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->InTimestampReps);
+	pmiPutValue("network.icmp.intimestampreps", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->OutTimestamps, snic->OutTimestamps, itv));
-	pmiPutValue("network.snmp.icmp.icmpOutTimestamps", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->OutTimestamps);
+	pmiPutValue("network.icmp.outtimestamps", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->OutTimestampReps, snic->OutTimestampReps, itv));
-	pmiPutValue("network.snmp.icmp.icmpOutTimestampReps", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->OutTimestampReps);
+	pmiPutValue("network.icmp.outtimestampreps", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InAddrMasks, snic->InAddrMasks, itv));
-	pmiPutValue("network.snmp.icmp.icmpInAddrMasks", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->InAddrMasks);
+	pmiPutValue("network.icmp.inaddrmasks", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InAddrMaskReps, snic->InAddrMaskReps, itv));
-	pmiPutValue("network.snmp.icmp.icmpInAddrMaskReps", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->InAddrMaskReps);
+	pmiPutValue("network.icmp.inaddrmaskreps", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->OutAddrMasks, snic->OutAddrMasks, itv));
-	pmiPutValue("network.snmp.icmp.icmpOutAddrMasks", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->OutAddrMasks);
+	pmiPutValue("network.icmp.outaddrmasks", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->OutAddrMaskReps, snic->OutAddrMaskReps, itv));
-	pmiPutValue("network.snmp.icmp.icmpOutAddrMaskReps", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->OutAddrMaskReps);
+	pmiPutValue("network.icmp.outaddrmaskreps", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -1242,66 +987,50 @@ __print_funct_t pcp_print_net_icmp_stats(struct activity *a, int curr, unsigned 
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_net_eicmp_stats(struct activity *a, int curr, unsigned long long itv,
-					  struct record_header *record_hdr)
+__print_funct_t pcp_print_net_eicmp_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_net_eicmp
-		*sneic = (struct stats_net_eicmp *) a->buf[curr],
-		*sneip = (struct stats_net_eicmp *) a->buf[!curr];
+		*sneic = (struct stats_net_eicmp *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InErrors, sneic->InErrors, itv));
-	pmiPutValue("network.snmp.icmp.icmpInErrors", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->InErrors);
+	pmiPutValue("network.icmp.inerrors", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->OutErrors, sneic->OutErrors, itv));
-	pmiPutValue("network.snmp.icmp.icmpOutErrors", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->OutErrors);
+	pmiPutValue("network.icmp.outerrors", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InDestUnreachs, sneic->InDestUnreachs, itv));
-	pmiPutValue("network.snmp.icmp.icmpInDestUnreachs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->InDestUnreachs);
+	pmiPutValue("network.icmp.indestunreachs", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->OutDestUnreachs, sneic->OutDestUnreachs, itv));
-	pmiPutValue("network.snmp.icmp.icmpOutDestUnreachs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->OutDestUnreachs);
+	pmiPutValue("network.icmp.outdestunreachs", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InTimeExcds, sneic->InTimeExcds, itv));
-	pmiPutValue("network.snmp.icmp.icmpInTimeExcds", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->InTimeExcds);
+	pmiPutValue("network.icmp.intimeexcds", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->OutTimeExcds, sneic->OutTimeExcds, itv));
-	pmiPutValue("network.snmp.icmp.icmpOutTimeExcds", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->OutTimeExcds);
+	pmiPutValue("network.icmp.outtimeexcds", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InParmProbs, sneic->InParmProbs, itv));
-	pmiPutValue("network.snmp.icmp.icmpInParmProbs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->InParmProbs);
+	pmiPutValue("network.icmp.inparmprobs", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->OutParmProbs, sneic->OutParmProbs, itv));
-	pmiPutValue("network.snmp.icmp.icmpOutParmProbs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->OutParmProbs);
+	pmiPutValue("network.icmp.outparmprobs", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InSrcQuenchs, sneic->InSrcQuenchs, itv));
-	pmiPutValue("network.snmp.icmp.icmpInSrcQuenchs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->InSrcQuenchs);
+	pmiPutValue("network.icmp.insrcquenchs", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->OutSrcQuenchs, sneic->OutSrcQuenchs, itv));
-	pmiPutValue("network.snmp.icmp.icmpOutSrcQuenchs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->OutSrcQuenchs);
+	pmiPutValue("network.icmp.outsrcquenchs", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InRedirects, sneic->InRedirects, itv));
-	pmiPutValue("network.snmp.icmp.icmpInRedirects", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->InRedirects);
+	pmiPutValue("network.icmp.inredirects", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->OutRedirects, sneic->OutRedirects, itv));
-	pmiPutValue("network.snmp.icmp.icmpOutRedirects", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->OutRedirects);
+	pmiPutValue("network.icmp.outredirects", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -1312,34 +1041,26 @@ __print_funct_t pcp_print_net_eicmp_stats(struct activity *a, int curr, unsigned
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_net_tcp_stats(struct activity *a, int curr, unsigned long long itv,
-					struct record_header *record_hdr)
+__print_funct_t pcp_print_net_tcp_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_net_tcp
-		*sntc = (struct stats_net_tcp *) a->buf[curr],
-		*sntp = (struct stats_net_tcp *) a->buf[!curr];
+		*sntc = (struct stats_net_tcp *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sntp->ActiveOpens, sntc->ActiveOpens, itv));
-	pmiPutValue("network.snmp.tcp.tcpActiveOpens", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sntc->ActiveOpens);
+	pmiPutValue("network.tcp.activeopens", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sntp->PassiveOpens, sntc->PassiveOpens, itv));
-	pmiPutValue("network.snmp.tcp.tcpPassiveOpens", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sntc->PassiveOpens);
+	pmiPutValue("network.tcp.passiveopens", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sntp->InSegs, sntc->InSegs, itv));
-	pmiPutValue("network.snmp.tcp.tcpInSegs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sntc->InSegs);
+	pmiPutValue("network.tcp.insegs", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sntp->OutSegs, sntc->OutSegs, itv));
-	pmiPutValue("network.snmp.tcp.tcpOutSegs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sntc->OutSegs);
+	pmiPutValue("network.tcp.outsegs", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -1350,38 +1071,29 @@ __print_funct_t pcp_print_net_tcp_stats(struct activity *a, int curr, unsigned l
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_net_etcp_stats(struct activity *a, int curr, unsigned long long itv,
-					 struct record_header *record_hdr)
+__print_funct_t pcp_print_net_etcp_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_net_etcp
-		*snetc = (struct stats_net_etcp *) a->buf[curr],
-		*snetp = (struct stats_net_etcp *) a->buf[!curr];
+		*snetc = (struct stats_net_etcp *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snetp->AttemptFails, snetc->AttemptFails, itv));
-	pmiPutValue("network.snmp.tcp.tcpAttemptFails", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snetc->AttemptFails);
+	pmiPutValue("network.tcp.attemptfails", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snetp->EstabResets, snetc->EstabResets, itv));
-	pmiPutValue("network.snmp.tcp.tcpEstabResets", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snetc->EstabResets);
+	pmiPutValue("network.tcp.tcpestabresets", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snetp->RetransSegs, snetc->RetransSegs, itv));
-	pmiPutValue("network.snmp.tcp.tcpRetransSegs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snetc->RetransSegs);
+	pmiPutValue("network.tcp.tcpretranssegs", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snetp->InErrs, snetc->InErrs, itv));
-	pmiPutValue("network.snmp.tcp.tcpInErrs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snetc->InErrs);
+	pmiPutValue("network.tcp.inerrs", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snetp->OutRsts, snetc->OutRsts, itv));
-	pmiPutValue("network.snmp.tcp.tcpOutRsts", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snetc->OutRsts);
+	pmiPutValue("network.tcp.outrsts", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -1392,34 +1104,26 @@ __print_funct_t pcp_print_net_etcp_stats(struct activity *a, int curr, unsigned 
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_net_udp_stats(struct activity *a, int curr, unsigned long long itv,
-					struct record_header *record_hdr)
+__print_funct_t pcp_print_net_udp_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_net_udp
-		*snuc = (struct stats_net_udp *) a->buf[curr],
-		*snup = (struct stats_net_udp *) a->buf[!curr];
+		*snuc = (struct stats_net_udp *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snup->InDatagrams, snuc->InDatagrams, itv));
-	pmiPutValue("network.snmp.udp.udpInDatagrams", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snuc->InDatagrams);
+	pmiPutValue("network.udp.indatagrams", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snup->OutDatagrams, snuc->OutDatagrams, itv));
-	pmiPutValue("network.snmp.udp.udpOutDatagrams", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snuc->OutDatagrams);
+	pmiPutValue("network.udp.outdatagrams", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snup->NoPorts, snuc->NoPorts, itv));
-	pmiPutValue("network.snmp.udp.udpNoPorts", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snuc->NoPorts);
+	pmiPutValue("network.udp.noports", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snup->InErrors, snuc->InErrors, itv));
-	pmiPutValue("network.snmp.udp.udpInErrors", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snuc->InErrors);
+	pmiPutValue("network.udp.inerrors", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -1430,12 +1134,9 @@ __print_funct_t pcp_print_net_udp_stats(struct activity *a, int curr, unsigned l
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_net_sock6_stats(struct activity *a, int curr, unsigned long long itv,
-					  struct record_header *record_hdr)
+__print_funct_t pcp_print_net_sock6_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
@@ -1443,16 +1144,16 @@ __print_funct_t pcp_print_net_sock6_stats(struct activity *a, int curr, unsigned
 		*snsc = (struct stats_net_sock6 *) a->buf[curr];
 
 	snprintf(buf, sizeof(buf), "%u", snsc->tcp6_inuse);
-	pmiPutValue("network.socket6.tcp6_inuse", NULL, buf);
+	pmiPutValue("network.sockstat.tcp6.inuse", NULL, buf);
 
 	snprintf(buf, sizeof(buf), "%u", snsc->udp6_inuse);
-	pmiPutValue("network.socket6.udp6_inuse", NULL, buf);
+	pmiPutValue("network.sockstat.udp6.inuse", NULL, buf);
 
 	snprintf(buf, sizeof(buf), "%u", snsc->raw6_inuse);
-	pmiPutValue("network.socket6.raw6_inuse", NULL, buf);
+	pmiPutValue("network.sockstat.raw6.inuse", NULL, buf);
 
 	snprintf(buf, sizeof(buf), "%u", snsc->frag6_inuse);
-	pmiPutValue("network.socket6.frag6_inuse", NULL, buf);
+	pmiPutValue("network.sockstat.frag6.inuse", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -1463,58 +1164,44 @@ __print_funct_t pcp_print_net_sock6_stats(struct activity *a, int curr, unsigned
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_net_ip6_stats(struct activity *a, int curr, unsigned long long itv,
-					struct record_header *record_hdr)
+__print_funct_t pcp_print_net_ip6_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_net_ip6
-		*snic = (struct stats_net_ip6 *) a->buf[curr],
-		*snip = (struct stats_net_ip6 *) a->buf[!curr];
+		*snic = (struct stats_net_ip6 *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InReceives6, snic->InReceives6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsInReceives", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", snic->InReceives6);
+	pmiPutValue("network.ip6.inreceives", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->OutForwDatagrams6, snic->OutForwDatagrams6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsOutForwDatagrams", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", snic->OutForwDatagrams6);
+	pmiPutValue("network.ip6.outforwdatagrams", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InDelivers6, snic->InDelivers6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsInDelivers", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", snic->InDelivers6);
+	pmiPutValue("network.ip6.indelivers", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->OutRequests6, snic->OutRequests6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsOutRequests", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", snic->OutRequests6);
+	pmiPutValue("network.ip6.outrequests", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->ReasmReqds6, snic->ReasmReqds6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsReasmReqds", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", snic->ReasmReqds6);
+	pmiPutValue("network.ip6.reasmreqds", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->ReasmOKs6, snic->ReasmOKs6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsReasmOKs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", snic->ReasmOKs6);
+	pmiPutValue("network.ip6.reasmoks", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InMcastPkts6, snic->InMcastPkts6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsInMcastPkts", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", snic->InMcastPkts6);
+	pmiPutValue("network.ip6.inmcastpkts", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->OutMcastPkts6, snic->OutMcastPkts6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsOutMcastPkts", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", snic->OutMcastPkts6);
+	pmiPutValue("network.ip6.outmcastpkts", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->FragOKs6, snic->FragOKs6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsOutFragOKs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", snic->FragOKs6);
+	pmiPutValue("network.ip6.fragoks", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->FragCreates6, snic->FragCreates6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsOutFragCreates", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", snic->FragCreates6);
+	pmiPutValue("network.ip6.fragcreates", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -1525,62 +1212,47 @@ __print_funct_t pcp_print_net_ip6_stats(struct activity *a, int curr, unsigned l
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_net_eip6_stats(struct activity *a, int curr, unsigned long long itv,
-					 struct record_header *record_hdr)
+__print_funct_t pcp_print_net_eip6_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_net_eip6
-		*sneic = (struct stats_net_eip6 *) a->buf[curr],
-		*sneip = (struct stats_net_eip6 *) a->buf[!curr];
+		*sneic = (struct stats_net_eip6 *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InHdrErrors6, sneic->InHdrErrors6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsInHdrErrors", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->InHdrErrors6);
+	pmiPutValue("network.ip6.inhdrerrors", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InAddrErrors6, sneic->InAddrErrors6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsInAddrErrors", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->InAddrErrors6);
+	pmiPutValue("network.ip6.inaddrerrors", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InUnknownProtos6, sneic->InUnknownProtos6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsInUnknownProtos", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->InUnknownProtos6);
+	pmiPutValue("network.ip6.inunknownprotos", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InTooBigErrors6, sneic->InTooBigErrors6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsInTooBigErrors", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->InTooBigErrors6);
+	pmiPutValue("network.ip6.intoobigerrors", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InDiscards6, sneic->InDiscards6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsInDiscards", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->InDiscards6);
+	pmiPutValue("network.ip6.indiscards", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->OutDiscards6, sneic->OutDiscards6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsOutDiscards", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->OutDiscards6);
+	pmiPutValue("network.ip6.outdiscards", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InNoRoutes6, sneic->InNoRoutes6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsInNoRoutes", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->InNoRoutes6);
+	pmiPutValue("network.ip6.innoroutes", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->OutNoRoutes6, sneic->OutNoRoutes6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsOutNoRoutes", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->OutNoRoutes6);
+	pmiPutValue("network.ip6.outnoroutes", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->ReasmFails6, sneic->ReasmFails6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsReasmFails", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->ReasmFails6);
+	pmiPutValue("network.ip6.reasmfails", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->FragFails6, sneic->FragFails6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsOutFragFails", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->FragFails6);
+	pmiPutValue("network.ip6.fragfails", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InTruncatedPkts6, sneic->InTruncatedPkts6, itv));
-	pmiPutValue("network.snmp.ip6.ipv6IfStatsInTruncatedPkts", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", sneic->InTruncatedPkts6);
+	pmiPutValue("network.ip6.intruncatedpkts", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -1591,86 +1263,65 @@ __print_funct_t pcp_print_net_eip6_stats(struct activity *a, int curr, unsigned 
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_net_icmp6_stats(struct activity *a, int curr, unsigned long long itv,
-					  struct record_header *record_hdr)
+__print_funct_t pcp_print_net_icmp6_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_net_icmp6
-		*snic = (struct stats_net_icmp6 *) a->buf[curr],
-		*snip = (struct stats_net_icmp6 *) a->buf[!curr];
+		*snic = (struct stats_net_icmp6 *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InMsgs6, snic->InMsgs6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpInMsgs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->InMsgs6);
+	pmiPutValue("network.icmp6.inmsgs", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->OutMsgs6, snic->OutMsgs6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpOutMsgs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->OutMsgs6);
+	pmiPutValue("network.icmp6.outmsgs", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InEchos6, snic->InEchos6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpInEchos", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->InEchos6);
+	pmiPutValue("network.icmp6.inechos", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InEchoReplies6, snic->InEchoReplies6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpInEchoReplies", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->InEchoReplies6);
+	pmiPutValue("network.icmp6.inechoreplies", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->OutEchoReplies6, snic->OutEchoReplies6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpOutEchoReplies", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->OutEchoReplies6);
+	pmiPutValue("network.icmp6.outechoreplies", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InGroupMembQueries6, snic->InGroupMembQueries6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpInGroupMembQueries", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->InGroupMembQueries6);
+	pmiPutValue("network.icmp6.ingroupmembqueries", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InGroupMembResponses6, snic->InGroupMembResponses6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpInGroupMembResponses", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->InGroupMembResponses6);
+	pmiPutValue("network.icmp6.ingroupmembresponses", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->OutGroupMembResponses6, snic->OutGroupMembResponses6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpOutGroupMembResponses", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->OutGroupMembResponses6);
+	pmiPutValue("network.icmp6.outgroupmembresponses", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InGroupMembReductions6, snic->InGroupMembReductions6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpInGroupMembReductions", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->InGroupMembReductions6);
+	pmiPutValue("network.icmp6.ingroupmembreductions", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->OutGroupMembReductions6, snic->OutGroupMembReductions6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpOutGroupMembReductions", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->OutGroupMembReductions6);
+	pmiPutValue("network.icmp6.outgroupmembreductions", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InRouterSolicits6, snic->InRouterSolicits6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpInRouterSolicits", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->InRouterSolicits6);
+	pmiPutValue("network.icmp6.inroutersolicits", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->OutRouterSolicits6, snic->OutRouterSolicits6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpOutRouterSolicits", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->OutRouterSolicits6);
+	pmiPutValue("network.icmp6.outroutersolicits", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InRouterAdvertisements6, snic->InRouterAdvertisements6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpInRouterAdvertisements", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->InRouterAdvertisements6);
+	pmiPutValue("network.icmp6.inrouteradvertisements", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InNeighborSolicits6, snic->InNeighborSolicits6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpInNeighborSolicits", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->InNeighborSolicits6);
+	pmiPutValue("network.icmp6.inneighborsolicits", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->OutNeighborSolicits6, snic->OutNeighborSolicits6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpOutNeighborSolicits", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->OutNeighborSolicits6);
+	pmiPutValue("network.icmp6.outneighborsolicits", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->InNeighborAdvertisements6, snic->InNeighborAdvertisements6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpInNeighborAdvertisements", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->InNeighborAdvertisements6);
+	pmiPutValue("network.icmp6.inneighboradvertisements", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snip->OutNeighborAdvertisements6, snic->OutNeighborAdvertisements6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpOutNeighborAdvertisements", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snic->OutNeighborAdvertisements6);
+	pmiPutValue("network.icmp6.outneighboradvertisements", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -1681,62 +1332,47 @@ __print_funct_t pcp_print_net_icmp6_stats(struct activity *a, int curr, unsigned
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_net_eicmp6_stats(struct activity *a, int curr, unsigned long long itv,
-					   struct record_header *record_hdr)
+__print_funct_t pcp_print_net_eicmp6_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_net_eicmp6
-		*sneic = (struct stats_net_eicmp6 *) a->buf[curr],
-		*sneip = (struct stats_net_eicmp6 *) a->buf[!curr];
+		*sneic = (struct stats_net_eicmp6 *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InErrors6, sneic->InErrors6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpInErrors", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->InErrors6);
+	pmiPutValue("network.icmp6.inerrors", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InDestUnreachs6, sneic->InDestUnreachs6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpInDestUnreachs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->InDestUnreachs6);
+	pmiPutValue("network.icmp6.indestunreachs", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->OutDestUnreachs6, sneic->OutDestUnreachs6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpOutDestUnreachs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->OutDestUnreachs6);
+	pmiPutValue("network.icmp6.outdestunreachs", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InTimeExcds6, sneic->InTimeExcds6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpInTimeExcds", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->InTimeExcds6);
+	pmiPutValue("network.icmp6.intimeexcds", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->OutTimeExcds6, sneic->OutTimeExcds6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpOutTimeExcds", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->OutTimeExcds6);
+	pmiPutValue("network.icmp6.outtimeexcds", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InParmProblems6, sneic->InParmProblems6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpInParmProblems", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->InParmProblems6);
+	pmiPutValue("network.icmp6.inparmproblems", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->OutParmProblems6, sneic->OutParmProblems6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpOutParmProblems", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->OutParmProblems6);
+	pmiPutValue("network.icmp6.outparmproblems", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InRedirects6, sneic->InRedirects6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpInRedirects", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->InRedirects6);
+	pmiPutValue("network.icmp6.inredirects", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->OutRedirects6, sneic->OutRedirects6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpOutRedirects", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->OutRedirects6);
+	pmiPutValue("network.icmp6.outredirects", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->InPktTooBigs6, sneic->InPktTooBigs6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpInPktTooBigs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->InPktTooBigs6);
+	pmiPutValue("network.icmp6.inpkttoobigs", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(sneip->OutPktTooBigs6, sneic->OutPktTooBigs6, itv));
-	pmiPutValue("network.snmp.icmp6.ipv6IfIcmpOutPktTooBigs", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sneic->OutPktTooBigs6);
+	pmiPutValue("network.icmp6.outpkttoobigs", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -1747,34 +1383,26 @@ __print_funct_t pcp_print_net_eicmp6_stats(struct activity *a, int curr, unsigne
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_net_udp6_stats(struct activity *a, int curr, unsigned long long itv,
-					 struct record_header *record_hdr)
+__print_funct_t pcp_print_net_udp6_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_net_udp6
-		*snuc = (struct stats_net_udp6 *) a->buf[curr],
-		*snup = (struct stats_net_udp6 *) a->buf[!curr];
+		*snuc = (struct stats_net_udp6 *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snup->InDatagrams6, snuc->InDatagrams6, itv));
-	pmiPutValue("network.snmp.udp6.udpInDatagrams", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snuc->InDatagrams6);
+	pmiPutValue("network.udp6.indatagrams", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snup->OutDatagrams6, snuc->OutDatagrams6, itv));
-	pmiPutValue("network.snmp.udp6.udpOutDatagrams", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snuc->OutDatagrams6);
+	pmiPutValue("network.udp6.outdatagrams", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snup->NoPorts6, snuc->NoPorts6, itv));
-	pmiPutValue("network.snmp.udp6.udpNoPorts", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snuc->NoPorts6);
+	pmiPutValue("network.udp6.noports", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		S_VALUE(snup->InErrors6, snuc->InErrors6, itv));
-	pmiPutValue("network.snmp.udp6.udpInErrors", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long) snuc->InErrors6);
+	pmiPutValue("network.udp6.inerrors", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -1785,18 +1413,14 @@ __print_funct_t pcp_print_net_udp6_stats(struct activity *a, int curr, unsigned 
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_pwr_cpufreq_stats(struct activity *a, int curr, unsigned long long itv,
-					    struct record_header *record_hdr)
+__print_funct_t pcp_print_pwr_cpufreq_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	int i;
 	struct stats_pwr_cpufreq *spc;
 	char buf[64], cpuno[64];
-	char *str;
 
 	for (i = 0; (i < a->nr[curr]) && (i < a->bitmap->b_size + 1); i++) {
 
@@ -1809,15 +1433,14 @@ __print_funct_t pcp_print_pwr_cpufreq_stats(struct activity *a, int curr, unsign
 
 		if (!i) {
 			/* This is CPU "all" */
-			str = NULL;
+			continue;
 		}
 		else {
 			sprintf(cpuno, "cpu%d", i - 1);
-			str = cpuno;
 		}
 
 		snprintf(buf, sizeof(buf), "%f", ((double) spc->cpufreq) / 100);
-		pmiPutValue(i ? "kernel.percpu.cpu.freqMHz" : "kernel.all.cpu.freqMHz", str, buf);
+		pmiPutValue("hinv.cpu.clock", cpuno, buf);
 	}
 #endif	/* HAVE_PCP */
 }
@@ -1829,12 +1452,9 @@ __print_funct_t pcp_print_pwr_cpufreq_stats(struct activity *a, int curr, unsign
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_pwr_fan_stats(struct activity *a, int curr, unsigned long long itv,
-					struct record_header *record_hdr)
+__print_funct_t pcp_print_pwr_fan_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	int i;
@@ -1854,8 +1474,7 @@ __print_funct_t pcp_print_pwr_fan_stats(struct activity *a, int curr, unsigned l
 			 (unsigned long long) (spc->rpm - spc->rpm_min));
 		pmiPutValue("power.fan.drpm", instance, buf);
 
-		snprintf(buf, sizeof(buf), "%s",
-			spc->device);
+		snprintf(buf, sizeof(buf), "%s", spc->device);
 		pmiPutValue("power.fan.device", instance, buf);
 	}
 #endif	/* HAVE_PCP */
@@ -1868,12 +1487,9 @@ __print_funct_t pcp_print_pwr_fan_stats(struct activity *a, int curr, unsigned l
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_pwr_temp_stats(struct activity *a, int curr, unsigned long long itv,
-					 struct record_header *record_hdr)
+__print_funct_t pcp_print_pwr_temp_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	int i;
@@ -1885,15 +1501,14 @@ __print_funct_t pcp_print_pwr_temp_stats(struct activity *a, int curr, unsigned 
 		spc = (struct stats_pwr_temp *) ((char *) a->buf[curr] + i * a->msize);
 		sprintf(instance, "temp%d", i + 1);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 spc->temp);
-		pmiPutValue("power.temp.degC", instance, buf);
+		snprintf(buf, sizeof(buf), "%f", spc->temp);
+		pmiPutValue("power.temp.celcius", instance, buf);
 
 		snprintf(buf, sizeof(buf), "%f",
 			 (spc->temp_max - spc->temp_min) ?
 			 (spc->temp - spc->temp_min) / (spc->temp_max - spc->temp_min) * 100 :
 			 0.0);
-		pmiPutValue("power.temp.temp_pct", instance, buf);
+		pmiPutValue("power.temp.percent", instance, buf);
 
 		snprintf(buf, sizeof(buf), "%s",
 			spc->device);
@@ -1913,8 +1528,7 @@ __print_funct_t pcp_print_pwr_temp_stats(struct activity *a, int curr, unsigned 
  * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_pwr_in_stats(struct activity *a, int curr, unsigned long long itv,
-				       struct record_header *record_hdr)
+__print_funct_t pcp_print_pwr_in_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	int i;
@@ -1928,13 +1542,13 @@ __print_funct_t pcp_print_pwr_in_stats(struct activity *a, int curr, unsigned lo
 
 		snprintf(buf, sizeof(buf), "%f",
 			 spc->in);
-		pmiPutValue("power.in.inV", instance, buf);
+		pmiPutValue("power.in.voltage", instance, buf);
 
 		snprintf(buf, sizeof(buf), "%f",
 			 (spc->in_max - spc->in_min) ?
 			 (spc->in - spc->in_min) / (spc->in_max - spc->in_min) * 100 :
 			 0.0);
-		pmiPutValue("power.in.in_pct", instance, buf);
+		pmiPutValue("power.in.percent", instance, buf);
 
 		snprintf(buf, sizeof(buf), "%s",
 			spc->device);
@@ -1954,28 +1568,24 @@ __print_funct_t pcp_print_pwr_in_stats(struct activity *a, int curr, unsigned lo
  * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_huge_stats(struct activity *a, int curr, unsigned long long itv,
-				     struct record_header *record_hdr)
+__print_funct_t pcp_print_huge_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_huge
 		*smc = (struct stats_huge *) a->buf[curr];
 
-	snprintf(buf, sizeof(buf), "%llu", smc->frhkb);
-	pmiPutValue("mem.huge.free", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", smc->frhkb * 1024);
+	pmiPutValue("mem.util.hugepagesFreeBytes", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%llu", smc->tlhkb - smc->frhkb);
-	pmiPutValue("mem.huge.used", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", smc->tlhkb * 1024);
+	pmiPutValue("mem.util.hugepagesTotalBytes", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%f", smc->tlhkb ? SP_VALUE(smc->frhkb, smc->tlhkb, smc->tlhkb) : 0.0);
-	pmiPutValue("mem.huge.used_pct", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", smc->rsvdhkb * 1024);
+	pmiPutValue("mem.util.hugepagesRsvdBytes", NULL, buf);
 
-	snprintf(buf, sizeof(buf), "%llu", smc->rsvdhkb);
-	pmiPutValue("mem.huge.reserved", NULL, buf);
-
-	snprintf(buf, sizeof(buf), "%llu", smc->surphkb);
-	pmiPutValue("mem.huge.surplus", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", smc->surphkb * 1024);
+	pmiPutValue("mem.util.hugepagesSurpBytes", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -1986,12 +1596,9 @@ __print_funct_t pcp_print_huge_stats(struct activity *a, int curr, unsigned long
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_pwr_usb_stats(struct activity *a, int curr, unsigned long long itv,
-					struct record_header *record_hdr)
+__print_funct_t pcp_print_pwr_usb_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	int i;
@@ -2031,12 +1638,9 @@ __print_funct_t pcp_print_pwr_usb_stats(struct activity *a, int curr, unsigned l
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_filesystem_stats(struct activity *a, int curr, unsigned long long itv,
-					   struct record_header *record_hdr)
+__print_funct_t pcp_print_filesystem_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	int i;
@@ -2057,36 +1661,32 @@ __print_funct_t pcp_print_filesystem_stats(struct activity *a, int curr, unsigne
 				continue;
 		}
 
-		snprintf(buf, sizeof(buf), "%.0f",
-			 (double) sfc->f_bfree / 1024 / 1024);
-		pmiPutValue("fs.util.fsfree", dev_name, buf);
+		snprintf(buf, sizeof(buf), "%llu", sfc->f_blocks / 1024);
+		pmiPutValue("filesys.capacity", dev_name, buf);
 
-		snprintf(buf, sizeof(buf), "%.0f",
-			 (double) (sfc->f_blocks - sfc->f_bfree) / 1024 / 1024);
-		pmiPutValue("fs.util.fsused", dev_name, buf);
+		snprintf(buf, sizeof(buf), "%llu", sfc->f_bfree / 1024);
+		pmiPutValue("filesys.free", dev_name, buf);
+
+		snprintf(buf, sizeof(buf), "%llu",
+			 (sfc->f_blocks - sfc->f_bfree) / 1024);
+		pmiPutValue("filesys.used", dev_name, buf);
 
 		snprintf(buf, sizeof(buf), "%f",
 			 sfc->f_blocks ? SP_VALUE(sfc->f_bfree, sfc->f_blocks, sfc->f_blocks)
 				       : 0.0);
-		pmiPutValue("fs.util.fsused_pct", dev_name, buf);
+		pmiPutValue("filesys.full", dev_name, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 sfc->f_blocks ? SP_VALUE(sfc->f_bavail, sfc->f_blocks, sfc->f_blocks)
-				       : 0.0);
-		pmiPutValue("fs.util.ufsused_pct", dev_name, buf);
+		snprintf(buf, sizeof(buf), "%llu", sfc->f_files);
+		pmiPutValue("filesys.maxfiles", dev_name, buf);
 
-		snprintf(buf, sizeof(buf), "%llu",
-			 sfc->f_ffree);
-		pmiPutValue("fs.util.ifree", dev_name, buf);
+		snprintf(buf, sizeof(buf), "%llu", sfc->f_ffree);
+		pmiPutValue("filesys.freefiles", dev_name, buf);
 
-		snprintf(buf, sizeof(buf), "%llu",
-			 sfc->f_files - sfc->f_ffree);
-		pmiPutValue("fs.util.iused", dev_name, buf);
+		snprintf(buf, sizeof(buf), "%llu", sfc->f_files - sfc->f_ffree);
+		pmiPutValue("filesys.usedfiles", dev_name, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 sfc->f_files ? SP_VALUE(sfc->f_ffree, sfc->f_files, sfc->f_files)
-				      : 0.0);
-		pmiPutValue("fs.util.iused_pct", dev_name, buf);
+		snprintf(buf, sizeof(buf), "%llu", sfc->f_bavail / 1024);
+		pmiPutValue("filesys.avail", dev_name, buf);
 	}
 #endif	/* HAVE_PCP */
 }
@@ -2098,19 +1698,15 @@ __print_funct_t pcp_print_filesystem_stats(struct activity *a, int curr, unsigne
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_softnet_stats(struct activity *a, int curr, unsigned long long itv,
-					struct record_header *record_hdr)
+__print_funct_t pcp_print_softnet_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	int i;
-	struct stats_softnet *ssnc, *ssnp;
+	struct stats_softnet *ssnc;
 	char buf[64], cpuno[64];
 	unsigned char offline_cpu_bitmap[BITMAP_SIZE(NR_CPUS)] = {0};
-	char *str;
 
 	/*
 	 * @nr[curr] cannot normally be greater than @nr_ini.
@@ -2132,36 +1728,29 @@ __print_funct_t pcp_print_softnet_stats(struct activity *a, int curr, unsigned l
 			continue;
 
                 ssnc = (struct stats_softnet *) ((char *) a->buf[curr]  + i * a->msize);
-                ssnp = (struct stats_softnet *) ((char *) a->buf[!curr] + i * a->msize);
 
 		if (!i) {
 			/* This is CPU "all" */
-			str = NULL;
+			continue;
 		}
 		else {
 			sprintf(cpuno, "cpu%d", i - 1);
-			str = cpuno;
 		}
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(ssnp->processed, ssnc->processed, itv));
-		pmiPutValue(i ? "network.percpu.soft.processed" : "network.all.soft.processed", str, buf);
+		snprintf(buf, sizeof(buf), "%llu", (unsigned long long) ssnc->processed);
+		pmiPutValue("network.softnet.percpu.processed", cpuno, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(ssnp->dropped, ssnc->dropped, itv));
-		pmiPutValue(i ? "network.percpu.soft.dropped" : "network.all.soft.dropped", str, buf);
+		snprintf(buf, sizeof(buf), "%llu", (unsigned long long) ssnc->dropped);
+		pmiPutValue("network.softnet.percpu.dropped", cpuno, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(ssnp->time_squeeze, ssnc->time_squeeze, itv));
-		pmiPutValue(i ? "network.percpu.soft.time_squeeze" : "network.all.soft.time_squeeze", str, buf);
+		snprintf(buf, sizeof(buf), "%llu", (unsigned long long) ssnc->time_squeeze);
+		pmiPutValue("network.softnet.percpu.time_squeeze", cpuno, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(ssnp->received_rps, ssnc->received_rps, itv));
-		pmiPutValue(i ? "network.percpu.soft.received_rps" : "network.all.soft.received_rps", str, buf);
+		snprintf(buf, sizeof(buf), "%llu", (unsigned long long) ssnc->received_rps);
+		pmiPutValue("network.softnet.percpu.received_rps", cpuno, buf);
 
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(ssnp->flow_limit, ssnc->flow_limit, itv));
-		pmiPutValue(i ? "network.percpu.soft.flow_limit" : "network.all.soft.flow_limit", str, buf);
+		snprintf(buf, sizeof(buf), "%llu", (unsigned long long) ssnc->flow_limit);
+		pmiPutValue("network.softnet.percpu.flow_limit", cpuno, buf);
 	}
 #endif	/* HAVE_PCP */
 }
@@ -2173,68 +1762,30 @@ __print_funct_t pcp_print_softnet_stats(struct activity *a, int curr, unsigned l
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_fchost_stats(struct activity *a, int curr, unsigned long long itv,
-				       struct record_header *record_hdr)
+__print_funct_t pcp_print_fchost_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
-	int i, j, j0, found;
-	struct stats_fchost *sfcc, *sfcp, sfczero;
+	int i;
+	struct stats_fchost *sfcc;
 	char buf[64];
-
-	memset(&sfczero, 0, sizeof(struct stats_fchost));
 
 	for (i = 0; i < a->nr[curr]; i++) {
 
-		found = FALSE;
 		sfcc = (struct stats_fchost *) ((char *) a->buf[curr] + i * a->msize);
 
-		if (a->nr[!curr] > 0) {
-			/* Look for corresponding structure in previous iteration */
-			j = i;
+		snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sfcc->f_rxframes);
+		pmiPutValue("fchost.in.frames", sfcc->fchost_name, buf);
 
-			if (j >= a->nr[!curr]) {
-				j = a->nr[!curr] - 1;
-			}
+		snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sfcc->f_txframes);
+		pmiPutValue("fchost.out.frames", sfcc->fchost_name, buf);
 
-			j0 = j;
+		snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sfcc->f_rxwords * 4);
+		pmiPutValue("fchost.in.bytes", sfcc->fchost_name, buf);
 
-			do {
-				sfcp = (struct stats_fchost *) ((char *) a->buf[!curr] + j * a->msize);
-				if (!strcmp(sfcc->fchost_name, sfcp->fchost_name)) {
-					found = TRUE;
-					break;
-				}
-				if (++j >= a->nr[!curr]) {
-					j = 0;
-				}
-			}
-			while (j != j0);
-		}
-
-		if (!found) {
-			/* This is a newly registered host */
-			sfcp = &sfczero;
-		}
-
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(sfcp->f_rxframes, sfcc->f_rxframes, itv));
-		pmiPutValue("network.fchost.in.frame", sfcc->fchost_name, buf);
-
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(sfcp->f_txframes, sfcc->f_txframes, itv));
-		pmiPutValue("network.fchost.out.frame", sfcc->fchost_name, buf);
-
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(sfcp->f_rxwords, sfcc->f_rxwords, itv));
-		pmiPutValue("network.fchost.in.word", sfcc->fchost_name, buf);
-
-		snprintf(buf, sizeof(buf), "%f",
-			 S_VALUE(sfcp->f_txwords, sfcc->f_txwords, itv));
-		pmiPutValue("network.fchost.out.word", sfcc->fchost_name, buf);
+		snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sfcc->f_txwords * 4);
+		pmiPutValue("fchost.out.bytes", sfcc->fchost_name, buf);
 	}
 #endif	/* HAVE_PCP */
 }
@@ -2246,31 +1797,26 @@ __print_funct_t pcp_print_fchost_stats(struct activity *a, int curr, unsigned lo
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_psicpu_stats(struct activity *a, int curr, unsigned long long itv,
-				       struct record_header *record_hdr)
+__print_funct_t pcp_print_psicpu_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_psi_cpu
-		*psic = (struct stats_psi_cpu *) a->buf[curr],
-		*psip = (struct stats_psi_cpu *) a->buf[!curr];
+		*psic = (struct stats_psi_cpu *) a->buf[curr];
 
 	snprintf(buf, sizeof(buf), "%f", (double) psic->some_acpu_10 / 100);
-	pmiPutValue("psi.cpu.some.trends", "10 sec", buf);
+	pmiPutValue("kernel.all.pressure.cpu.some.avg", "10 second", buf);
 
 	snprintf(buf, sizeof(buf), "%f", (double) psic->some_acpu_60 / 100);
-	pmiPutValue("psi.cpu.some.trends", "60 sec", buf);
+	pmiPutValue("kernel.all.pressure.cpu.some.avg", "1 minute", buf);
 
 	snprintf(buf, sizeof(buf), "%f", (double) psic->some_acpu_300 / 100);
-	pmiPutValue("psi.cpu.some.trends", "300 sec", buf);
+	pmiPutValue("kernel.all.pressure.cpu.some.avg", "5 minute", buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 ((double) psic->some_cpu_total - psip->some_cpu_total) / (100 * itv));
-	pmiPutValue("psi.cpu.some.avg", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", psic->some_cpu_total);
+	pmiPutValue("kernel.all.pressure.cpu.some.total", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -2281,44 +1827,38 @@ __print_funct_t pcp_print_psicpu_stats(struct activity *a, int curr, unsigned lo
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_psiio_stats(struct activity *a, int curr, unsigned long long itv,
-				      struct record_header *record_hdr)
+__print_funct_t pcp_print_psiio_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_psi_io
-		*psic = (struct stats_psi_io *) a->buf[curr],
-		*psip = (struct stats_psi_io *) a->buf[!curr];
+		*psic = (struct stats_psi_io *) a->buf[curr];
 
 	snprintf(buf, sizeof(buf), "%f", (double) psic->some_aio_10 / 100);
-	pmiPutValue("psi.io.some.trends", "10 sec", buf);
+	pmiPutValue("kernel.all.pressure.io.some.avg", "10 second", buf);
 
 	snprintf(buf, sizeof(buf), "%f", (double) psic->some_aio_60 / 100);
-	pmiPutValue("psi.io.some.trends", "60 sec", buf);
+	pmiPutValue("kernel.all.pressure.io.some.avg", "1 minute", buf);
 
 	snprintf(buf, sizeof(buf), "%f", (double) psic->some_aio_300 / 100);
-	pmiPutValue("psi.io.some.trends", "300 sec", buf);
+	pmiPutValue("kernel.all.pressure.io.some.avg", "5 minute", buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 ((double) psic->some_io_total - psip->some_io_total) / (100 * itv));
-	pmiPutValue("psi.io.some.avg", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", psic->some_io_total);
+	pmiPutValue("kernel.all.pressure.io.some.total", NULL, buf);
 
 	snprintf(buf, sizeof(buf), "%f", (double) psic->full_aio_10 / 100);
-	pmiPutValue("psi.io.full.trends", "10 sec", buf);
+	pmiPutValue("kernel.all.pressure.io.full.avg", "10 second", buf);
 
 	snprintf(buf, sizeof(buf), "%f", (double) psic->full_aio_60 / 100);
-	pmiPutValue("psi.io.full.trends", "60 sec", buf);
+	pmiPutValue("kernel.all.pressure.io.full.avg", "1 minute", buf);
 
 	snprintf(buf, sizeof(buf), "%f", (double) psic->full_aio_300 / 100);
-	pmiPutValue("psi.io.full.trends", "300 sec", buf);
+	pmiPutValue("kernel.all.pressure.io.full.avg", "5 minute", buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 ((double) psic->full_io_total - psip->full_io_total) / (100 * itv));
-	pmiPutValue("psi.io.full.avg", NULL, buf);
+	snprintf(buf, sizeof(buf), "%f", (double) psic->full_io_total);
+	pmiPutValue("kernel.all.pressure.io.full.total", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -2329,43 +1869,37 @@ __print_funct_t pcp_print_psiio_stats(struct activity *a, int curr, unsigned lon
  * IN:
  * @a		Activity structure with statistics.
  * @curr	Index in array for current sample statistics.
- * @itv		Interval of time in 1/100th of a second.
- * @record_hdr	Record header for current sample.
  ***************************************************************************
  */
-__print_funct_t pcp_print_psimem_stats(struct activity *a, int curr, unsigned long long itv,
-				       struct record_header *record_hdr)
+__print_funct_t pcp_print_psimem_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	char buf[64];
 	struct stats_psi_mem
-		*psic = (struct stats_psi_mem *) a->buf[curr],
-		*psip = (struct stats_psi_mem *) a->buf[!curr];
+		*psic = (struct stats_psi_mem *) a->buf[curr];
 
 	snprintf(buf, sizeof(buf), "%f", (double) psic->some_amem_10 / 100);
-	pmiPutValue("psi.mem.some.trends", "10 sec", buf);
+	pmiPutValue("kernel.all.pressure.memory.some.avg", "10 second", buf);
 
 	snprintf(buf, sizeof(buf), "%f", (double) psic->some_amem_60 / 100);
-	pmiPutValue("psi.mem.some.trends", "60 sec", buf);
+	pmiPutValue("kernel.all.pressure.memory.some.avg", "1 minute", buf);
 
 	snprintf(buf, sizeof(buf), "%f", (double) psic->some_amem_300 / 100);
-	pmiPutValue("psi.mem.some.trends", "300 sec", buf);
+	pmiPutValue("kernel.all.pressure.memory.some.avg", "5 minute", buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 ((double) psic->some_mem_total - psip->some_mem_total) / (100 * itv));
-	pmiPutValue("psi.mem.some.avg", NULL, buf);
+	snprintf(buf, sizeof(buf), "%llu", psic->some_mem_total);
+	pmiPutValue("kernel.all.pressure.memory.some.total", NULL, buf);
 
 	snprintf(buf, sizeof(buf), "%f", (double) psic->full_amem_10 / 100);
-	pmiPutValue("psi.mem.full.trends", "10 sec", buf);
+	pmiPutValue("kernel.all.pressure.memory.full.avg", "10 second", buf);
 
 	snprintf(buf, sizeof(buf), "%f", (double) psic->full_amem_60 / 100);
-	pmiPutValue("psi.mem.full.trends", "60 sec", buf);
+	pmiPutValue("kernel.all.pressure.memory.full.avg", "1 minute", buf);
 
 	snprintf(buf, sizeof(buf), "%f", (double) psic->full_amem_300 / 100);
-	pmiPutValue("psi.mem.full.trends", "300 sec", buf);
+	pmiPutValue("kernel.all.pressure.memory.full.avg", "5 minute", buf);
 
-	snprintf(buf, sizeof(buf), "%f",
-		 ((double) psic->full_mem_total - psip->full_mem_total) / (100 * itv));
-	pmiPutValue("psi.mem.full.avg", NULL, buf);
+	snprintf(buf, sizeof(buf), "%f", (double) psic->full_mem_total);
+	pmiPutValue("kernel.all.pressure.memory.full.total", NULL, buf);
 #endif	/* HAVE_PCP */
 }

--- a/pcp_stats.c
+++ b/pcp_stats.c
@@ -185,7 +185,7 @@ __print_funct_t pcp_print_pcsw_stats(struct activity *a, int curr)
 	pmiPutValue("kernel.all.pswitch", NULL, buf);
 
 	snprintf(buf, sizeof(buf), "%lu", spc->processes);
-	pmiPutValue("kernel.all.nprocs", NULL, buf);
+	pmiPutValue("kernel.all.sysfork", NULL, buf);
 #endif	/* HAVE_PCP */
 }
 
@@ -351,6 +351,12 @@ __print_funct_t pcp_print_memory_stats(struct activity *a, int curr)
 		*smc = (struct stats_memory *) a->buf[curr];
 
 	if (DISPLAY_MEMORY(a->opt_flags)) {
+
+		snprintf(buf, sizeof(buf), "%lu", (unsigned long)(smc->tlmkb >> 10));
+		pmiPutValue("hinv.physmem", NULL, buf);
+
+		snprintf(buf, sizeof(buf), "%llu", smc->tlmkb);
+		pmiPutValue("mem.physmem", NULL, buf);
 
 		snprintf(buf, sizeof(buf), "%llu", smc->frmkb);
 		pmiPutValue("mem.util.free", NULL, buf);
@@ -526,10 +532,10 @@ __print_funct_t pcp_print_disk_stats(struct activity *a, int curr)
 		snprintf(buf, sizeof(buf), "%llu", (unsigned long long) sdc->dc_sect / 2);
 		pmiPutValue("disk.dev.discard_bytes", dev_name, buf);
 
-		snprintf(buf, sizeof(buf), "%lu", (unsigned long) sdc->rq_ticks + sdc->wr_ticks);
+		snprintf(buf, sizeof(buf), "%lu", (unsigned long) sdc->rd_ticks + sdc->wr_ticks);
 		pmiPutValue("disk.dev.total_rawactive", dev_name, buf);
 
-		snprintf(buf, sizeof(buf), "%lu", (unsigned long) sdc->rq_ticks);
+		snprintf(buf, sizeof(buf), "%lu", (unsigned long) sdc->rd_ticks);
 		pmiPutValue("disk.dev.read_rawactive", dev_name, buf);
 
 		snprintf(buf, sizeof(buf), "%lu", (unsigned long) sdc->wr_ticks);
@@ -1502,7 +1508,7 @@ __print_funct_t pcp_print_pwr_temp_stats(struct activity *a, int curr)
 		sprintf(instance, "temp%d", i + 1);
 
 		snprintf(buf, sizeof(buf), "%f", spc->temp);
-		pmiPutValue("power.temp.celcius", instance, buf);
+		pmiPutValue("power.temp.celsius", instance, buf);
 
 		snprintf(buf, sizeof(buf), "%f",
 			 (spc->temp_max - spc->temp_min) ?

--- a/pcp_stats.h
+++ b/pcp_stats.h
@@ -14,86 +14,86 @@
 
 /* Functions used to display statistics in PCP format */
 __print_funct_t pcp_print_cpu_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_pcsw_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_irq_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_swap_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_paging_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_io_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_memory_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_ktables_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_queue_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_disk_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_serial_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_net_dev_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_net_edev_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_net_nfs_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_net_nfsd_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_net_sock_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_net_ip_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_net_eip_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_net_icmp_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_net_eicmp_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_net_tcp_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_net_etcp_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_net_udp_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_net_sock6_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_net_ip6_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_net_eip6_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_net_icmp6_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_net_eicmp6_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_net_udp6_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_pwr_cpufreq_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_pwr_fan_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_pwr_temp_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_pwr_in_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_huge_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_pwr_usb_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_filesystem_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_fchost_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_softnet_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_psicpu_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_psiio_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 __print_funct_t pcp_print_psimem_stats
-	(struct activity *, int, unsigned long long, struct record_header *);
+	(struct activity *, int);
 
 #endif /* _PCP_STATS_H */

--- a/sa.h
+++ b/sa.h
@@ -979,8 +979,7 @@ struct activity {
 	/*
 	 * This function is used by sadf to display activity statistics in PCP format.
 	 */
-	__print_funct_t (*f_pcp_print) (struct activity *, int, unsigned long long,
-					struct record_header *);
+	__print_funct_t (*f_pcp_print) (struct activity *, int);
 	/*
 	 * This function is used by sadf to count the number of new items in current
 	 * sample and add them to the linked list @item_list.

--- a/sadf.c
+++ b/sadf.c
@@ -764,7 +764,7 @@ int generic_write_stats(int curr, int use_tm_start, int use_tm_end, int reset,
 			else if (format == F_PCP_OUTPUT) {
 				/* PCP archive */
 				if (*act[i]->f_pcp_print) {
-					(*act[i]->f_pcp_print)(act[i], curr, itv, &record_hdr[curr]);
+					(*act[i]->f_pcp_print)(act[i], curr);
 				}
 			}
 

--- a/sadf_misc.c
+++ b/sadf_misc.c
@@ -1434,11 +1434,29 @@ __printf_funct_t print_pcp_header(void *parm, int action, char *dfile,
 
 		/* Save number of CPU in PCP archive */
 		pmiAddMetric("hinv.ncpu",
-			     PM_IN_NULL, PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_DISCRETE,
-			     pmiUnits(0, 0, 1, 0, 0, PM_COUNT_ONE));
+			     pmiID(60, 0, 32), PM_TYPE_U32, PM_INDOM_NULL,
+			     PM_SEM_DISCRETE, pmiUnits(0, 0, 0, 0, 0, 0));
 		snprintf(buf, sizeof(buf), "%u",
 			 file_hdr->sa_cpu_nr > 1 ? file_hdr->sa_cpu_nr - 1 : 1);
 		pmiPutValue("hinv.ncpu", NULL, buf);
+
+		/* Save uname(2) information */
+		pmiAddMetric("kernel.uname.release",
+			     pmiID(60, 12, 0), PM_TYPE_STRING, PM_INDOM_NULL,
+			     PM_SEM_DISCRETE, pmiUnits(0, 0, 0, 0, 0, 0));
+		pmiPutValue("kernel.uname.release", NULL, file_hdr->sa_release);
+		pmiAddMetric("kernel.uname.sysname",
+			     pmiID(60, 12, 2), PM_TYPE_STRING, PM_INDOM_NULL,
+			     PM_SEM_DISCRETE, pmiUnits(0, 0, 0, 0, 0, 0));
+		pmiPutValue("kernel.uname.sysname", NULL, file_hdr->sa_sysname);
+		pmiAddMetric("kernel.uname.machine",
+			     pmiID(60, 12, 3), PM_TYPE_STRING, PM_INDOM_NULL,
+			     PM_SEM_DISCRETE, pmiUnits(0, 0, 0, 0, 0, 0));
+		pmiPutValue("kernel.uname.machine", NULL, file_hdr->sa_machine);
+		pmiAddMetric("kernel.uname.nodename",
+			     pmiID(60, 12, 4), PM_TYPE_STRING, PM_INDOM_NULL,
+			     PM_SEM_DISCRETE, pmiUnits(0, 0, 0, 0, 0, 0));
+		pmiPutValue("kernel.uname.nodename", NULL, file_hdr->sa_nodename);
 	}
 
 	if (action & F_END) {


### PR DESCRIPTION
When operating with the -l option in sadf we want to generate PCP
archives that match the PCP archives generated by pmlogger(1) as
closely as possible.  The advantage to doing this is that the live
and historical modes to the PCP tools become interchangeable; i.e.
pmchart views, pmie rules, grafana-pcp dashboards, and so on, all
expect metrics named according to the PCP conventions.

The reason sadf is not already doing this (AIUI), is that it was
originally based on the sar2pcp(1) utility.  This tool (which we
plan to deprecate in PCP in favour of the sysstat functionality)
used the rate-converted counter values as its starting point and
not the raw counters we have access to within sysstat itself.

I've audited all of the metrics being added to PCP archives with
the sadf -l option now, and all now align with current metadata
in PCP.  I've also added a few uname(2) metrics from the record
header (in the way hinv.ncpu was already being used).