### PR TITLE
Avoid util over 100

### DIFF
--- a/rd_stats.c
+++ b/rd_stats.c
@@ -448,9 +448,12 @@ void read_uptime(unsigned long long *uptime)
 void compute_ext_disk_stats(struct stats_disk *sdc, struct stats_disk *sdp,
 			    unsigned long long itv, struct ext_disk_stats *xds)
 {
+	double aqu_sz = S_VALUE(sdp->rq_ticks, sdc->rq_ticks, itv) / 1000.0;
 	xds->util  = sdc->tot_ticks < sdp->tot_ticks ?
 		     0.0 :
 		     S_VALUE(sdp->tot_ticks, sdc->tot_ticks, itv);
+	/* avoid util over 100 */
+	xds->util  = MINIMUM(xds->util, MINIMUM(aqu_sz, 1.0) * 1000);
 	/*
 	 * Kernel gives ticks already in milliseconds for all platforms
 	 * => no need for further scaling.


### PR DESCRIPTION
Fixes #412 
Due to inaccuracies in the io_ticks metric from the kernel’s /proc/diskstats, the util field in iostat (calculated based on io_ticks) is also inaccurate and may output abnormal values exceeding the theoretical maximum of 100.

The aqu-sz field in iostat, which represents the average queue length of requests issued to the device, can be used to compare disk usage.

By reassigning util as util = min(util, min(aqu-sz, 1.0) * 100), two abnormal scenarios can be addressed:
1.Low aqu-sz but high util: This contradicts the actual disk usage scenario.
2.util over 100: Values surpassing the theoretical maximum of 100 are invalid.