### PR TITLE
rd_stats.c: Fix pgsteal/s double counting by only summing pgsteal_anon and pgsteal_file

### DIFF
--- a/rd_stats.c
+++ b/rd_stats.c
@@ -760,7 +760,6 @@ __nr_t read_vmstat_paging(struct stats_paging *st_paging)
 	FILE *fp;
 	char line[128];
 	unsigned long pgtmp;
-	short pg_start = FALSE, pg_end = FALSE;
 
 	if ((fp = fopen(VMSTAT, "r")) == NULL)
 		return 0;
@@ -791,10 +790,14 @@ __nr_t read_vmstat_paging(struct stats_paging *st_paging)
 			/* Read number of pages freed by the system */
 			sscanf(line + 7, "%lu", &st_paging->pgfree);
 		}
-		else if (!strncmp(line, "pgsteal_", 8) && !pg_end) {
-			pg_start = TRUE;
-			/* Read number of pages stolen by the system */
-			sscanf(strchr(line, ' '), "%lu", &pgtmp);
+		else if (!strncmp(line, "pgsteal_anon ", 13)) {
+			/* Read number of anonymous pages stolen by the system */
+			sscanf(line + 13, "%lu", &pgtmp);
+			st_paging->pgsteal += pgtmp;
+		}
+		else if (!strncmp(line, "pgsteal_file ", 13)) {
+			/* Read number of file pages stolen by the system */
+			sscanf(line + 13, "%lu", &pgtmp);
 			st_paging->pgsteal += pgtmp;
 		}
 		else if (!strncmp(line, "pgscan_kswapd ", 14)) {
@@ -812,15 +815,6 @@ __nr_t read_vmstat_paging(struct stats_paging *st_paging)
 		else if (!strncmp(line, "pgdemote_", 9)) {
 			sscanf(strchr(line, ' '), "%lu", &pgtmp);
 			st_paging->pgdemote += pgtmp;
-		}
-
-		/*
-		 * Read only the first pg_steal_* values in /proc/vmstat
-		 * (i.e. the "reclaimer": pgsteal_kswapd, pgsteal_direct, etc.)
-		 * but not the type of memory reclaimed (pgsteal_anon, pgsteal_file).
-		 */
-		if (strncmp(line, "pgsteal_", 8) && pg_start) {
-			pg_end = TRUE;
 		}
 	}
 


### PR DESCRIPTION
In read_vmstat_paging(), the kernel records each reclaim event twice in
/proc/vmstat: once by reclaimer type (pgsteal_kswapd, pgsteal_direct,
pgsteal_khugepaged, pgsteal_proactive) and once by memory type
(pgsteal_anon, pgsteal_file). The current code sums all pgsteal_*
entries, which doubles the reported pgsteal/s value and causes %vmeff
to exceed 100%.

Fix by only summing pgsteal_anon and pgsteal_file, which represent
the actual pages reclaimed regardless of who reclaimed them. This also
corrects the %vmeff calculation (pgsteal/pgscan) which previously showed
values >100% due to the doubled numerator.

The pg_start/pg_end logic used to stop reading after the "first group"
of pgsteal_* entries is removed since the entries are now matched
explicitly.

Fixes #415