### PR TITLE
A_IRQ: sadf: Update PCP interface for per-CPU interrupts statistics

### DIFF
--- a/pcp_stats.c
+++ b/pcp_stats.c
@@ -202,7 +202,7 @@ __print_funct_t pcp_print_irq_stats(struct activity *a, int curr)
 {
 #ifdef HAVE_PCP
 	int i, c;
-	char buf[64], cpuno[64], name[64];
+	char buf[64], name[64];
 	struct stats_irq *stc_cpu_irq, *stc_cpuall_irq;
 	unsigned char masked_cpu_bitmap[BITMAP_SIZE(NR_CPUS)] = {0};
 
@@ -250,16 +250,11 @@ __print_funct_t pcp_print_irq_stats(struct activity *a, int curr)
 			}
 			else {
 				/* This is a particular CPU */
-				sprintf(cpuno, "cpu%d", c - 1);
-
-				snprintf(name, sizeof(name), "kernel.percpu.interrupts.%s",
-					 stc_cpuall_irq->irq_name);
+				snprintf(name, sizeof(name), "%s::cpu%d",
+					 stc_cpuall_irq->irq_name, c - 1);
 				name[sizeof(name) - 1] = '\0';
 
-				/* Metric name cannot contain digits */
-				replace_digits(name);
-
-				pmiPutValue(name, cpuno, buf);
+				pmiPutValue("kernel.percpu.interrupts", name, buf);
 			}
 		}
 	}

--- a/sa.h
+++ b/sa.h
@@ -1576,8 +1576,6 @@ int read_record_hdr
 	 int, size_t, uint64_t, struct report_format *);
 void reallocate_all_buffers
 	(struct activity *, __nr_t);
-void replace_digits
-	(char []);
 void replace_nonprintable_char
 	(int, char *);
 int sa_fread

--- a/sadf_misc.c
+++ b/sadf_misc.c
@@ -1728,19 +1728,3 @@ void init_custom_color_palette()
 		}
 	}
 }
-
-/*
- ***************************************************************************
- * Replace digits in a string with letters ('0' -> 'a', etc.
- ***************************************************************************
- */
-void replace_digits(char name[])
-{
-	int i;
-
-	for (i = 0; i < strlen(name); i++) {
-		if ((name[i] >= '0') && (name[i] <= '9')) {
-			name[i] += 'a' - '0';
-		}
-	}
-}


### PR DESCRIPTION
Use the PCP instance domain convention with kernel.percpu.interrupts
where the interrupt line and cpu ID are combined.  This provides the
same metric as PCP and also a single stable metric identifier (pmID).

Signed-off-by: Nathan Scott <nathans@redhat.com>