### PR TITLE
man: fix typo 'correspondind' -> 'corresponding' in sar man page

### DIFF
--- a/man/sar.in
+++ b/man/sar.in
@@ -1712,7 +1712,7 @@ All the statistics are not necessarily available, depending on the kernel versio
 assumes that you are using at least a 2.6 kernel.
 .PP
 .RB "Although " "sar"
-displays units correspondind to kilobytes (kB), megabytes (MB)..., it actually uses kibibytes (kiB), mebibytes (MiB)...
+displays units corresponding to kilobytes (kB), megabytes (MB)..., it actually uses kibibytes (kiB), mebibytes (MiB)...
 A kibibyte is equal to 1024 bytes, and a mebibyte is equal to 1024 kibibytes.
 
 .SH FILES


### PR DESCRIPTION
## Summary

Fix a typo in `man/sar.in`: `correspondind` → `corresponding`.

The affected line:
```
Although sar displays units correspondind to kilobytes (kB)...
```
should read:
```
Although sar displays units corresponding to kilobytes (kB)...
```