### PR TITLE
fix: use write() instead of printf() in signal handler for JSON output safety

### DIFF
--- a/mpstat.c
+++ b/mpstat.c
@@ -169,7 +169,7 @@ void alarm_handler(int sig)
 void int_handler(int sig)
 {
 	sigint_caught = 1;
-	printf("\n");	/* Skip "^C" displayed on screen (SIGINT) */
+	write(STDOUT_FILENO, "\n", 1);	/* Skip "^C" displayed on screen (SIGINT) */
 }
 
 /*
@@ -2153,6 +2153,7 @@ void rw_mpstat_loop(int dis_hdr, int rows)
 terminate:
 	if (DISPLAY_JSON_OUTPUT(xflags)) {
 		printf("\n\t\t\t]\n\t\t}\n\t]\n}}\n");
+		fflush(stdout);
 	}
 }
 

--- a/sar.c
+++ b/sar.c
@@ -242,7 +242,7 @@ void which_sadc(void)
 void int_handler(int sig)
 {
 	sigint_caught = 1;
-	printf("\n");	/* Skip "^C" displayed on screen (SIGINT) */
+	write(STDOUT_FILENO, "\n", 1);	/* Skip "^C" displayed on screen (SIGINT) */
 
 }
 


### PR DESCRIPTION
## Summary
- Replace printf() with write() in signal handlers (int_handler) in mpstat.c and sar.c, since printf() is not async-signal-safe
- Add fflush(stdout) after JSON closing output in mpstat.c to ensure buffered data is written
- When SIGTERM is received while stdout is being used by another printf() call (e.g., writing JSON statistics), the FILE structure can be corrupted, causing the JSON closing braces to be lost from the output

Fixes #410
