### PR TITLE
Prevent irq_name format overflows, as warned by gcc

### DIFF
--- a/sa_conv.c
+++ b/sa_conv.c
@@ -552,6 +552,7 @@ void upgrade_stats_irq(struct activity *act[], int p, unsigned int magic)
 				strcpy(sic->irq_name, K_LOWERSUM);
 			}
 			else {
+				/* irq name is 8 bytes, but a %d could be up to 10, so limit it */
 				sprintf(sic->irq_name, "%d", ( i & 0x7fffff ) - 1);
 			}
 		}

--- a/sa_conv.c
+++ b/sa_conv.c
@@ -552,7 +552,7 @@ void upgrade_stats_irq(struct activity *act[], int p, unsigned int magic)
 				strcpy(sic->irq_name, K_LOWERSUM);
 			}
 			else {
-				sprintf(sic->irq_name, "%d", ( i & 0x7fffff ) - 1);
+				sprintf(sic->irq_name, "%d", ( i & 0x7fff ) - 1);
 			}
 		}
 	}
@@ -571,7 +571,7 @@ void upgrade_stats_irq(struct activity *act[], int p, unsigned int magic)
 			}
 			else {
 				/* irq name is 8 bytes, but a %d could be up to 10, so limit it */
-				sprintf(sic->irq_name, "%d", ( i & 0x7fffff ) - 1);
+				sprintf(sic->irq_name, "%d", ( i & 0x7fff ) - 1);
 			}
 		}
 	}

--- a/sa_conv.c
+++ b/sa_conv.c
@@ -552,7 +552,7 @@ void upgrade_stats_irq(struct activity *act[], int p, unsigned int magic)
 				strcpy(sic->irq_name, K_LOWERSUM);
 			}
 			else {
-				sprintf(sic->irq_name, "%d", ( i & 0x7fff ) - 1);
+				sprintf(sic->irq_name, "%d", ( i & 0x7fffff ) - 1);
 			}
 		}
 	}
@@ -571,7 +571,7 @@ void upgrade_stats_irq(struct activity *act[], int p, unsigned int magic)
 			}
 			else {
 				/* irq name is 8 bytes, but a %d could be up to 10, so limit it */
-				sprintf(sic->irq_name, "%d", ( i & 0x7fff ) - 1);
+				sprintf(sic->irq_name, "%d", ( i & 0x7fffff ) - 1);
 			}
 		}
 	}

--- a/sa_conv.c
+++ b/sa_conv.c
@@ -552,8 +552,8 @@ void upgrade_stats_irq(struct activity *act[], int p, unsigned int magic)
 				strcpy(sic->irq_name, K_LOWERSUM);
 			}
 			else {
-				/* irq name is 8 bytes, but a %d could be up to 10, so limit it */
-				sprintf(sic->irq_name, "%d", ( i & 0x7fffff ) - 1);
+				snprintf(sic->irq_name, sizeof(sic->irq_name), "%d", i - 1 > NR2_MAX ? NR2_MAX : i - 1);
+				sic->irq_name[sizeof(sic->irq_name) - 1] = '\0';
 			}
 		}
 	}
@@ -571,8 +571,8 @@ void upgrade_stats_irq(struct activity *act[], int p, unsigned int magic)
 				strcpy(sic->irq_name, K_LOWERSUM);
 			}
 			else {
-				/* irq name is 8 bytes, but a %d could be up to 10, so limit it */
-				sprintf(sic->irq_name, "%d", ( i & 0x7fffff ) - 1);
+				snprintf(sic->irq_name, sizeof(sic->irq_name), "%d", i - 1 > NR2_MAX ? NR2_MAX : i - 1);
+				sic->irq_name[sizeof(sic->irq_name) - 1] = '\0';
 			}
 		}
 	}

--- a/sa_conv.c
+++ b/sa_conv.c
@@ -552,7 +552,7 @@ void upgrade_stats_irq(struct activity *act[], int p, unsigned int magic)
 				strcpy(sic->irq_name, K_LOWERSUM);
 			}
 			else {
-				sprintf(sic->irq_name, "%d", i - 1);
+				sprintf(sic->irq_name, "%d", ( i & 0x7fffff ) - 1);
 			}
 		}
 	}
@@ -570,7 +570,8 @@ void upgrade_stats_irq(struct activity *act[], int p, unsigned int magic)
 				strcpy(sic->irq_name, K_LOWERSUM);
 			}
 			else {
-				sprintf(sic->irq_name, "%d", i - 1);
+				/* irq name is 8 bytes, but a %d could be up to 10, so limit it */
+				sprintf(sic->irq_name, "%d", ( i & 0x7fffff ) - 1);
 			}
 		}
 	}


### PR DESCRIPTION
Avoid gcc warnings that arise from placing %d (up to 10 bytes) into a char of size 8.

By masking the irq number with 0x7fffff, it becomes limited to 0 thru 8388607, thus neatly fitting into the char of size 8.

And thereby giving a clean gcc run.
````
sa_conv.c: In function ‘upgrade_stats_irq’:
sa_conv.c:573:57: warning: ‘%d’ directive writing between 1 and 10 bytes into a region of size 8 [-Wformat-overflow=]
  573 |                                 sprintf(sic->irq_name, "%d", i - 1);
      |                                                         ^~
sa_conv.c:573:56: note: directive argument in the range [0, 2147483646]
  573 |                                 sprintf(sic->irq_name, "%d", i - 1);
      |                                                        ^~~~
sa_conv.c:573:33: note: ‘sprintf’ output between 2 and 11 bytes into a destination of size 8
  573 |                                 sprintf(sic->irq_name, "%d", i - 1);
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sa_conv.c:555:57: warning: ‘%d’ directive writing between 1 and 10 bytes into a region of size 8 [-Wformat-overflow=]
  555 |                                 sprintf(sic->irq_name, "%d", i - 1);
      |                                                         ^~
sa_conv.c:555:56: note: directive argument in the range [0, 2147483646]
  555 |                                 sprintf(sic->irq_name, "%d", i - 1);
      |                                                        ^~~~
sa_conv.c:555:33: note: ‘sprintf’ output between 2 and 11 bytes into a destination of size 8
  555 |                                 sprintf(sic->irq_name, "%d", i - 1);
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
````