### PR TITLE
fix: Skip s390x aggregate interrupt lines to avoid double-counting

### DIFF
--- a/rd_stats.c
+++ b/rd_stats.c
@@ -255,6 +255,13 @@ __nr_t read_stat_irq(struct stats_irq *st_irq, __nr_t nr_alloc, __nr_t nr_int)
 			/* ...then save its name */
 			strncpy(st_cpuall_irq->irq_name, li, len);
 			st_cpuall_irq->irq_name[len] = '\0';
+			/* Skip s390x aggregate interrupt lines to avoid double-counting */
+			if (!strcmp(st_cpuall_irq->irq_name, "EXT") ||
+			    !strcmp(st_cpuall_irq->irq_name, "I/O") ||
+			    !strcmp(st_cpuall_irq->irq_name, "AIO")) {
+				irq_read--;
+				continue;
+			}
 
 			/* For each interrupt: Get number received by each CPU */
 			for (cpu = 0; cpu < index; cpu++) {


### PR DESCRIPTION
## Summary
- Fix interrupt double-counting on s390x architecture in read_stat_irq()
- On s390x, /proc/interrupts contains aggregate lines (EXT, I/O, AIO) that summarize sub-interrupts which also appear separately in the same file
- read_stat_irq() was treating both aggregate and detail lines as independent interrupts, causing every s390x interrupt to be counted twice
- Skip interrupts named "EXT", "I/O", or "AIO" after name extraction to prevent this

## Details
The s390x /proc/interrupts format has aggregate categories followed by detail sub-interrupts:
- EXT:  Total external interrupts (aggregate)
- [EXT] Specific_Device: Detail counts
- I/O:  Total I/O interrupts (aggregate)
- [I/O] Specific_Device: Detail counts

The fix adds a check in read_stat_irq() after the interrupt name is extracted: if the name is "EXT", "I/O", or "AIO" (the three-letter aggregate categories), the line is skipped and irq_read is decremented to maintain correct counting.

Fixes #421
