### PR TITLE
Fix out-of-tree builds

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,6 +1,8 @@
 # Makefile to build sysstat commands
 # (C) 1999-2023 Sebastien GODARD (sysstat <at> orange.fr)
 
+VPATH = @srcdir@
+
 # Version and package name
 VERSION = @PACKAGE_VERSION@
 PACKAGE = @PACKAGE_NAME@
@@ -8,7 +10,7 @@ PACKAGE = @PACKAGE_NAME@
 PACKAGE_TARNAME = $(PACKAGE)-$(VERSION)
 
 # Compiler to use
-CC = @CC@
+CC = @CC@ -I@builddir@
 
 # Other commands
 CHMOD = @CHMOD@
@@ -581,14 +583,14 @@ endif
 	$(INSTALL_BIN) mpstat $(DESTDIR)$(BIN_DIR)
 	$(INSTALL_BIN) pidstat $(DESTDIR)$(BIN_DIR)
 	$(INSTALL_BIN) cifsiostat $(DESTDIR)$(BIN_DIR)
-	$(INSTALL_DATA) sysstat.ioconf $(DESTDIR)$(SYSCONFIG_DIR)
 	$(INSTALL_DATA) sysstat.sysconfig $(DESTDIR)$(SYSCONFIG_DIR)/$(SYSCONFIG_FILE)
+	$(INSTALL_DATA) @srcdir@/sysstat.ioconf $(DESTDIR)$(SYSCONFIG_DIR)
 ifeq ($(INSTALL_DOC),y)
-	$(INSTALL_DATA) CHANGES $(DESTDIR)$(DOC_DIR)
-	$(INSTALL_DATA) COPYING $(DESTDIR)$(DOC_DIR)
-	$(INSTALL_DATA) CREDITS $(DESTDIR)$(DOC_DIR)
-	$(INSTALL_DATA) README.md $(DESTDIR)$(DOC_DIR)
-	$(INSTALL_DATA) FAQ.md $(DESTDIR)$(DOC_DIR)
+	$(INSTALL_DATA) @srcdir@/CHANGES $(DESTDIR)$(DOC_DIR)
+	$(INSTALL_DATA) @srcdir@/COPYING $(DESTDIR)$(DOC_DIR)
+	$(INSTALL_DATA) @srcdir@/CREDITS $(DESTDIR)$(DOC_DIR)
+	$(INSTALL_DATA) @srcdir@/README.md $(DESTDIR)$(DOC_DIR)
+	$(INSTALL_DATA) @srcdir@/FAQ.md $(DESTDIR)$(DOC_DIR)
 endif
 
 ifdef SYSTEMD_UNIT_DIR
@@ -803,11 +805,11 @@ else
 po-files:
 endif
 
-TESTDIR="tests"
+TESTDIR="@srcdir@/tests"
 TESTRUN="/bin/sh"
-TESTLIST:=$(shell ls $(TESTDIR) | grep -E '^[0-9]+$$' | sort -n)
-EXTRADIR="tests/extra"
-EXTRALIST:=$(shell ls $(EXTRADIR) | grep -E '^[0-9]+$$' | sort -n)
+TESTLIST:=$(shell cd $(TESTDIR) && echo * | grep -E '^[0-9]+$$' | sort -n)
+EXTRADIR="@srcdir@/tests/extra"
+EXTRALIST:=$(shell cd $(EXTRADIR) && echo * | grep -E '^[0-9]+$$' | sort -n)
 
 testcomp: tests/ini/inisar sa32bit
 

--- a/iconfig
+++ b/iconfig
@@ -2,38 +2,40 @@
 #@(#) Configuration script for sysstat
 # (C) 2000-2025 Sebastien GODARD (sysstat <at> orange.fr)
 
+srcdir="${0%/*}"
+
 if [ "$1" = "xlocal" ]
 then
 	echo
-	echo -n "./configure sa_lib_dir=. sa_dir=. conf_dir=. conf_file=sysstat.sysconfig"
+	echo -n "${srcdir}/configure sa_lib_dir=. sa_dir=. conf_dir=. conf_file=sysstat.sysconfig"
 	echo
