### PR TITLE
README: consolidate systemctl commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,7 @@ CentOS and Fedora systems call the collector process using a cron job in /etc/cr
 On recent versions, systemd is used instead of cron. You may need to enable and start the sysstat service:
 
 ```
-$ sudo systemctl enable sysstat
-$ sudo systemctl start sysstat
+$ sudo systemctl enable --now sysstat
 ```
 
 #### Install from Ubuntu


### PR DESCRIPTION
It's a really minor thing, but the two commands provided in the README:

```sh
$ sudo systemctl enable sysstat
$ sudo systemctl start sysstat
```
can be written as a single command using the `systemctl enable --now` flag. This PR updates the README commands accordingly.