### PR TITLE
iostat: add -T to show timestamp for each line for easy grep

### DIFF
--- a/common.c
+++ b/common.c
@@ -1904,4 +1904,40 @@ void write_sample_timestamp(int tab, struct tm *rectime, uint64_t xflags)
 #endif
 }
 
+/*
+ * **************************************************************************
+ * Write current sample's timestamp, in plain and no \n
+ *
+ * IN:
+ * @rectime	Current date and time.
+ * @xflags	Flag for common options and system state.
+ ***************************************************************************
+ */
+void write_sample_timestamp_log(struct tm *rectime, uint64_t xflags)
+{
+	char timestamp[TIMESTAMP_LEN];
+
+	if (rectime == NULL)
+		return;
+
+	if (DISPLAY_SEC_EPOCH(xflags)) {
+		snprintf(timestamp, sizeof(timestamp), "%ld", (long) mktime(rectime));
+	}
+	else if (DISPLAY_ISO(xflags)) {
+		strftime(timestamp, sizeof(timestamp), DATE_TIME_FORMAT_ISO, rectime);
+	}
+	else {
+		strftime(timestamp, sizeof(timestamp), DATE_TIME_FORMAT_LOCAL, rectime);
+	}
+
+	/* Make sure timestamp is null-terminated */
+	timestamp[sizeof(timestamp) - 1] = '\0';
+
+	/*
+	 * 01234567890123456
+	 * dd/mm/yy HH:MM:SS
+	 */
+	printf("%-17s ", timestamp);
+}
+
 #endif /* SOURCE_SADC undefined */

--- a/common.h
+++ b/common.h
@@ -409,6 +409,8 @@ char *strtolower
 	(char *);
 void write_sample_timestamp
 	(int, struct tm *, uint64_t);
+void write_sample_timestamp_log
+	(struct tm *, uint64_t);
 void xprintf
 	(int, const char *, ...);
 void xprintf0

--- a/iostat.h
+++ b/iostat.h
@@ -32,6 +32,7 @@
 #define I_D_UNIT		0x100000
 #define I_D_SHORT_OUTPUT	0x200000
 #define I_D_COMPACT		0x400000
+#define I_D_TIMESTAMP_LOG	0x800000
 
 #define DISPLAY_CPU(m)			(((m) & I_D_CPU)              == I_D_CPU)
 #define DISPLAY_DISK(m)			(((m) & I_D_DISK)             == I_D_DISK)
@@ -53,6 +54,7 @@
 #define DISPLAY_SHORT_OUTPUT(m)		(((m) & I_D_SHORT_OUTPUT)     == I_D_SHORT_OUTPUT)
 #define USE_ALL_DIR(m)			(((m) & I_D_ALL_DIR)          == I_D_ALL_DIR)
 #define DISPLAY_COMPACT(m)		(((m) & I_D_COMPACT)          == I_D_COMPACT)
