### PR TITLE
Honour `LDFLAGS` passed to `./configure`

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -110,7 +110,7 @@ DFLAGS += $(TFLAGS)
 endif
 
 ifndef LFLAGS
-LFLAGS = @STRIP@
+LFLAGS = @STRIP@ @LDFLAGS@
 endif
 
 # Commands

--- a/configure
+++ b/configure
@@ -7052,4 +7052,5 @@ echo "   Configuration file:		${SYSCONFIG_DIR}/${SYSCONFIG_FILE}
    Man pages directory:		$mandir
    Compiler:			$CC
    Compiler flags:		$CFLAGS
+   Linker flags:		$LDFLAGS
 "

--- a/configure
+++ b/configure
@@ -4783,7 +4783,8 @@ HAVE_SENSORS32="n"
 if test $SENSORS_SUPPORT = "y"; then
 	CFLAGS_SAVE=$CFLAGS
 	CFLAGS+=" -m32"
-	LDFLAGS=" -lsensors"
+	LDFLAGS_SAVE=$LDFLAGS
+	LDFLAGS+=" -lsensors"
 	SENSORS=no
 #	Check for another function to avoid using cached result
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for sensors_cleanup in -lsensors" >&5
@@ -4852,6 +4853,7 @@ rm -f core conftest.err conftest.$ac_objext \
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $SENSORS" >&5
 $as_echo "$SENSORS" >&6; }
 	CFLAGS=$CFLAGS_SAVE
+	LDFLAGS=$LDFLAGS_SAVE
 fi
 
 

--- a/configure.in
+++ b/configure.in
@@ -803,4 +803,5 @@ echo "   Configuration file:		${SYSCONFIG_DIR}/${SYSCONFIG_FILE}
    Man pages directory:		$mandir
    Compiler:			$CC
    Compiler flags:		$CFLAGS
+   Linker flags:		$LDFLAGS
 "

--- a/configure.in
+++ b/configure.in
@@ -191,7 +191,8 @@ HAVE_SENSORS32="n"
 if test $SENSORS_SUPPORT = "y"; then
 	CFLAGS_SAVE=$CFLAGS
 	CFLAGS+=" -m32"
-	LDFLAGS=" -lsensors"
+	LDFLAGS_SAVE=$LDFLAGS
+	LDFLAGS+=" -lsensors"
 	SENSORS=no
 #	Check for another function to avoid using cached result
 	AC_CHECK_LIB(sensors, sensors_cleanup, LFSENSORS32="-lsensors", HAVE_SENSORS32="n")
@@ -201,6 +202,7 @@ if test $SENSORS_SUPPORT = "y"; then
 					[[sensors_cleanup();]])], SENSORS=yes; HAVE_SENSORS32="y"; DFSENSORS32="-DHAVE_SENSORS32", HAVE_SENSORS32="n"; SENSORS=no)
 	AC_MSG_RESULT($SENSORS)
 	CFLAGS=$CFLAGS_SAVE
+	LDFLAGS=$LDFLAGS_SAVE
 fi
 AC_SUBST(HAVE_SENSORS32)
 AC_SUBST(LFSENSORS32)


### PR DESCRIPTION
The `configure` script help says that the `LDFLAGS` environment variable can be used to pass additional flags to linker during build.

However, `Makefile.in` did not mention this variable at all so the additional flags were silently skipped.