### PR TITLE
Display physical hotplug vCPU stats

### DIFF
--- a/man/mpstat.1
+++ b/man/mpstat.1
@@ -4,7 +4,7 @@
 mpstat \- Report processors related statistics.
 
 .SH SYNOPSIS
-.B mpstat [ -A ] [ --dec={ 0 | 1 | 2 } ] [ -n ] [ -u ] [ -T ] [ -V ] [ -I {
+.B mpstat [ -A ] [ --dec={ 0 | 1 | 2 } ] [ -n ] [ -u ] [ -T ] [ -V ] [ -H ] [ -I {
 .IB "keyword" "[,...] | ALL } ] [ -N { " "node_list " "| ALL } ] [ -o JSON ] [ -P {"
 .IB "cpu_list " "| ALL } ] [ " "interval " "[ " "count " "] ]"
 
@@ -44,6 +44,8 @@ unless these options are explicitly set on the command line.
 .B --dec={ 0 | 1 | 2 }
 Specify the number of decimal places to use (0 to 2, default value is 2).
 .TP
+.B -H
+Detect and Display stats of physically hotplugged vCPUs also
 .BI "-I { " "keyword" "[,...] | ALL }"
 Report interrupts statistics.
 .RI "Possible " "keywords " "are"

--- a/mpstat.c
+++ b/mpstat.c
@@ -175,75 +175,81 @@ void int_handler(int sig)
  * IN:
  * @nr_cpus	Number of CPUs. This is the real number of available CPUs + 1
  * 		because we also have to allocate a structure for CPU 'all'.
+ * @reset	reset the memory only when set to TRUE
  ***************************************************************************
  */
-void salloc_mp_struct(int nr_cpus)
+void salloc_mp_struct(int nr_cpus, int reset)
 {
 	int i;
 
 	for (i = 0; i < 3; i++) {
 
-		if ((st_cpu[i] = (struct stats_cpu *) malloc(STATS_CPU_SIZE * nr_cpus))
+		if ((st_cpu[i] = (struct stats_cpu *) realloc(st_cpu[i], STATS_CPU_SIZE * nr_cpus))
 		    == NULL) {
-			perror("malloc");
+			perror("realloc");
 			exit(4);
 		}
-		memset(st_cpu[i], 0, STATS_CPU_SIZE * nr_cpus);
 
-		if ((st_node[i] = (struct stats_cpu *) malloc(STATS_CPU_SIZE * nr_cpus))
+		if ((st_node[i] = (struct stats_cpu *) realloc(st_node[i], STATS_CPU_SIZE * nr_cpus))
 		    == NULL) {
-			perror("malloc");
+			perror("realloc");
 			exit(4);
 		}
-		memset(st_node[i], 0, STATS_CPU_SIZE * nr_cpus);
 
-		if ((st_irq[i] = (struct stats_global_irq *) malloc(STATS_GLOBAL_IRQ_SIZE * nr_cpus))
+		if ((st_irq[i] = (struct stats_global_irq *) realloc(st_irq[i], STATS_GLOBAL_IRQ_SIZE * nr_cpus))
 		    == NULL) {
-			perror("malloc");
+			perror("realloc");
 			exit(4);
 		}
-		memset(st_irq[i], 0, STATS_GLOBAL_IRQ_SIZE * nr_cpus);
 
-		if ((st_irqcpu[i] = (struct stats_irqcpu *) malloc(STATS_IRQCPU_SIZE * nr_cpus * irqcpu_nr))
+		if ((st_irqcpu[i] = (struct stats_irqcpu *) realloc(st_irqcpu[i], STATS_IRQCPU_SIZE * nr_cpus * irqcpu_nr))
 		    == NULL) {
-			perror("malloc");
+			perror("realloc");
 			exit(4);
 		}
-		memset(st_irqcpu[i], 0, STATS_IRQCPU_SIZE * nr_cpus * irqcpu_nr);
 
-		if ((st_softirqcpu[i] = (struct stats_irqcpu *) malloc(STATS_IRQCPU_SIZE * nr_cpus * softirqcpu_nr))
+		if ((st_softirqcpu[i] = (struct stats_irqcpu *) realloc(st_softirqcpu[i], STATS_IRQCPU_SIZE * nr_cpus * softirqcpu_nr))
 		     == NULL) {
-			perror("malloc");
+			perror("realloc");
 			exit(4);
 		}
-		memset(st_softirqcpu[i], 0, STATS_IRQCPU_SIZE * nr_cpus * softirqcpu_nr);
 	}
 
-	if ((cpu_bitmap = (unsigned char *) malloc((nr_cpus >> 3) + 1)) == NULL) {
-		perror("malloc");
-		exit(4);
-	}
-	memset(cpu_bitmap, 0, (nr_cpus >> 3) + 1);
-
-	if ((node_bitmap = (unsigned char *) malloc((nr_cpus >> 3) + 1)) == NULL) {
-		perror("malloc");
-		exit(4);
-	}
-	memset(node_bitmap, 0, (nr_cpus >> 3) + 1);
-
-	if ((cpu_per_node = (int *) malloc(sizeof(int) * nr_cpus)) == NULL) {
-		perror("malloc");
+	if ((cpu_bitmap = (unsigned char *) realloc(cpu_bitmap, (nr_cpus >> 3) + 1)) == NULL) {
+		perror("realloc");
 		exit(4);
 	}
 
-	if ((cpu2node = (int *) malloc(sizeof(int) * nr_cpus)) == NULL) {
-		perror("malloc");
+	if ((node_bitmap = (unsigned char *) realloc(node_bitmap, (nr_cpus >> 3) + 1)) == NULL) {
+		perror("realloc");
 		exit(4);
 	}
 
-	if ((st_cpu_topology = (struct cpu_topology *) malloc(sizeof(struct cpu_topology) * nr_cpus)) == NULL) {
-		perror("malloc");
+	if ((cpu_per_node = (int *) realloc(cpu_per_node, sizeof(int) * nr_cpus)) == NULL) {
+		perror("realloc");
 		exit(4);
+	}
+
+	if ((cpu2node = (int *) realloc(cpu2node, sizeof(int) * nr_cpus)) == NULL) {
+		perror("realloc");
+		exit(4);
+	}
+
+	if ((st_cpu_topology = (struct cpu_topology *) realloc(st_cpu_topology, sizeof(struct cpu_topology) * nr_cpus)) == NULL) {
+		perror("realloc");
+		exit(4);
+	}
+
+	if (reset == TRUE) {
+		for (i = 0; i < 3; i++) {
+			memset(st_cpu[i], 0, STATS_CPU_SIZE * nr_cpus);
+			memset(st_node[i], 0, STATS_CPU_SIZE * nr_cpus);
+			memset(st_irq[i], 0, STATS_GLOBAL_IRQ_SIZE * nr_cpus);
+			memset(st_irqcpu[i], 0, STATS_IRQCPU_SIZE * nr_cpus * irqcpu_nr);
+			memset(st_softirqcpu[i], 0, STATS_IRQCPU_SIZE * nr_cpus * softirqcpu_nr);
+		}
+		memset(cpu_bitmap, 0, (nr_cpus >> 3) + 1);
+		memset(node_bitmap, 0, (nr_cpus >> 3) + 1);
 	}
 }
 
@@ -2175,7 +2181,7 @@ int main(int argc, char **argv)
 	 * cpu_nr: a value of 2 means there are 2 processors (0 and 1).
 	 * In this case, we have to allocate 3 structures: global, proc0 and proc1.
 	 */
-	salloc_mp_struct(cpu_nr + 1);
+	salloc_mp_struct(cpu_nr + 1, TRUE);
 
 	/* Get NUMA node placement */
 	node_nr = get_node_placement(cpu_nr, cpu_per_node, cpu2node);

--- a/mpstat.h
+++ b/mpstat.h
@@ -53,12 +53,15 @@
 #define F_OPTION_N	0x08
 /* Display topology */
 #define F_TOPOLOGY	0x10
+/* Indicate that option -H has been used */
+#define F_OPTION_H	0x20
 
 #define USE_OPTION_P(m)		(((m) & F_OPTION_P) == F_OPTION_P)
 #define USE_OPTION_A(m)		(((m) & F_OPTION_A) == F_OPTION_A)
 #define DISPLAY_JSON_OUTPUT(m)	(((m) & F_JSON_OUTPUT) == F_JSON_OUTPUT)
 #define USE_OPTION_N(m)		(((m) & F_OPTION_N) == F_OPTION_N)
 #define DISPLAY_TOPOLOGY(m)	(((m) & F_TOPOLOGY) == F_TOPOLOGY)
+#define USE_OPTION_H(m)		(((m) & F_OPTION_H) == F_OPTION_H)
 
 #define K_SUM	"SUM"
 #define K_CPU	"CPU"


### PR DESCRIPTION
This is for fixing following issue :
Fixes https://github.com/sysstat/sysstat/issues/327

By introducing a -H option, we can also detect and display stats of physically hotplug CPUs, which could occur especially in virtual machines/ environments.

Tests:
Create a VM using virsh and run mpstat with an interval inside it.
`virsh setvcpus vm1 5 --live --config`

Before:
[root@localhost sysstat]# ./mpstat -P ALL 5
Linux 5.4.17-2136.310.7.1.el8uek.x86_64 (localhost.localdomain)         09/15/2022      _x86_64_        (2 CPU)

06:36:17 PM  CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
06:36:22 PM  all    0.10    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00   99.90
06:36:22 PM    0    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00  100.00
06:36:22 PM    1    0.20    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00   99.80
[19545.212043] CPU2 has been hot-added
[19545.213481] CPU3 has been hot-added
[19545.218034] smpboot: Booting Node 0 Processor 3 APIC 0x3
[19545.231848] kvm-clock: cpu 3, msr 129c010c1, secondary cpu clock
[19545.232232] KVM setup async PF for cpu 3
[19545.233814] kvm-stealtime: cpu 3, msr 13b9b2040
[19545.234985] Will online and init hotplugged CPU: 3
[19545.245984] CPU4 has been hot-added
[19545.259915] smpboot: Booting Node 0 Processor 4 APIC 0x4
[19545.261168] kvm-clock: cpu 4, msr 129c01101, secondary cpu clock
[19545.261568] KVM setup async PF for cpu 4
[19545.263335] kvm-stealtime: cpu 4, msr 13ba32040
[19545.264853] Will online and init hotplugged CPU: 4
[19545.295991] smpboot: Booting Node 0 Processor 2 APIC 0x2
[19545.297523] kvm-clock: cpu 2, msr 129c01081, secondary cpu clock
[19545.297900] KVM setup async PF for cpu 2
[19545.299693] kvm-stealtime: cpu 2, msr 13b932040
[19545.301206] Will online and init hotplugged CPU: 2

06:36:22 PM  CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
06:36:27 PM  all    0.60    0.00    1.31    0.00    0.00    0.00    0.00    0.00    0.00   98.09
06:36:27 PM    0    0.60    0.00    1.20    0.00    0.00    0.00    0.00    0.00    0.00   98.20
06:36:27 PM    1    0.60    0.00    1.41    0.00    0.00    0.00    0.00    0.00    0.00   97.99

06:36:27 PM  CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
06:36:32 PM  all    0.00    0.00    0.10    0.00    0.00    0.00    0.00    0.00    0.00   99.90
06:36:32 PM    0    0.00    0.00    0.20    0.00    0.00    0.00    0.00    0.00    0.00   99.80
06:36:32 PM    1    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00  100.00

After :
With -H option :
[root@localhost sysstat]# ./mpstat -P ALL -H 5
Linux 5.4.17-2136.310.7.1.el8uek.x86_64 (localhost.localdomain)         09/15/2022      _x86_64_        (3 CPU)

06:05:07 PM  CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
06:05:12 PM  all    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00  100.00
06:05:12 PM    0    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00  100.00
06:05:12 PM    1    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00  100.00
06:05:12 PM    2    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00  100.00

06:05:12 PM  CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
06:05:17 PM  all    0.07    0.00    0.07    0.00    0.00    0.00    0.00    0.00    0.00   99.87
06:05:17 PM    0    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00  100.00
06:05:17 PM    1    0.20    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00   99.80
06:05:17 PM    2    0.00    0.00    0.20    0.00    0.00    0.00    0.00    0.00    0.00   99.80
[17681.346355] CPU3 has been hot-added
[17681.347999] CPU4 has been hot-added
[17681.354137] smpboot: Booting Node 0 Processor 4 APIC 0x4
[17682.906404] kvm-clock: cpu 4, msr 129c01101, secondary cpu clock
[17682.907051] KVM setup async PF for cpu 4
[17682.908886] kvm-stealtime: cpu 4, msr 13ba32040
[17682.909891] Will online and init hotplugged CPU: 4
[17682.937090] smpboot: Booting Node 0 Processor 3 APIC 0x3
[17682.938347] kvm-clock: cpu 3, msr 129c010c1, secondary cpu clock
[17682.938797] KVM setup async PF for cpu 3
[17682.940446] kvm-stealtime: cpu 3, msr 13b9b2040
[17682.941345] Will online and init hotplugged CPU: 3

Average:     CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
Average:     all    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00  100.00
Average:       0    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00  100.00
Average:       1    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00  100.00
Average:       2    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00  100.00
Linux 5.4.17-2136.310.7.1.el8uek.x86_64 (localhost.localdomain)         09/15/2022      _x86_64_        (5 CPU)

06:05:22 PM  CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
06:05:27 PM  all    2.40    0.00    0.92    0.00    0.00    0.00    0.00    0.00    0.00   96.68
06:05:27 PM    0    0.40    0.00    0.80    0.00    0.00    0.00    0.00    0.00    0.00   98.80
06:05:27 PM    1    0.40    0.00    0.40    0.00    0.00    0.00    0.00    0.00    0.00   99.20
06:05:27 PM    2   10.60    0.00    2.40    0.00    0.00    0.00    0.00    0.00    0.00   87.00
06:05:27 PM    3    0.40    0.00    0.60    0.00    0.00    0.00    0.00    0.00    0.00   99.00
06:05:27 PM    4    0.20    0.00    0.40    0.00    0.00    0.00    0.00    0.00    0.00   99.40

Average:     CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
Average:     all    2.40    0.00    0.92    0.00    0.00    0.00    0.00    0.00    0.00   96.68
Average:       0    0.40    0.00    0.80    0.00    0.00    0.00    0.00    0.00    0.00   98.80
Average:       1    0.40    0.00    0.40    0.00    0.00    0.00    0.00    0.00    0.00   99.20
Average:       2   10.60    0.00    2.40    0.00    0.00    0.00    0.00    0.00    0.00   87.00
Average:       3    0.40    0.00    0.60    0.00    0.00    0.00    0.00    0.00    0.00   99.00
Average:       4    0.20    0.00    0.40    0.00    0.00    0.00    0.00    0.00    0.00   99.40
[root@localhost sysstat]# ./mpstat -V
sysstat version 12.7.1
(C) Sebastien Godard (sysstat <at> orange.fr)
[root@localhost sysstat]#

Without -H option
[root@localhost sysstat]# ./mpstat -P ALL 5
Linux 5.4.17-2136.310.7.1.el8uek.x86_64 (localhost.localdomain)         09/15/2022      _x86_64_        (2 CPU)

06:32:08 PM  CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
06:32:13 PM  all    0.10    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00   99.90
06:32:13 PM    0    0.20    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00   99.80
06:32:13 PM    1    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00  100.00
[19296.396148] CPU2 has been hot-added
[19296.397632] CPU3 has been hot-added
[19296.403029] smpboot: Booting Node 0 Processor 3 APIC 0x3
[19296.407762] kvm-clock: cpu 3, msr 129c010c1, secondary cpu clock
[19296.408190] KVM setup async PF for cpu 3
[19296.410083] kvm-stealtime: cpu 3, msr 13b9b2040
[19296.411585] Will online and init hotplugged CPU: 3
[19296.423999] CPU4 has been hot-added
[19296.443019] smpboot: Booting Node 0 Processor 4 APIC 0x4
[19296.444209] kvm-clock: cpu 4, msr 129c01101, secondary cpu clock
[19296.444679] KVM setup async PF for cpu 4
[19296.446387] kvm-stealtime: cpu 4, msr 13ba32040
[19296.447745] Will online and init hotplugged CPU: 4
[19296.473977] smpboot: Booting Node 0 Processor 2 APIC 0x2
[19296.475129] kvm-clock: cpu 2, msr 129c01081, secondary cpu clock
[19296.475807] KVM setup async PF for cpu 2
[19296.477809] kvm-stealtime: cpu 2, msr 13b932040
[19296.478883] Will online and init hotplugged CPU: 2

06:32:13 PM  CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
06:32:18 PM  all    5.80    0.00    2.20    0.00    0.00    0.00    0.00    0.00    0.00   92.00
06:32:18 PM    0   10.62    0.00    3.21    0.00    0.00    0.00    0.00    0.00    0.00   86.17
06:32:18 PM    1    1.00    0.00    1.20    0.00    0.00    0.00    0.00    0.00    0.00   97.80

06:32:18 PM  CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
06:32:23 PM  all    0.10    0.00    0.10    0.00    0.00    0.00    0.00    0.00    0.00   99.80
06:32:23 PM    0    0.20    0.00    0.20    0.00    0.00    0.00    0.00    0.00    0.00   99.60
06:32:23 PM    1    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00    0.00  100.00