-	./configure sa_lib_dir=. sa_dir=. sar_dir=. conf_dir=. conf_file=sysstat.sysconfig
+	${srcdir}/configure sa_lib_dir=. sa_dir=. sar_dir=. conf_dir=. conf_file=sysstat.sysconfig
 	exit
 elif [ "$1" = "local" ]
 then
 	# This mode is just to make sure that sar will call sadc located in current directory
 	echo
-	echo -n "./configure sa_lib_dir=."
+	echo -n "${srcdir}/configure sa_lib_dir=."
 	echo
-	./configure sa_lib_dir=.
+	${srcdir}/configure sa_lib_dir=.
 	exit
 elif [ "$1" = "debug" ]
 then
 	echo
-	echo -n "./configure sa_lib_dir=. --enable-debuginfo --disable-stripping"
+	echo -n "${srcdir}/configure sa_lib_dir=. --enable-debuginfo --disable-stripping"
 	echo
-	./configure sa_lib_dir=. --enable-debuginfo --disable-stripping
+	${srcdir}/configure sa_lib_dir=. --enable-debuginfo --disable-stripping
 	exit
 fi
 
-ASK="sh build/Ask.sh"
+ASK="sh ${srcdir}/build/Ask.sh"
 
 echo ; echo
 echo Welcome to sysstat\'s  Interactive Configuration script!
 echo
-echo This script enables you to set the parameters value used by ./configure.
+echo This script enables you to set the parameters value used by ${srcdir}/configure.
 echo Please enter the value for the parameters listed below.
-echo Press Return to tell ./configure to use the default value or to try to guess the proper one.
+echo Press Return to tell ${srcdir}/configure to use the default value or to try to guess the proper one.
 echo "Default value for yes/no questions is no (parameter is NOT set)."
 echo You can enter a ? to display a help message at any time...
 echo
@@ -260,7 +262,7 @@ else
 fi
 
 echo
-echo -n "./configure ${PREFIX}${SA_LIB_DIR}${SA_DIR}${SYSCONFIG_DIR}${SYSCONFIG_FILE} \
+echo -n "${srcdir}/configure ${PREFIX}${SA_LIB_DIR}${SA_DIR}${SYSCONFIG_DIR}${SYSCONFIG_FILE} \
 ${CLEAN_SA_DIR}${NLS}${LTO}${HISTORY}${DELAY_RANGE}${COMPRESSAFTER}${MAN}${IGNORE_FILE_ATTR} \
 ${CRON}${USE_CROND}${RCDIR}"
 if [ "${SADC_OPT}" != "" ];
@@ -270,7 +272,7 @@ fi
 echo "${COMPRESSMANPG}${INSTALL_DOC}${DEBUGINFO}${SENSORS}${PCP}${STRIP}${COPY_ONLY}"
 echo
 
-./configure ${PREFIX}${SA_LIB_DIR}${SA_DIR}${SYSCONFIG_DIR}${SYSCONFIG_FILE} \
+${srcdir}/configure ${PREFIX}${SA_LIB_DIR}${SA_DIR}${SYSCONFIG_DIR}${SYSCONFIG_FILE} \
 ${CLEAN_SA_DIR}${NLS}${LTO} \
 ${HISTORY}${DELAY_RANGE}${COMPRESSAFTER}${MAN}${IGNORE_FILE_ATTR}${CRON}${USE_CROND}${RCDIR} \
 sadc_options="${SADC_OPT}" ${COMPRESSMANPG}${INSTALL_DOC}${DEBUGINFO}${SENSORS} \


### PR DESCRIPTION
This PR makes the necessary changes to support building sysstat with generated artifacts placed in an output directory other than the source directory, as is already the case with most Autotools software. Take the following workflow as an example:

```sh
$ mkdir out && cd out
$ ../configure # or ../iconfig
$ make
```

Previously, failure would occur at the `make` stage:

```txt
ls: cannot access 'tests/extra': No such file or directory
make: *** No rule to make target 'sadc.c', needed by 'sadc.o'.  Stop.
```

Now, the build (as well as `make install`) works as expected. This allows for better flexibility and space savings when configuring/building sysstat for multiple platforms at once.