### PR TITLE
fix: Remove unnecessary unsigned int cast that truncates irq_nr in read_stat_total_irq()

### DIFF
--- a/mpstat.c
+++ b/mpstat.c
@@ -1802,8 +1802,8 @@ void read_stat_total_irq(struct stats_global_irq *st_irq)
 
 		if (!strncmp(line, "intr ", 5)) {
 			/* Read total number of interrupts received since system boot */
-			sscanf(line + 5, "%llu", &irq_nr);
-			st_irq->irq_nr = (unsigned int) irq_nr;
+			if (sscanf(line + 5, "%llu", &irq_nr) == 1)
+			st_irq->irq_nr = irq_nr;
 
 			break;
 		}


### PR DESCRIPTION
## Summary
- Fix total interrupt count truncation in mpstat `read_stat_total_irq()`
- Remove unnecessary `(unsigned int)` cast that truncates upper 32 bits of `irq_nr`
- The `stats_global_irq.irq_nr` struct member is already `unsigned long long`, so the cast was silently discarding the high bits
- On systems with high interrupt counts (e.g., under stress workloads), the truncated value caused incorrect `intr/s` display for the "all" CPU row

Fixes #314