### PR TITLE
Tools that take `--dec=X` option should only accept digits

### DIFF
--- a/cifsiostat.c
+++ b/cifsiostat.c
@@ -522,6 +522,11 @@ int main(int argc, char **argv)
 		}
 
 		else if (!strncmp(argv[opt], "--dec=", 6) && (strlen(argv[opt]) == 7)) {
+			/* Check that the argument is a digit */
+			if (!isdigit(argv[opt][6])) {
+				usage(argv[0]);
+			}
+
 			/* Get number of decimal places */
 			dplaces_nr = atoi(argv[opt] + 6);
 			if ((dplaces_nr < 0) || (dplaces_nr > 2)) {

--- a/iostat.c
+++ b/iostat.c
@@ -2142,6 +2142,11 @@ int main(int argc, char **argv)
 #endif
 
 		else if (!strncmp(argv[opt], "--dec=", 6) && (strlen(argv[opt]) == 7)) {
+			/* Check that the argument is a digit */
+			if (!isdigit(argv[opt][6])) {
+				usage(argv[0]);
+			}
+
 			/* Get number of decimal places */
 			dplaces_nr = atoi(argv[opt] + 6);
 			if ((dplaces_nr < 0) || (dplaces_nr > 2)) {

--- a/mpstat.c
+++ b/mpstat.c
@@ -2221,6 +2221,11 @@ int main(int argc, char **argv)
 	while (++opt < argc) {
 
 		if (!strncmp(argv[opt], "--dec=", 6) && (strlen(argv[opt]) == 7)) {
+			/* Check that the argument is a digit */
+			if (!isdigit(argv[opt][6])) {
+				usage(argv[0]);
+			}
+
 			/* Get number of decimal places */
 			dplaces_nr = atoi(argv[opt] + 6);
 			if ((dplaces_nr < 0) || (dplaces_nr > 2)) {

--- a/pidstat.c
+++ b/pidstat.c
@@ -2633,6 +2633,11 @@ int main(int argc, char **argv)
 		}
 
 		else if (!strncmp(argv[opt], "--dec=", 6) && (strlen(argv[opt]) == 7)) {
+			/* Check that the argument is a digit */
+			if (!isdigit(argv[opt][6])) {
+				usage(argv[0]);
+			}
+
 			/* Get number of decimal places */
 			dplaces_nr = atoi(argv[opt] + 6);
 			if ((dplaces_nr < 0) || (dplaces_nr > 2)) {

--- a/sar.c
+++ b/sar.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <signal.h>
 #include <sys/stat.h>
+#include <ctype.h>
 
 #include "version.h"
 #include "sa.h"
@@ -1372,6 +1373,11 @@ int main(int argc, char **argv)
 		}
 
 		else if (!strncmp(argv[opt], "--dec=", 6) && (strlen(argv[opt]) == 7)) {
+			/* Check that the argument is a digit */
+			if (!isdigit(argv[opt][6])) {
+				usage(argv[0]);
+			}
+
 			/* Get number of decimal places */
 			dplaces_nr = atoi(argv[opt] + 6);
 			if ((dplaces_nr < 0) || (dplaces_nr > 2)) {


### PR DESCRIPTION
Right now the argument of `--dec` is passed to `atoi(3)` which returns `0` on conversion error.  Therefore, `--dec=A` was not rejected and was equivalent to `--dec=0` by mistake.