### PR TITLE
rd_stats.c: Fix pgscan_direct counter incorrectly including pgscan_di…

### DIFF
--- a/rd_stats.c
+++ b/rd_stats.c
@@ -802,7 +802,7 @@ __nr_t read_vmstat_paging(struct stats_paging *st_paging)
 			sscanf(strchr(line, ' '), "%lu", &pgtmp);
 			st_paging->pgscan_kswapd += pgtmp;
 		}
-		else if (!strncmp(line, "pgscan_direct", 13)) {
+		else if (!strncmp(line, "pgscan_direct ", 14)) {
 			/* Read number of pages scanned directly */
 			sscanf(strchr(line, ' '), "%lu", &pgtmp);
 			st_paging->pgscan_direct += pgtmp;


### PR DESCRIPTION
rd_stats.c: Fix pgscan_direct counter incorrectly including pgscan_direct_throttle

The strncmp() call matching "pgscan_direct" used a length of 13, which also matched "pgscan_direct_throttle" from /proc/vmstat since both strings share the same 13-character prefix. This caused the pgscan_direct_throttle value to be erroneously added to pgscan_direct.

Fix by appending a trailing space to the match string ("pgscan_direct ") and updating the length to 14, ensuring only the exact pgscan_direct field is matched.