### PR TITLE
doc-fix: remove `-I int_list` from man-page and help.

### DIFF
--- a/man/sar.in
+++ b/man/sar.in
@@ -1650,10 +1650,10 @@ The timestamp will also be compliant with ISO 8601 format.
 .B sar -u 2 5
 Report CPU utilization for each 2 seconds. 5 lines are displayed.
 .TP
-.B sar -I 14 -o int14.file 2 10
+.B sar -I ALL -o int_all.file 2 10
 Report statistics on IRQ 14 for each 2 seconds. 10 lines are displayed.
 Data are stored in a file called
-.IR "int14.file" "."
+.IR "int_all.file" "."
 .TP
 .B sar -r -n DEV -f @SA_DIR@/sa16
 .RI "Display memory and network statistics saved in daily data file " "sa16" "."

--- a/sar.c
+++ b/sar.c
@@ -123,7 +123,7 @@ void usage(char *progname)
 			  "[ -A ] [ -B ] [ -b ] [ -C ] [ -D ] [ -d ] [ -F [ MOUNT ] ] [ -H ] [ -h ]\n"
 			  "[ -p ] [ -r [ ALL ] ] [ -S ] [ -t ] [ -u [ ALL ] ] [ -V ]\n"
 			  "[ -v ] [ -W ] [ -w ] [ -y ] [ -z ]\n"
-			  "[ -I { <int_list> | SUM | ALL } ] [ -P { <cpu_list> | ALL } ]\n"
+			  "[ -I { SUM | ALL } ] [ -P { <cpu_list> | ALL } ]\n"
 			  "[ -m { <keyword> [,...] | ALL } ] [ -n { <keyword> [,...] | ALL } ]\n"
 			  "[ -q [ <keyword> [,...] | ALL ] ]\n"
 			  "[ --dev=<dev_list> ] [ --fs=<fs_list> ] [ --iface=<iface_list> ] "
@@ -153,7 +153,7 @@ void display_help(char *progname)
 	printf(_("\t-F [ MOUNT ]\n"));
 	printf(_("\t\tFilesystems statistics [A_FS]\n"));
 	printf(_("\t-H\tHugepages utilization statistics [A_HUGE]\n"));
-	printf(_("\t-I { <int_list> | SUM | ALL }\n"
+	printf(_("\t-I { SUM | ALL }\n"
 		 "\t\tInterrupts statistics [A_IRQ]\n"));
 	printf(_("\t-m { <keyword> [,...] | ALL }\n"
 		 "\t\tPower management statistics [A_PWR_...]\n"


### PR DESCRIPTION
Hi, this is no big contribution and I hope it is correct. I was a bit confused, when I tried the example from the man-page and it did not work. If I understand it correctly `-I 14` is not supported. Feel free to squash this into any cleanup commit :)