### PR TITLE
Slight changes to compile on Mac OS X

### DIFF
--- a/sa_common.c
+++ b/sa_common.c
@@ -161,7 +161,11 @@ void guess_sa_name(char *sa_dir, struct tm *rectime, int *sa_name)
 		/* Cannot find or access saYYYYMMDD, so use saDD */
 		return;
 	sa_mtime = sb.st_mtime;
+#ifndef __APPLE__
 	nsec = sb.st_mtim.tv_nsec;
+#else
+	nsec = sb.st_mtimespec.tv_nsec;
+#endif
 
 	/* Look for saDD */
 	snprintf(filename, sizeof(filename),
@@ -176,7 +180,12 @@ void guess_sa_name(char *sa_dir, struct tm *rectime, int *sa_name)
 	}
 
 	if ((sa_mtime > sb.st_mtime) ||
-	    ((sa_mtime == sb.st_mtime) && (nsec > sb.st_mtim.tv_nsec))) {
+#ifndef __APPLE__
+	    ((sa_mtime == sb.st_mtime) && (nsec > sb.st_mtim.tv_nsec))
+#else
+	    ((sa_mtime == sb.st_mtime) && (nsec > sb.st_mtimespec.tv_nsec))
+#endif
+ ) {
 		/* saYYYYMMDD is more recent than saDD, so use it */
 		*sa_name = 1;
 	}

--- a/sadf_misc.c
+++ b/sadf_misc.c
@@ -1735,7 +1735,7 @@ __nr_t count_new_bat(struct activity *a, int curr)
  * Init custom color palette used to draw graphs (sadf -g).
  ***************************************************************************
  */
-void init_custom_color_palette()
+void init_custom_color_palette(void)
 {
 	char *e, *p;
 	int len;


### PR DESCRIPTION
Previously (#247) was rejected since sysstat is strictly for Linux, yet I found it very useful to be able to process `sa` binary data files on my mac laptop.  The changes are so simple that I created this branch for myself to be able to compile `sadf` (at least) and use it.  It works flawlessly.

Even if this PR is not accepted, this branch is easy enough to keep around and rebase as needed.