### PR TITLE
*: use `grep -E` instead of `egrep`

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -559,8 +559,8 @@ install_base: all sa1 sa2 sysstat.sysconfig install_man install_nls
 	mkdir -p $(DESTDIR)$(SA_LIB_DIR)
 	mkdir -p $(DESTDIR)$(SA_DIR)
 ifeq ($(CLEAN_SA_DIR),y)
-	find $(DESTDIR)$(SA_DIR) -type f | egrep "/sar?[0-9]{2,8}(\.(Z|gz|bz2|xz|lz|lzo))?$$" | xargs rm -f
-	find $(DESTDIR)$(SA_DIR) -type f | egrep "/sar?[0-9]{2,8}$$" | xargs rm -f
+	find $(DESTDIR)$(SA_DIR) -type f | grep -E "/sar?[0-9]{2,8}(\.(Z|gz|bz2|xz|lz|lzo))?$$" | xargs rm -f
+	find $(DESTDIR)$(SA_DIR) -type f | grep -E "/sar?[0-9]{2,8}$$" | xargs rm -f
 endif
 	mkdir -p $(DESTDIR)$(BIN_DIR)
 	mkdir -p $(DESTDIR)$(DOC_DIR)
@@ -795,9 +795,9 @@ endif
 
 TESTDIR="tests"
 TESTRUN="/bin/sh"
-TESTLIST:=$(shell ls $(TESTDIR) | egrep '^[0-9]+$$' | sort -n)
+TESTLIST:=$(shell ls $(TESTDIR) | grep -E '^[0-9]+$$' | sort -n)
 EXTRADIR="tests/extra"
-EXTRALIST:=$(shell ls $(EXTRADIR) | egrep '^[0-9]+$$' | sort -n)
+EXTRALIST:=$(shell ls $(EXTRADIR) | grep -E '^[0-9]+$$' | sort -n)
 
 testcomp: tests/ini/inisar sa32bit
 

--- a/contrib/sargraph/sargraph
+++ b/contrib/sargraph/sargraph
@@ -404,7 +404,7 @@ EOF
 
 
 SA_FILES=`$FIND "$SA_DIR" -type f -printf '%T@,%p\n' \
-    | egrep "$SA_REGEX" | $SORT -n -r | $CUT -d, -f2`
+    | grep -E "$SA_REGEX" | $SORT -n -r | $CUT -d, -f2`
 
 # Main loop
 

--- a/contrib/sargraph/sargraph2
+++ b/contrib/sargraph/sargraph2
@@ -130,7 +130,7 @@ decompress_copy()
 cpu_gnuplot()                             # %iowait,%user,%nice,%system,%steal
 {
     # First make sure that the columns are where we expect them to be
-    HEADER=`egrep -v ';LINUX-RESTART|;COM' $2 | head -1 | cut -d ';' -f 5-10`
+    HEADER=`grep -Ev ';LINUX-RESTART|;COM' $2 | head -1 | cut -d ';' -f 5-10`
     EXPECTED="%user;%nice;%system;%iowait;%steal;%idle"
     if [ "$HEADER" != "$EXPECTED" ]
     then
@@ -159,14 +159,14 @@ EOF
 mem_gnuplot()                    # free,used,buffers,cached / %commit,%swpused
 {
     # First make sure that the columns are where we expect them to be
-    HEADER=`egrep -v ';LINUX-RESTART|;COM' $2 | head -1 | cut -d ';' -f 4-10`
+    HEADER=`grep -Ev ';LINUX-RESTART|;COM' $2 | head -1 | cut -d ';' -f 4-10`
     EXPECTED="kbmemfree;kbmemused;%memused;kbbuffers;kbcached;kbcommit;%commit"
     if [ "$HEADER" != "$EXPECTED" ]
     then
         echo "Headers not in right order: $HEADER" 1>&2
         exit 1
     fi
-    HEADER=`egrep -v ';LINUX-RESTART|;COM' $3 | head -1 | cut -d ';' -f 4-6`
+    HEADER=`grep -Ev ';LINUX-RESTART|;COM' $3 | head -1 | cut -d ';' -f 4-6`
     EXPECTED="kbswpfree;kbswpused;%swpused"
     if [ "$HEADER" != "$EXPECTED" ]
     then
@@ -201,7 +201,7 @@ EOF
 io_gnuplot()                                      # %KBr/s,KBw/s / rIOPS,wIOPS
 {
     # First make sure that the columns are where we expect them to be
-    HEADER=`egrep -v ';LINUX-RESTART|;COM' $2 | head -1 | cut -d ';' -f 4-8`
+    HEADER=`grep -Ev ';LINUX-RESTART|;COM' $2 | head -1 | cut -d ';' -f 4-8`
     EXPECTED="tps;rtps;wtps;bread/s;bwrtn/s"
     if [ "$HEADER" != "$EXPECTED" ]
     then

--- a/sa2.in
+++ b/sa2.in
@@ -67,13 +67,13 @@ fi
 SAFILES_REGEX='/sar?[0-9]{2,8}(\.(Z|gz|bz2|xz|lz|lzo))?$'
 
 find "${SA_DIR}" -type f -mtime +${HISTORY} \
-	| egrep "${SAFILES_REGEX}" \
+	| grep -E "${SAFILES_REGEX}" \
 	| xargs   rm -f
 
 UNCOMPRESSED_SAFILES_REGEX='/sar?[0-9]{2,8}$'
 
 find "${SA_DIR}" -type f -mtime +${COMPRESSAFTER} \
-	| egrep "${UNCOMPRESSED_SAFILES_REGEX}" \
+	| grep -E "${UNCOMPRESSED_SAFILES_REGEX}" \
 	| xargs -r "${ZIP}" > /dev/null
 
 exit 0


### PR DESCRIPTION
`egrep` has been deprecated in GNU grep since 2007, and in current post
3.7 Git it has been made to emit obsolescence warnings:
https://git.savannah.gnu.org/cgit/grep.git/commit/?id=a9515624709865d480e3142fd959bccd1c9372d1