### PR TITLE
configure.ac: fix erroneous bashisms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -191,9 +191,9 @@ DFSENSORS32=""
 HAVE_SENSORS32="n"
 if test $SENSORS_SUPPORT = "y"; then
 	CFLAGS_SAVE=$CFLAGS
-	CFLAGS+=" -m32"
+	CFLAGS="$CFLAGS -m32"
 	LDFLAGS_SAVE=$LDFLAGS
-	LDFLAGS+=" -lsensors"
+	LDFLAGS="$LDFLAGS -lsensors"
 	SENSORS=no
 #	Check for another function to avoid using cached result
 	AC_CHECK_LIB(sensors, sensors_cleanup, LFSENSORS32="-lsensors", HAVE_SENSORS32="n")
@@ -212,7 +212,7 @@ AC_SUBST(DFSENSORS32)
 # Check for 32-bit system libraries
 TGLIB32=no
 CFLAGS_SAVE=$CFLAGS
-CFLAGS+=" -m32"
+CFLAGS="$CFLAGS -m32"
 AC_MSG_CHECKING(for 32-bit system libraries)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>]],
 				   [[printf("%d\n", sizeof(long));]])],TGLIB32=yes, TGLIB32=no)


### PR DESCRIPTION
An autoconf generated script is designed to work with POSIX sh, and contains a /bin/sh shebang. As a result, it *cannot* assume it will be run with bash, as it won't be.

POSIX sh provides no way to extend the contents of a variable. A bash-specific extension is to use the += notation.

Instead, the standard (albeit somewhat more wordy) POSIX compatible approach is to expand the previous contents into a regular assignment. Do so.

Fixes: https://bugs.gentoo.org/923989

```
 * QA Notice: Abnormal configure code
 * 
 * ./configure: 4927: CFLAGS+= -m32: not found
```