+#define DISPLAY_TIMESTAMP_LOG(m)	(((m) & I_D_TIMESTAMP_LOG)    == I_D_TIMESTAMP_LOG)
 
 enum {
 	T_PART		= 0,

--- a/man/iostat.in
+++ b/man/iostat.in
@@ -6,13 +6,13 @@ statistics for devices and partitions.
 
 .SH SYNOPSIS
 .ie 'yes'@WITH_DEBUG@' \{
-.B iostat [ \-c ] [ \-d ] [ \-h ] [ \-k | \-m ] [ \-N ] [ \-s ] [ \-t ] [ \-U ] [ \-V ] [ \-x ] [ \-y ] [ \-z ]
+.B iostat [ \-c ] [ \-d ] [ \-h ] [ \-k | \-m ] [ \-N ] [ \-s ] [ \-t ] [ \-T ] [ \-U ] [ \-V ] [ \-x ] [ \-y ] [ \-z ]
 .BI "[ \-\-compact ] [ \-\-dec={ 0 | 1 | 2 } ] [ { \-f | +f } " "directory" " ] [ \-j { ID | LABEL | PATH | UUID | ... } ] "
 .BI "[ \-o JSON ] [ [ \-H ] \-g " "group_name " "] [ \-\-human ] [ \-\-pretty ] [ \-p [ " "device" "[,...] | ALL ] ] ["
 .IB "device " "[...] | ALL ] [ \-\-debuginfo ] [ " "interval " "[ " "count " "] ] "
 .\}
 .el \{
-.B iostat [ \-c ] [ \-d ] [ \-h ] [ \-k | \-m ] [ \-N ] [ \-s ] [ \-t ] [ \-U ] [ \-V ] [ \-x ] [ \-y ] [ \-z ]
+.B iostat [ \-c ] [ \-d ] [ \-h ] [ \-k | \-m ] [ \-N ] [ \-s ] [ \-t ] [ \-T ] [ \-U ] [ \-V ] [ \-x ] [ \-y ] [ \-z ]
 .BI "[ \-\-compact ] [ \-\-dec={ 0 | 1 | 2 } ] [ { \-f | +f } " "directory" " ] [ \-j { ID | LABEL | PATH | UUID | ... } ] "
 .BI "[ \-o JSON ] [ [ \-H ] \-g " "group_name " "] [ \-\-human ] [ \-\-pretty ] [ \-p [ " "device" "[,...] | ALL ] ] ["
 .IB "device " "[...] | ALL ] [ " "interval " "[ " "count " "] ]"
@@ -351,6 +351,11 @@ characters wide screens.
 .TP
 .B \-t
 Print the time for each report displayed. The timestamp format may depend
+on the value of the
+.BR "S_TIME_FORMAT " "environment variable (see below) and on whether option -U has been used."
+.TP
+.B \-T
+Print the time for each output line. The timestamp format may depend
 on the value of the
 .BR "S_TIME_FORMAT " "environment variable (see below) and on whether option -U has been used."
 .TP


### PR DESCRIPTION
This patch add new -T option to show timestamp for each output line, it's more friendly for user to grep some time window from iostat log.

For basic stats:

./iostat -mt 1 sda sdb
Linux 5.15.0-97-generic (zwp-5820-Tower) 	09/29/25 	_x86_64_	(16 CPU)

09/29/25 15:22:03
avg-cpu:  %user   %nice %system %iowait  %steal   %idle
           0.83    0.00    1.56    0.47    0.00   97.14

Device             tps    MB_read/s    MB_wrtn/s    MB_dscd/s    MB_read    MB_wrtn    MB_dscd
sda              72.08         0.00         0.38         0.00       5060    2631239          0
sdb               0.00         0.00         0.00         0.00          0          0          0

./iostat -mT 1 sda sdb
Linux 5.15.0-97-generic (zwp-5820-Tower) 	09/29/25 	_x86_64_	(16 CPU)

Datetime          avg-cpu:  %user   %nice %system %iowait  %steal   %idle
09/29/25 15:22:19            0.83    0.00    1.56    0.47    0.00   97.14

Datetime          Device             tps    MB_read/s    MB_wrtn/s    MB_dscd/s    MB_read    MB_wrtn    MB_dscd
09/29/25 15:22:19 sda              72.08         0.00         0.38         0.00       5060    2631254          0
09/29/25 15:22:19 sdb               0.00         0.00         0.00         0.00          0          0          0

For extend stats:

./iostat -xmt 1 sda sdb
Linux 5.15.0-97-generic (zwp-5820-Tower) 	09/29/25 	_x86_64_	(16 CPU)

09/29/25 15:21:08
avg-cpu:  %user   %nice %system %iowait  %steal   %idle
           0.83    0.00    1.56    0.47    0.00   97.14

Device            r/s     rMB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wMB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dMB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
sda              0.03      0.00     0.01  18.76   42.11    25.95   72.05      0.38    11.83  14.10    6.13     5.42    0.00      0.00     0.00   0.00    0.00     0.00    0.25   24.93    0.45   7.27
sdb              0.00      0.00     0.00   0.00    1.33     0.17    0.00      0.00     0.00   0.00    0.00     0.00    0.00      0.00     0.00   0.00    0.00     0.00    0.00    0.00    0.00   0.00

./iostat -xmT 1 sda sdb
Linux 5.15.0-97-generic (zwp-5820-Tower) 	09/29/25 	_x86_64_	(16 CPU)

Datetime          avg-cpu:  %user   %nice %system %iowait  %steal   %idle
09/29/25 15:21:34            0.83    0.00    1.56    0.47    0.00   97.14

Datetime          Device            r/s     rMB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wMB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dMB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
09/29/25 15:21:34 sda              0.03      0.00     0.01  18.76   42.11    25.95   72.05      0.38    11.83  14.10    6.13     5.42    0.00      0.00     0.00   0.00    0.00     0.00    0.25   24.93    0.45   7.27
09/29/25 15:21:34 sdb              0.00      0.00     0.00   0.00    1.33     0.17    0.00      0.00     0.00   0.00    0.00     0.00    0.00      0.00     0.00   0.00    0.00     0.00    0.00    0.00    0.00   0.00