### PR TITLE
Convert 64-bit time value to time_t as needed

### DIFF
--- a/sa_common.c
+++ b/sa_common.c
@@ -755,6 +755,8 @@ void get_itv_value(struct record_header *record_hdr_curr,
 void get_file_timestamp_struct(uint64_t flags, struct tm *rectime,
 			       struct file_header *file_hdr)
 {
+	time_t t = file_hdr->sa_ust_time;
+
 	if (PRINT_TRUE_TIME(flags)) {
 		/* Get local time. This is just to fill fields with a default value. */
 		get_time(rectime, 0);
@@ -770,7 +772,7 @@ void get_file_timestamp_struct(uint64_t flags, struct tm *rectime,
 		mktime(rectime);
 	}
 	else {
-		localtime_r((const time_t *) &file_hdr->sa_ust_time, rectime);
+		localtime_r(&t, rectime);
 	}
 }
 
@@ -2841,20 +2843,21 @@ int sa_get_record_timestamp_struct(uint64_t l_flags, struct record_header *recor
 				   struct tm *rectime)
 {
 	struct tm *ltm;
+	time_t t = record_hdr->ust_time;
 	int rc = 0;
 
 	/*
 	 * Fill generic rectime structure in local time.
 	 * Done so that we have some default values.
 	 */
-	ltm = localtime_r((const time_t *) &(record_hdr->ust_time), rectime);
+	ltm = localtime_r(&t, rectime);
 
 	if (!PRINT_LOCAL_TIME(l_flags) && !PRINT_TRUE_TIME(l_flags)) {
 		/*
 		 * Get time in UTC
 		 * (the user doesn't want local time nor time of file's creator).
 		 */
-		ltm = gmtime_r((const time_t *) &(record_hdr->ust_time), rectime);
+		ltm = gmtime_r(&t, rectime);
 	}
 
 	if (!ltm) {

--- a/sadf.c
+++ b/sadf.c
@@ -403,10 +403,10 @@ void list_fields(unsigned int act_id)
 time_t get_time_ref(void)
 {
 	struct tm ltm;
-	time_t t;
+	time_t t = record_hdr[2].ust_time;
 
 	if (DISPLAY_ONE_DAY(flags)) {
-		localtime_r((time_t *) &(record_hdr[2].ust_time), &ltm);
+		localtime_r(&t, &ltm);
 
 		/* Move back to midnight */
 		ltm.tm_sec = ltm.tm_min = ltm.tm_hour = 0;

--- a/sadf_misc.c
+++ b/sadf_misc.c
@@ -61,13 +61,14 @@ void pcp_write_data(struct record_header *record_hdr, unsigned int flags)
 #ifdef HAVE_PCP
 	int rc;
 	struct tm lrectime;
+	time_t t = record_hdr->ust_time;
 	unsigned long long utc_sec = record_hdr->ust_time;
 	static long long delta_utc = LONG_MAX;
 
 	if (!PRINT_LOCAL_TIME(flags)) {
 		if (delta_utc == LONG_MAX) {
 			/* Convert a time_t value from local time to UTC */
-			if (gmtime_r((const time_t *) &(record_hdr->ust_time), &lrectime)) {
+			if (gmtime_r(&t, &lrectime)) {
 				utc_sec = mktime(&lrectime);
 				delta_utc = utc_sec - record_hdr->ust_time;
 			}
@@ -1080,6 +1081,7 @@ __printf_funct_t print_xml_header(void *parm, int action, char *dfile,
 				  struct file_activity *file_actlst)
 {
 	struct tm rectime, loc_t;
+	time_t t = file_hdr->sa_ust_time;
 	char cur_time[TIMESTAMP_LEN];
 	int *tab = (int *) parm;
 
@@ -1111,7 +1113,7 @@ __printf_funct_t print_xml_header(void *parm, int action, char *dfile,
 		strftime(cur_time, sizeof(cur_time), "%Y-%m-%d", &rectime);
 		xprintf(*tab, "<file-date>%s</file-date>", cur_time);
 
-		if (gmtime_r((const time_t *) &file_hdr->sa_ust_time, &loc_t) != NULL) {
+		if (gmtime_r(&t, &loc_t) != NULL) {
 			strftime(cur_time, sizeof(cur_time), "%T", &loc_t);
 			xprintf(*tab, "<file-utc-time>%s</file-utc-time>", cur_time);
 		}
@@ -1149,6 +1151,7 @@ __printf_funct_t print_json_header(void *parm, int action, char *dfile,
 				   struct file_activity *file_actlst)
 {
 	struct tm rectime, loc_t;
+	time_t t = file_hdr->sa_ust_time;
 	char cur_time[TIMESTAMP_LEN];
 	int *tab = (int *) parm;
 
@@ -1170,7 +1173,7 @@ __printf_funct_t print_json_header(void *parm, int action, char *dfile,
 		strftime(cur_time, sizeof(cur_time), "%Y-%m-%d", &rectime);
 		xprintf(*tab, "\"file-date\": \"%s\",", cur_time);
 
-		if (gmtime_r((const time_t *) &file_hdr->sa_ust_time, &loc_t) != NULL) {
+		if (gmtime_r(&t, &loc_t) != NULL) {
 			strftime(cur_time, sizeof(cur_time), "%T", &loc_t);
 			xprintf(*tab, "\"file-utc-time\": \"%s\",", cur_time);
 		}
@@ -1208,6 +1211,7 @@ __printf_funct_t print_hdr_header(void *parm, int action, char *dfile,
 {
 	int i, p;
 	struct tm rectime, loc_t;
+	time_t t = file_hdr->sa_ust_time;
 	struct file_activity *fal;
 	char cur_time[TIMESTAMP_LEN];
 
@@ -1227,7 +1231,7 @@ __printf_funct_t print_hdr_header(void *parm, int action, char *dfile,
 		       file_magic->upgraded);
 
 		printf(_("Host: "));
-		print_gal_header(localtime_r((const time_t *) &(file_hdr->sa_ust_time), &rectime),
+		print_gal_header(localtime_r(&t, &rectime),
 				 file_hdr->sa_sysname, file_hdr->sa_release,
 				 file_hdr->sa_nodename, file_hdr->sa_machine,
 				 file_hdr->sa_cpu_nr > 1 ? file_hdr->sa_cpu_nr - 1 : 1,
@@ -1238,7 +1242,7 @@ __printf_funct_t print_hdr_header(void *parm, int action, char *dfile,
 		strftime(cur_time, sizeof(cur_time), "%Y-%m-%d", &rectime);
 		printf(_("File date: %s\n"), cur_time);
 
-		if (gmtime_r((const time_t *) &file_hdr->sa_ust_time, &loc_t) != NULL) {
+		if (gmtime_r(&t, &loc_t) != NULL) {
 			printf(_("File time: "));
 			strftime(cur_time, sizeof(cur_time), "%T", &loc_t);
 			printf("%s UTC (%lld)\n", cur_time, file_hdr->sa_ust_time);
@@ -1310,6 +1314,7 @@ __printf_funct_t print_svg_header(void *parm, int action, char *dfile,
 {
 	struct svg_hdr_parm *hdr_parm = (struct svg_hdr_parm *) parm;
 	struct tm rectime;
+	time_t t = file_hdr->sa_ust_time;
 	unsigned int height = 0, ht = 0;
 	int i, p;
 
@@ -1349,7 +1354,7 @@ __printf_funct_t print_svg_header(void *parm, int action, char *dfile,
 		       svg_colors[palette][SVG_COL_DEFAULT_IDX]);
 		printf("<text x=\"0\" y=\"30\" text-anchor=\"start\" stroke=\"#%06x\">",
 		       svg_colors[palette][SVG_COL_HEADER_IDX]);
-		print_gal_header(localtime_r((const time_t *) &(file_hdr->sa_ust_time), &rectime),
+		print_gal_header(localtime_r(&t, &rectime),
 				 file_hdr->sa_sysname, file_hdr->sa_release,
 				 file_hdr->sa_nodename, file_hdr->sa_machine,
 				 file_hdr->sa_cpu_nr > 1 ? file_hdr->sa_cpu_nr - 1 : 1,
@@ -1417,6 +1422,7 @@ __printf_funct_t print_pcp_header(void *parm, int action, char *dfile,
 #ifdef HAVE_PCP
 	char buf[64];
 	struct tm lrectime;
+	time_t t = file_hdr->sa_ust_time;
 	unsigned long long utc_sec = file_hdr->sa_ust_time;
 
 	if (action & F_BEGIN) {
@@ -1465,7 +1471,7 @@ __printf_funct_t print_pcp_header(void *parm, int action, char *dfile,
 			/* Only the header data will be written to PCP archive */
 			if (!PRINT_LOCAL_TIME(flags)) {
 				/* Convert a time_t value from local time to UTC */
-				if (gmtime_r((const time_t *) &(file_hdr->sa_ust_time), &lrectime)) {
+				if (gmtime_r(&t, &lrectime)) {
 					utc_sec = mktime(&lrectime);
 				}
 			}

--- a/svg_stats.c
+++ b/svg_stats.c
@@ -876,6 +876,7 @@ int draw_activity_graphs(int g_nr, int g_type[], char *title[], char *g_title[],
 	double lmax, xfactor, yfactor, ypos, gmin, gmax;
 	char val[32], cur_date[TIMESTAMP_LEN];
 	struct tm rectime;
+	time_t t = svg_p->file_hdr->sa_ust_time;
 
 	/* Print activity name in debug mode */
 	if (DISPLAY_DEBUG_MODE(flags)) {
@@ -996,7 +997,7 @@ int draw_activity_graphs(int g_nr, int g_type[], char *title[], char *g_title[],
 			       svg_p->file_hdr->sa_nodename);
 
 			/* Get report date */
-			set_report_date(localtime_r((const time_t *) &(svg_p->file_hdr->sa_ust_time), &rectime),
+			set_report_date(localtime_r(&t, &rectime),
 					cur_date, sizeof(cur_date));
 			printf("<tspan x=\"%d\" y=\"%d\" "
 			       "style=\"fill: #%06x; text-anchor: end; stroke: none; font-size: 14px\">"


### PR DESCRIPTION
On platforms with 32-bit time_t, code up converts it to a 64-bit data
type.  The pointer to this 64-bit value is incorrectly passed to
a few functions that accept a pointer to a 32-bit time_t.

On little endian platforms the original 32-bit time_t value will be visible
this way but on big endian platforms only zeros will be seen and time
will be show as wrong values.

Update code to convert to time_t to be compatible with 32-bit be
platforms.