### PR TITLE
Fix extra space when no TZ printed

### DIFF
--- a/sadf_misc.c
+++ b/sadf_misc.c
@@ -832,11 +832,18 @@ char *print_dbppc_timestamp(int fmt, struct file_header *file_hdr, char *cur_dat
 	else {
 		strcpy(temp2, temp1);
 	}
-	snprintf(pre, sizeof(pre), "%s%s %s", temp2, cur_time,
-		 strlen(cur_date) ? (PRINT_LOCAL_TIME(flags) ? my_tz
-							     : (PRINT_TRUE_TIME(flags) ? file_hdr->sa_tzname
-										       : "UTC"))
-				  : "");
+
+	if (strlen(cur_date) && (!PRINT_TRUE_TIME(flags) || (PRINT_TRUE_TIME(flags) && strlen(file_hdr->sa_tzname)))) {
+		snprintf(pre, sizeof(pre), "%s%s %s", temp2, cur_time,
+		 PRINT_LOCAL_TIME(flags) ? my_tz 
+		 	: (PRINT_TRUE_TIME(flags) ? file_hdr->sa_tzname 
+				: "UTC"));
+	} else {
+		snprintf(pre, sizeof(pre), "%s%s", temp2, cur_time);
+	}
+
+
+	
 	pre[sizeof(pre) - 1] = '\0';
 
 	if (DISPLAY_HORIZONTALLY(flags)) {


### PR DESCRIPTION
A recent commit change the format string in the snprintf function call on line 835 of sadf_misc.c, adding a space between the time and time zone in the output. In cases where there is no time zone to print, or if outputting epoch time with the -U option, there is trailing whitespace after the timestamp. This does not look nice, and can cause issues with parsers not expecting the whitespace.

This patch checks whether or not a time zone will be printed, and chooses the proper format accordingly.