### PR TITLE
rd_stats.c: Fix pgsteal/s double counting by only summing pgsteal_anon and pgsteal_file

### DIFF
--- a/rd_stats.c
+++ b/rd_stats.c
@@ -760,7 +760,6 @@ __nr_t read_vmstat_paging(struct stats_paging *st_paging)
 	FILE *fp;
 	char line[128];
 	unsigned long pgtmp;
-	short pg_start = FALSE, pg_end = FALSE;
 
 	if ((fp = fopen(VMSTAT, "r")) == NULL)
 		return 0;
@@ -791,11 +790,17 @@ __nr_t read_vmstat_paging(struct stats_paging *st_paging)
 			/* Read number of pages freed by the system */
 			sscanf(line + 7, "%lu", &st_paging->pgfree);
 		}
-		else if (!strncmp(line, "pgsteal_", 8) && !pg_end) {
-			pg_start = TRUE;
-			/* Read number of pages stolen by the system */
-			sscanf(strchr(line, ' '), "%lu", &pgtmp);
-			st_paging->pgsteal += pgtmp;
+		else if (!strncmp(line, "pgsteal_anon ", 13)) {
+			/* Read number of anonymous pages stolen by the system */
+			if (sscanf(line + 13, "%lu", &pgtmp) == 1) {
+				st_paging->pgsteal += pgtmp;
+			}
+		}
+		else if (!strncmp(line, "pgsteal_file ", 13)) {
+			/* Read number of file pages stolen by the system */
+			if (sscanf(line + 13, "%lu", &pgtmp) == 1) {
+				st_paging->pgsteal += pgtmp;
+			}
 		}
 		else if (!strncmp(line, "pgscan_kswapd ", 14)) {
 			/* Read number of pages scanned by the kswapd daemon */
@@ -812,15 +817,6 @@ __nr_t read_vmstat_paging(struct stats_paging *st_paging)
 		else if (!strncmp(line, "pgdemote_", 9)) {
 			sscanf(strchr(line, ' '), "%lu", &pgtmp);
 			st_paging->pgdemote += pgtmp;
-		}
-
-		/*
-		 * Read only the first pg_steal_* values in /proc/vmstat
-		 * (i.e. the "reclaimer": pgsteal_kswapd, pgsteal_direct, etc.)
-		 * but not the type of memory reclaimed (pgsteal_anon, pgsteal_file).
-		 */
-		if (strncmp(line, "pgsteal_", 8) && pg_start) {
-			pg_end = TRUE;
 		}
 	}
 


### PR DESCRIPTION
In read_vmstat_paging(), the kernel records each reclaim event twice in
/proc/vmstat: once by reclaimer type (pgsteal_kswapd, pgsteal_direct,
pgsteal_khugepaged, pgsteal_proactive) and once by memory type
(pgsteal_anon, pgsteal_file). The current code sums all pgsteal_*
entries, which doubles the reported pgsteal/s value and causes %vmeff
to exceed 100%.

The old pg_start/pg_end state-machine logic attempted to stop reading
after the first group of pgsteal_* entries, but this relies on the
assumption that /proc/vmstat entry ordering is stable across sampling
windows. Under extreme memory pressure (e.g. stress-ng), the relative
positions of vmstat entries can shift dynamically, causing the flags to
include both groups of pgsteal_* entries instead of stopping after the
first group — producing the same double count.

Fix by only summing pgsteal_anon and pgsteal_file, which represent
the actual pages reclaimed regardless of who reclaimed them. The
pg_start/pg_end flag logic is removed since entries are now matched
explicitly, making the fix immune to vmstat entry ordering changes.

This also corrects the %vmeff calculation (pgsteal/pgscan) which
previously showed values >100% due to the doubled numerator.

Fixes #415