### PR TITLE
Account for IOPS in GB (revisited)

### DIFF
--- a/cifsiostat.c
+++ b/cifsiostat.c
@@ -78,15 +78,13 @@ void usage(char *progname)
 	fprintf(stderr, _("Usage: %s [ options ] [ <interval> [ <count> ] ]\n"),
 		progname);
 
+	fprintf(stderr, _("Options are:\n"
+			  "[ --dec={ 0 | 1 | 2 } ] [ --human ] [ --pretty ] [ -o JSON ]\n"
+			  "[ -h ] [ -k | -m | -G ] [ -t ] [ -U ] [ -V ] [ -y ]"
 #ifdef DEBUG
-	fprintf(stderr, _("Options are:\n"
-			  "[ --dec={ 0 | 1 | 2 } ] [ --human ] [ --pretty ] [ -o JSON ]\n"
-			  "[ -h ] [ -k | -m ] [ -t ] [ -U ] [ -V ] [ -y ] [ --debuginfo ]\n"));
-#else
-	fprintf(stderr, _("Options are:\n"
-			  "[ --dec={ 0 | 1 | 2 } ] [ --human ] [ --pretty ] [ -o JSON ]\n"
-			  "[ -h ] [ -k | -m ] [ -t ] [ -U ] [ -V ] [ -y ]\n"));
+			  " [ --debuginfo ]"
 #endif
+			  "\n"));
 	exit(1);
 }
 
@@ -324,6 +322,11 @@ void write_cifs_stat_header(int *fctr, int *tab)
 	else if (DISPLAY_MEGABYTES(flags)) {
 		*fctr = 1024 * 1024;
 		units = "MB";
+		spc = "";
+	}
+	else if (DISPLAY_GIGABYTES(flags)) {
+		*fctr = 1024 * 1024 * 1024;
+		units = "GB";
 		spc = "";
 	}
 	else {
@@ -714,8 +717,16 @@ int main(int argc, char **argv)
 					flags |= I_D_PRETTY + I_D_UNIT;
 					break;
 
+				case 'G':
+					if (DISPLAY_KILOBYTES(flags) || DISPLAY_MEGABYTES(flags)) {
+						usage(argv[0]);
+					}
+					/* Display stats in GB/s */
+					flags |= I_D_GIGABYTES;
+					break;
+
 				case 'k':
-					if (DISPLAY_MEGABYTES(flags)) {
+					if (DISPLAY_MEGABYTES(flags) || DISPLAY_GIGABYTES(flags)) {
 						usage(argv[0]);
 					}
 					/* Display stats in kB/s */
@@ -723,7 +734,7 @@ int main(int argc, char **argv)
 					break;
 
 				case 'm':
-					if (DISPLAY_KILOBYTES(flags)) {
+					if (DISPLAY_KILOBYTES(flags) || DISPLAY_GIGABYTES(flags)) {
 						usage(argv[0]);
 					}
 					/* Display stats in MB/s */

--- a/cifsiostat.h
+++ b/cifsiostat.h
@@ -19,11 +19,12 @@
 #define I_D_PRETTY		0x010
 /* Unused			0x020 */
 #define I_D_UNIT		0x040
-/* Unused			0x080 */
+#define I_D_GIGABYTES		0x080
 
 #define DISPLAY_TIMESTAMP(m)	   (((m) & I_D_TIMESTAMP)        == I_D_TIMESTAMP)
 #define DISPLAY_KILOBYTES(m)	   (((m) & I_D_KILOBYTES)        == I_D_KILOBYTES)
 #define DISPLAY_MEGABYTES(m)	   (((m) & I_D_MEGABYTES)        == I_D_MEGABYTES)
+#define DISPLAY_GIGABYTES(m)	   (((m) & I_D_GIGABYTES)        == I_D_GIGABYTES)
 #define DISPLAY_OMIT_SINCE_BOOT(m) (((m) & I_D_OMIT_SINCE_BOOT)  == I_D_OMIT_SINCE_BOOT)
 #define DISPLAY_PRETTY(m)	   (((m) & I_D_PRETTY)           == I_D_PRETTY)
 #define DISPLAY_UNIT(m)		   (((m) & I_D_UNIT)             == I_D_UNIT)

--- a/iostat.c
+++ b/iostat.c
@@ -87,21 +87,16 @@ void usage(char *progname)
 {
 	fprintf(stderr, _("Usage: %s [ options ] [ <interval> [ <count> ] ]\n"),
 		progname);
+	fprintf(stderr, _("Options are:\n"
+			  "[ -c ] [ -d ] [ -h ] [ -k | -m | -G ] [ -N ] [ -s ] [ -t ] [ -U ] [ -V ] [ -x ] [ -y ] [ -z ]\n"
+			  "[ { -f | +f } <directory> ] [ -j { ID | LABEL | PATH | UUID | ... } ]\n"
+			  "[ --compact ] [ --dec={ 0 | 1 | 2 } ] [ --human ] [ --pretty ] [ -o JSON ]\n"
+			  "[ [ -H ] -g <group_name> ] [ -p [ <device> [,...] | ALL ] ]\n"
+			  "[ <device> [...] | ALL ]"
 #ifdef DEBUG
-	fprintf(stderr, _("Options are:\n"
-			  "[ -c ] [ -d ] [ -h ] [ -k | -m | -g ] [ -N ] [ -s ] [ -t ] [ -U ] [ -V ] [ -x ] [ -y ] [ -z ]\n"
-			  "[ { -f | +f } <directory> ] [ -j { ID | LABEL | PATH | UUID | ... } ]\n"
-			  "[ --compact ] [ --dec={ 0 | 1 | 2 } ] [ --human ] [ --pretty ] [ -o JSON ]\n"
-			  "[ [ -H ] -g <group_name> ] [ -p [ <device> [,...] | ALL ] ]\n"
-			  "[ <device> [...] | ALL ] [ --debuginfo ]\n"));
-#else
-	fprintf(stderr, _("Options are:\n"
-			  "[ -c ] [ -d ] [ -h ] [ -k | -m ] [ -N ] [ -s ] [ -t ] [ -U ] [ -V ] [ -x ] [ -y ] [ -z ]\n"
-			  "[ { -f | +f } <directory> ] [ -j { ID | LABEL | PATH | UUID | ... } ]\n"
-			  "[ --compact ] [ --dec={ 0 | 1 | 2 } ] [ --human ] [ --pretty ] [ -o JSON ]\n"
-			  "[ [ -H ] -g <group_name> ] [ -p [ <device> [,...] | ALL ] ]\n"
-			  "[ <device> [...] | ALL ]\n"));
+			  " [ --debuginfo ]"
 #endif
+			  "\n"));
 	exit(1);
 }
 
@@ -114,7 +109,7 @@ void usage(char *progname)
  */
 void set_disk_output_unit(void)
 {
-	if (DISPLAY_KILOBYTES(flags) || DISPLAY_MEGABYTES(flags))
+	if (DISPLAY_KILOBYTES(flags) || DISPLAY_MEGABYTES(flags) || DISPLAY_GIGABYTES(flags))
 		return;
 
 	/* Check POSIXLY_CORRECT environment variable */
@@ -1069,12 +1064,12 @@ void write_disk_stat_header(int *fctr, int *tab, int hpart)
 		spc = " ";
 	}
 	else if (DISPLAY_MEGABYTES(flags)) {
-		*fctr = 2048;
+		*fctr = 2 * 1024;
 		units = "MB";
 		spc = " ";
 	}
 	else if (DISPLAY_GIGABYTES(flags)) {
-		*fctr = 2097152;
+		*fctr = 2 * 1024 * 1024;
 		units = "GB";
 		spc = " ";
 	}
@@ -1355,7 +1350,10 @@ void write_json_ext_stat(int tab, unsigned long long itv, int fctr,
 		       0.0 :
 		       S_VALUE(ioj->rd_ios + ioj->wr_ios + ioj->dc_ios,
 			       ioi->rd_ios + ioi->wr_ios + ioi->dc_ios, itv));
-		if (DISPLAY_MEGABYTES(flags)) {
+		if (DISPLAY_GIGABYTES(flags)) {
+			printf("GB/s");
+		}
+		else if (DISPLAY_MEGABYTES(flags)) {
 			printf("MB/s");
 		}
 		else if (DISPLAY_KILOBYTES(flags)) {
@@ -1388,7 +1386,10 @@ void write_json_ext_stat(int tab, unsigned long long itv, int fctr,
 						 : S_VALUE(ioj->dc_ios, ioi->dc_ios, itv),
 		       ioi->fl_ios < ioj->fl_ios ? 0.0
 						 : S_VALUE(ioj->fl_ios, ioi->fl_ios, itv));
-		if (DISPLAY_MEGABYTES(flags)) {
+		if (DISPLAY_GIGABYTES(flags)) {
+			sprintf(line, "\"rGB/s\": %%.2f, \"wGB/s\": %%.2f, \"dGB/s\": %%.2f, ");
+		}
+		else if (DISPLAY_MEGABYTES(flags)) {
 			sprintf(line, "\"rMB/s\": %%.2f, \"wMB/s\": %%.2f, \"dMB/s\": %%.2f, ");
 		}
 		else if (DISPLAY_KILOBYTES(flags)) {
@@ -1686,6 +1687,10 @@ void write_json_basic_stat(int tab, unsigned long long itv, int fctr,
 	else if (DISPLAY_MEGABYTES(flags)) {
 		sprintf(line, "\"MB_read/s\": %%.2f, \"MB_wrtn/s\": %%.2f, \"MB_dscd/s\": %%.2f, "
 			"\"MB_read\": %%llu, \"MB_wrtn\": %%llu, \"MB_dscd\": %%llu}");
+	}
+	else if (DISPLAY_GIGABYTES(flags)) {
+		sprintf(line, "\"GB_read/s\": %%.2f, \"GB_wrtn/s\": %%.2f, \"GB_dscd/s\": %%.2f, "
+			"\"GB_read\": %%llu, \"GB_wrtn\": %%llu, \"GB_dscd\": %%llu}");
 	}
 	else {
 		sprintf(line, "\"Blk_read/s\": %%.2f, \"Blk_wrtn/s\": %%.2f, \"Blk_dscd/s\": %%.2f, "
@@ -2239,7 +2244,7 @@ int main(int argc, char **argv)
 					break;
 
 				case 'k':
-					if (DISPLAY_MEGABYTES(flags)) {
+					if (DISPLAY_MEGABYTES(flags) || DISPLAY_GIGABYTES(flags)) {
 						usage(argv[0]);
 					}
 					/* Display stats in kB/s */
@@ -2247,11 +2252,19 @@ int main(int argc, char **argv)
 					break;
 
 				case 'm':
-					if (DISPLAY_KILOBYTES(flags)) {
+					if (DISPLAY_KILOBYTES(flags) || DISPLAY_GIGABYTES(flags)) {
 						usage(argv[0]);
 					}
 					/* Display stats in MB/s */
 					flags |= I_D_MEGABYTES;
+					break;
+
+				case 'G':
+					if (DISPLAY_KILOBYTES(flags) || DISPLAY_MEGABYTES(flags)) {
+						usage(argv[0]);
+					}
+					/* Display stats in GB/s */
+					flags |= I_D_GIGABYTES;
 					break;
 
 				case 'N':

--- a/iostat.c
+++ b/iostat.c
@@ -89,7 +89,7 @@ void usage(char *progname)
 		progname);
 #ifdef DEBUG
 	fprintf(stderr, _("Options are:\n"
-			  "[ -c ] [ -d ] [ -h ] [ -k | -m ] [ -N ] [ -s ] [ -t ] [ -U ] [ -V ] [ -x ] [ -y ] [ -z ]\n"
+			  "[ -c ] [ -d ] [ -h ] [ -k | -m | -g ] [ -N ] [ -s ] [ -t ] [ -U ] [ -V ] [ -x ] [ -y ] [ -z ]\n"
 			  "[ { -f | +f } <directory> ] [ -j { ID | LABEL | PATH | UUID | ... } ]\n"
 			  "[ --compact ] [ --dec={ 0 | 1 | 2 } ] [ --human ] [ --pretty ] [ -o JSON ]\n"
 			  "[ [ -H ] -g <group_name> ] [ -p [ <device> [,...] | ALL ] ]\n"
@@ -1071,6 +1071,11 @@ void write_disk_stat_header(int *fctr, int *tab, int hpart)
 	else if (DISPLAY_MEGABYTES(flags)) {
 		*fctr = 2048;
 		units = "MB";
+		spc = " ";
+	}
+	else if (DISPLAY_GIGABYTES(flags)) {
+		*fctr = 2097152;
+		units = "GB";
 		spc = " ";
 	}
 	else if (DISPLAY_EXTENDED(flags)) {

--- a/iostat.h
+++ b/iostat.h
@@ -16,7 +16,7 @@
 #define I_D_EVERYTHING		0x000010
 #define I_D_KILOBYTES		0x000020
 #define I_D_ALL_DIR		0x000040
-/* Unused			0x000080 */
+#define I_D_GIGABYTES		0x000080
 #define I_D_UNFILTERED		0x000100
 #define I_D_MEGABYTES		0x000200
 #define I_D_ALL_DEVICES		0x000400
@@ -40,6 +40,7 @@
 #define DISPLAY_EVERYTHING(m)		(((m) & I_D_EVERYTHING)       == I_D_EVERYTHING)
 #define DISPLAY_KILOBYTES(m)		(((m) & I_D_KILOBYTES)        == I_D_KILOBYTES)
 #define DISPLAY_MEGABYTES(m)		(((m) & I_D_MEGABYTES)        == I_D_MEGABYTES)
+#define DISPLAY_GIGABYTES(m)		(((m) & I_D_GIGABYTES)        == I_D_GIGABYTES)
 #define DISPLAY_UNFILTERED(m)		(((m) & I_D_UNFILTERED)       == I_D_UNFILTERED)
 #define DISPLAY_ALL_DEVICES(m)		(((m) & I_D_ALL_DEVICES)      == I_D_ALL_DEVICES)
 #define GROUP_DEFINED(m)		(((m) & I_F_GROUP_DEFINED)    == I_F_GROUP_DEFINED)

--- a/man/cifsiostat.in
+++ b/man/cifsiostat.in
@@ -5,11 +5,11 @@ cifsiostat \- Report CIFS statistics.
 
 .SH SYNOPSIS
 .ie 'yes'@WITH_DEBUG@' \{
-.B cifsiostat [ \-h ] [ \-k | \-m ] [ \-t ] [ \-U ] [ \-V ] [ -y ] [ \-\-debuginfo ] [ \-\-dec={ 0 | 1 | 2 } ] [ \-\-human ] [ \-o JSON ] [ \-\-pretty ] [
+.B cifsiostat [ \-h ] [ \-k | \-m | \-G ] [ \-t ] [ \-U ] [ \-V ] [ -y ] [ \-\-debuginfo ] [ \-\-dec={ 0 | 1 | 2 } ] [ \-\-human ] [ \-o JSON ] [ \-\-pretty ] [
 .IB "interval " "[ " "count " "] ]"
 .\}
 .el \{
-.B cifsiostat [ \-h ] [ \-k | \-m ] [ \-t ] [ \-U ] [ \-V ] [ -y ] [ \-\-dec={ 0 | 1 | 2 } ] [ \-\-human ] [ \-o JSON ] [ \-\-pretty ] [
+.B cifsiostat [ \-h ] [ \-k | \-m | \-G ] [ \-t ] [ \-U ] [ \-V ] [ -y ] [ \-\-dec={ 0 | 1 | 2 } ] [ \-\-human ] [ \-o JSON ] [ \-\-pretty ] [
 .IB "interval " "[ " "count " "] ]"
 .\}
 
@@ -41,10 +41,10 @@ The report shows the following fields:
 
 .IP Filesystem:
 This columns shows the mount point of the CIFS filesystem.
-.IP "rB/s (rkB/s, rMB/s)"
-Indicate the average number of bytes (kibibytes, mebibytes) read per second.
-.IP "wB/s (wkB/s, wMB/s)"
-Indicate the average number of bytes (kibibytes, mebibytes) written per second.
+.IP "rB/s (rkB/s, rMB/s, rGB/s)"
+Indicate the average number of bytes (kibibytes, mebibytes, gibibytes) read per second.
+.IP "wB/s (wkB/s, wMB/s, wGB/s)"
+Indicate the average number of bytes (kibibytes, mebibytes, gibibytes) written per second.
 .IP rop/s
 Indicate the number of 'read' operations that were issued to the filesystem
 per second.
@@ -76,6 +76,9 @@ This option is equivalent to specifying
 Print sizes in human readable format (e.g. 1.0k, 1.2M, etc.)
 The units displayed with this option supersede any other default units (e.g.
 kibibytes, sectors...) associated with the metrics.
+.TP
+.B \-G
+Display statistics in gibibytes per second.
 .TP
 .B \-k
 Display statistics in kibibytes per second.
@@ -149,8 +152,8 @@ command will use the ISO 8601 format (YYYY-MM-DD) instead.
 .BR "cifsiostat " "to work."
 .PP
 .RB "Although " "cifsiostat"
-displays units corresponding to kilobytes (kB), megabytes (MB)..., it actually uses kibibytes (kiB), mebibytes (MiB)...
-A kibibyte is equal to 1024 bytes, and a mebibyte is equal to 1024 kibibytes.
+displays units corresponding to kilobytes (kB), megabytes (MB), gigabytes (GB)..., it actually uses kibibytes (kiB), mebibytes (MiB), gibibytes (GiB)...
+A kibibyte is equal to 1024 bytes, a mebibyte is equal to 1024 kibibytes, and a gibibyte is equal to 1024 mebibytes.
 
 .SH FILE
 .IR "/proc/fs/cifs/Stats " "contains CIFS statistics."

--- a/man/iostat.in
+++ b/man/iostat.in
@@ -6,13 +6,13 @@ statistics for devices and partitions.
 
 .SH SYNOPSIS
 .ie 'yes'@WITH_DEBUG@' \{
-.B iostat [ \-c ] [ \-d ] [ \-h ] [ \-k | \-m ] [ \-N ] [ \-s ] [ \-t ] [ \-U ] [ \-V ] [ \-x ] [ \-y ] [ \-z ]
+.B iostat [ \-c ] [ \-d ] [ \-h ] [ \-k | \-m | \-G ] [ \-N ] [ \-s ] [ \-t ] [ \-U ] [ \-V ] [ \-x ] [ \-y ] [ \-z ]
 .BI "[ \-\-compact ] [ \-\-dec={ 0 | 1 | 2 } ] [ { \-f | +f } " "directory" " ] [ \-j { ID | LABEL | PATH | UUID | ... } ] "
 .BI "[ \-o JSON ] [ [ \-H ] \-g " "group_name " "] [ \-\-human ] [ \-\-pretty ] [ \-p [ " "device" "[,...] | ALL ] ] ["
 .IB "device " "[...] | ALL ] [ \-\-debuginfo ] [ " "interval " "[ " "count " "] ] "
 .\}
 .el \{
-.B iostat [ \-c ] [ \-d ] [ \-h ] [ \-k | \-m ] [ \-N ] [ \-s ] [ \-t ] [ \-U ] [ \-V ] [ \-x ] [ \-y ] [ \-z ]
+.B iostat [ \-c ] [ \-d ] [ \-h ] [ \-k | \-m | \-G ] [ \-N ] [ \-s ] [ \-t ] [ \-U ] [ \-V ] [ \-x ] [ \-y ] [ \-z ]
 .BI "[ \-\-compact ] [ \-\-dec={ 0 | 1 | 2 } ] [ { \-f | +f } " "directory" " ] [ \-j { ID | LABEL | PATH | UUID | ... } ] "
 .BI "[ \-o JSON ] [ [ \-H ] \-g " "group_name " "] [ \-\-human ] [ \-\-pretty ] [ \-p [ " "device" "[,...] | ALL ] ] ["
 .IB "device " "[...] | ALL ] [ " "interval " "[ " "count " "] ]"
@@ -109,7 +109,7 @@ variable
 .B POSIXLY_CORRECT
 is set, in which case 512-byte blocks are used.
 The report may show the following fields, depending on the flags used (e.g.
-.BR "\-x" ", " "\-s " "and " "\-k " "or " "\-m" "):"
+.BR "\-x" ", " "\-s " "and " "\-k" ", " "\-m " "or " "\-G" "):"
 .RS
 .IP Device:
 This column gives the device (or partition) name as listed in the
@@ -119,27 +119,27 @@ Indicate the number of transfers per second that were issued
 to the device. A transfer is an I/O request to the
 device. Multiple logical requests can be combined into a single I/O
 request to the device. A transfer is of indeterminate size.
-.IP "Blk_read/s (kB_read/s, MB_read/s)"
+.IP "Blk_read/s (kB_read/s, MB_read/s, GB_read/s)"
 Indicate the amount of data read from the device expressed in a number of
-blocks (kibibytes, mebibytes) per second. Blocks are equivalent to sectors
+blocks (kibibytes, mebibytes, gibibytes) per second. Blocks are equivalent to sectors
 and therefore have a size of 512 bytes.
-.IP "Blk_wrtn/s (kB_wrtn/s, MB_wrtn/s)"
+.IP "Blk_wrtn/s (kB_wrtn/s, MB_wrtn/s, GB_wrtn/s)"
 Indicate the amount of data written to the device expressed in a number of
-blocks (kibibytes, mebibytes) per second.
-.IP "Blk_dscd/s (kB_dscd/s, MB_dscd/s)"
+blocks (kibibytes, mebibytes, gibibytes) per second.
+.IP "Blk_dscd/s (kB_dscd/s, MB_dscd/s, GB_dscd/s)"
 Indicate the amount of data discarded for the device expressed in a number of
-blocks (kibibytes, mebibytes) per second.
-.IP "Blk_w+d/s (kB_w+d/s, MB_w+d/s)"
+blocks (kibibytes, mebibytes, gibibytes) per second.
+.IP "Blk_w+d/s (kB_w+d/s, MB_w+d/s, GB_w+d/s)"
 Indicate the amount of data written to or discarded for the device expressed
-in a number of blocks (kibibytes, mebibytes) per second.
-.IP "Blk_read (kB_read, MB_read)"
-The total number of blocks (kibibytes, mebibytes) read.
-.IP "Blk_wrtn (kB_wrtn, MB_wrtn)"
-The total number of blocks (kibibytes, mebibytes) written.
-.IP "Blk_dscd (kB_dscd, MB_dscd)"
-The total number of blocks (kibibytes, mebibytes) discarded.
-.IP "Blk_w+d (kB_w+d, MB_w+d)"
-The total number of blocks (kibibytes, mebibytes) written or discarded.
+in a number of blocks (kibibytes, mebibytes, gibibytes) per second.
+.IP "Blk_read (kB_read, MB_read, GB_read)"
+The total number of blocks (kibibytes, mebibytes, gibibytes) read.
+.IP "Blk_wrtn (kB_wrtn, MB_wrtn, GB_wrtn)"
+The total number of blocks (kibibytes, mebibytes, gibibytes) written.
+.IP "Blk_dscd (kB_dscd, MB_dscd, GB_dscd)"
+The total number of blocks (kibibytes, mebibytes, gibibytes) discarded.
+.IP "Blk_w+d (kB_w+d, MB_w+d, GB_w+d)"
+The total number of blocks (kibibytes, mebibytes, gibibytes) written or discarded.
 .IP r/s
 The number (after merges) of read requests completed per second for the device.
 .IP w/s
@@ -150,15 +150,15 @@ The number (after merges) of discard requests completed per second for the devic
 The number (after merges) of flush requests completed per second for the device.
 This counts flush requests executed by disks. Flush requests are not tracked for partitions.
 Before being merged, flush operations are counted as writes.
-.IP "sec/s (kB/s, MB/s)"
-The number of sectors (kibibytes, mebibytes) read from, written to or
+.IP "sec/s (kB/s, MB/s, GB/s)"
+The number of sectors (kibibytes, mebibytes, gibibytes) read from, written to or
 discarded for the device per second.
-.IP "rsec/s (rkB/s, rMB/s)"
-The number of sectors (kibibytes, mebibytes) read from the device per second.
-.IP "wsec/s (wkB/s, wMB/s)"
-The number of sectors (kibibytes, mebibytes) written to the device per second.
-.IP "dsec/s (dkB/s, dMB/s)"
-The number of sectors (kibibytes, mebibytes) discarded for the device per second.
+.IP "rsec/s (rkB/s, rMB/s, rGB/s)"
+The number of sectors (kibibytes, mebibytes, gibibytes) read from the device per second.
+.IP "wsec/s (wkB/s, wMB/s, wGB/s)"
+The number of sectors (kibibytes, mebibytes, gibibytes) written to the device per second.
+.IP "dsec/s (dkB/s, dMB/s, dGB/s)"
+The number of sectors (kibibytes, mebibytes, gibibytes) discarded for the device per second.
 .IP rqm/s
 The number of I/O requests merged per second that were queued to the device.
 .IP rrqm/s
@@ -310,6 +310,9 @@ Because persistent device names are usually long, option
 .B \-\-pretty
 is implicitly set with this option.
 .TP
+.B \-G
+Display statistics in gibibytes per second.
+.TP
 .B \-k
 Display statistics in kibibytes per second.
 .TP
@@ -454,8 +457,8 @@ partitions (sda1, etc.)
 Kernels older than 2.6.x are no longer supported.
 .PP
 .RB "Although " "iostat"
-displays units corresponding to kilobytes (kB), megabytes (MB)..., it actually uses kibibytes (kiB), mebibytes (MiB)...
-A kibibyte is equal to 1024 bytes, and a mebibyte is equal to 1024 kibibytes.
+displays units corresponding to kilobytes (kB), megabytes (MB), gigabytes (GB)..., it actually uses kibibytes (kiB), mebibytes (MiB), gibibytes (GiB)...
+A kibibyte is equal to 1024 bytes, a mebibyte is equal to 1024 kibibytes, and a gibibyte is equal to 1024 mebibytes.
 
 .SH FILES
 .IR "/proc/stat " "contains system statistics."

--- a/man/tapestat.1
+++ b/man/tapestat.1
@@ -5,7 +5,7 @@
 tapestat \- Report tape statistics.
 
 .SH SYNOPSIS
-.B tapestat [ \-k | \-m ] [ \-t ] [ \-U ] [ \-V ] [ \-y ] [ \-z ] [ \-\-human ] [ \-o JSON ] [
+.B tapestat [ \-k | \-m | \-G ] [ \-t ] [ \-U ] [ \-V ] [ \-y ] [ \-z ] [ \-\-human ] [ \-o JSON ] [
 .IB "interval " "[ " "count " "] ]"
 
 .SH DESCRIPTION
@@ -38,13 +38,17 @@ The following data are displayed:
 The number of reads issued expressed as the number per second averaged over the interval.
 .IP w/s
 The number of writes issued expressed as the number per second averaged over the interval.
-.IP "kB_read/s | MB_read/s"
+.IP "kB_read/s | MB_read/s | GB_read/s"
 The amount of data read expressed in kibibytes (by default or if option
-.BR "\-k " "used) or mebibytes (if option " "\-m"
+.BR "\-k " "used), mebibytes (if option " "\-m"
+used) or gibibytes (if option
+.BR "\-G"
 used) per second averaged over the interval.
-.IP "kB_wrtn/s | MB_wrtn/s"
+.IP "kB_wrtn/s | MB_wrtn/s | GB_wrtn/s"
 The amount of data written expressed in kibibytes (by default or if option
-.BR "\-k " "used) or mebibytes (if option " "\-m"
+.BR "\-k " "used), mebibytes (if option " "\-m"
+used) or gibibytes (if option
+.BR "\-G"
 used) per second averaged over the interval.
 .IP %Rd
 Read percentage wait - The percentage of time over the interval spent waiting for read requests
@@ -75,15 +79,20 @@ Print sizes in human readable format (e.g. 1.0k, 1.2M, etc.)
 The units displayed with this option supersede any other default units (e.g.
 kibibytes, sectors...) associated with the metrics.
 .TP
+.B \-G
+Show the amount of data written or read in gibibytes per second.
+This option is mutually exclusive with
+.BR "\-k " "and " "\-m" "."
+.TP
 .B \-k
 Show the amount of data written or read in kibibytes per second instead of mebibytes.
 This option is mutually exclusive with
-.BR "\-m" "."
+.BR "\-G " "and " "\-m" "."
 .TP
 .B \-m
 Show the amount of data written or read in mebibytes per second instead of kibibytes.
 This option is mutually exclusive with
-.BR "\-k" "."
+.BR "\-G " "and " "\-k" "."
 .TP
 .B \-o JSON
 Display the statistics in JSON (JavaScript Object Notation) format.
@@ -219,8 +228,8 @@ This command requires kernel version 4.2 or later
 (or tape statistics support backported for an earlier kernel version).
 .PP
 .RB "Although " "tapestat"
-displays units corresponding to kilobytes (kB), megabytes (MB)..., it actually uses kibibytes (kiB), mebibytes (MiB)...
-A kibibyte is equal to 1024 bytes, and a mebibyte is equal to 1024 kibibytes.
+displays units corresponding to kilobytes (kB), megabytes (MB), gigabytes (GB)..., it actually uses kibibytes (kiB), mebibytes (MiB), gibibytes (GiB)...
+A kibibyte is equal to 1024 bytes, a mebibyte is equal to 1024 kibibytes, and a gibibyte is equal to 1024 mebibytes.
 
 .SH FILES
 .I /sys/class/scsi_tape/st<num>/stats/*

--- a/tapestat.c
+++ b/tapestat.c
@@ -105,7 +105,7 @@ void usage(char *progname)
 	fprintf(stderr, _("Usage: %s [ options ] [ <interval> [ <count> ] ]\n"),
 		progname);
 	fprintf(stderr, _("Options are:\n"
-			  "[ --human ] [ -k | -m ] [ -o JSON ] [ -t ] [ -U ] [ -V ] [ -y ] [ -z ]\n"));
+			  "[ --human ] [ -k | -m | -G ] [ -o JSON ] [ -t ] [ -U ] [ -V ] [ -y ] [ -z ]\n"));
 	exit(1);
 }
 
@@ -402,7 +402,9 @@ void write_tape_headings(int *tab)
 	}
 
 	printf("Tape:     r/s     w/s   ");
-	if (DISPLAY_MEGABYTES(flags)) {
+	if (DISPLAY_GIGABYTES(flags)) {
+		printf("GB_read/s   GB_wrtn/s");
+	} else if (DISPLAY_MEGABYTES(flags)) {
 		printf("MB_read/s   MB_wrtn/s");
 	} else {
 		printf("kB_read/s   kB_wrtn/s");
@@ -478,7 +480,9 @@ void write_plain_tape_stats(struct calc_stats *tape, int i)
 	char buffer[32];
 	uint64_t divisor = 1;
 
-	if (DISPLAY_MEGABYTES(flags))
+	if (DISPLAY_GIGABYTES(flags))
+		divisor = 1024 * 1024;
+	else if (DISPLAY_MEGABYTES(flags))
 		divisor = 1024;
 
 	sprintf(buffer, "st%i        ", i);
@@ -523,7 +527,12 @@ void write_json_tape_stats(int tab, struct calc_stats *tape, int i)
 		 "\"r/s\": %" PRIu64 ", \"w/s\": %" PRIu64 ", ",
 		 i, tape->reads_per_second, tape->writes_per_second);
 
-	if (DISPLAY_MEGABYTES(flags)) {
+	if (DISPLAY_GIGABYTES(flags)) {
+		divisor = 1024 * 1024;
+		sprintf(line, "\"GB_read/s\": %%%s, \"GB_wrtn/s\": %%%s, ",
+			PRIu64, PRIu64);
+	}
+	else if (DISPLAY_MEGABYTES(flags)) {
 		divisor = 1024;
 		sprintf(line, "\"MB_read/s\": %%%s, \"MB_wrtn/s\": %%%s, ",
 			PRIu64, PRIu64);
@@ -782,7 +791,7 @@ int main(int argc, char **argv)
 				switch (*(argv[opt] + i)) {
 
 				case 'k':
-					if (DISPLAY_MEGABYTES(flags)) {
+					if (DISPLAY_MEGABYTES(flags) || DISPLAY_GIGABYTES(flags)) {
 						usage(argv[0]);
 					}
 					/* Display stats in kB/s */
@@ -790,11 +799,19 @@ int main(int argc, char **argv)
 					break;
 
 				case 'm':
-					if (DISPLAY_KILOBYTES(flags)) {
+					if (DISPLAY_KILOBYTES(flags) || DISPLAY_GIGABYTES(flags)) {
 						usage(argv[0]);
 					}
 					/* Display stats in MB/s */
 					flags |= T_D_MEGABYTES;
+					break;
+
+				case 'G':
+					if (DISPLAY_KILOBYTES(flags) || DISPLAY_MEGABYTES(flags)) {
+						usage(argv[0]);
+					}
+					/* Display stats in GB/s */
+					flags |= T_D_GIGABYTES;
 					break;
 
 				case 't':

--- a/tapestat.h
+++ b/tapestat.h
@@ -16,13 +16,14 @@
 #define T_D_KILOBYTES		0x00002
 #define T_D_MEGABYTES		0x00004
 #define T_D_OMIT_SINCE_BOOT	0x00008
-/* Unused			0x00010 */
+#define T_D_GIGABYTES		0x00010
 #define T_D_ZERO_OMIT		0x00020
 #define T_D_UNIT		0x00040
 
 #define DISPLAY_TIMESTAMP(m)		(((m) & T_D_TIMESTAMP)       == T_D_TIMESTAMP)
 #define DISPLAY_KILOBYTES(m)		(((m) & T_D_KILOBYTES)       == T_D_KILOBYTES)
 #define DISPLAY_MEGABYTES(m)		(((m) & T_D_MEGABYTES)       == T_D_MEGABYTES)
+#define DISPLAY_GIGABYTES(m)		(((m) & T_D_GIGABYTES)       == T_D_GIGABYTES)
 #define DISPLAY_OMIT_SINCE_BOOT(m)	(((m) & T_D_OMIT_SINCE_BOOT) == T_D_OMIT_SINCE_BOOT)
 #define DISPLAY_ZERO_OMIT(m)		(((m) & T_D_ZERO_OMIT)       == T_D_ZERO_OMIT)
 #define DISPLAY_UNIT(m)			(((m) & T_D_UNIT)	     == T_D_UNIT)

--- a/tests/02635
+++ b/tests/02635
@@ -1,0 +1,3 @@
+rm -f tests/root
+ln -s ${T_SRCDIR}/tests/root1 tests/root
+LC_ALL=C TZ=GMT ./iostat -Gz -p ALL 1 2 > tests/out.iostat-Gz.tmp && diff -u ${T_SRCDIR}/tests/expected.iostat-Gz tests/out.iostat-Gz.tmp

--- a/tests/04015
+++ b/tests/04015
@@ -1,0 +1,3 @@
+rm -f tests/root
+ln -s ${T_SRCDIR}/tests/root1 tests/root
+LC_ALL=C TZ=GMT ./tapestat -G 1 2 > tests/out.tapestat-G.tmp && diff -u ${T_SRCDIR}/tests/expected.tapestat-G tests/out.tapestat-G.tmp

--- a/tests/04513
+++ b/tests/04513
@@ -1,0 +1,3 @@
+rm -f tests/root
+ln -s ${T_SRCDIR}/tests/root1 tests/root
+LC_ALL=C TZ=GMT ./cifsiostat -G 1 3 > tests/out.cifsiostat-G.tmp && diff -u ${T_SRCDIR}/tests/expected.cifsiostat-G tests/out.cifsiostat-G.tmp

--- a/tests/TLIST
+++ b/tests/TLIST
@@ -473,6 +473,7 @@ NOTES:
 02615	LC_ALL=C TZ=GMT ./iostat -x --pretty --compact 1 2 > tests/out.iostat-compact.tmp
 02620	LC_ALL=C TZ=GMT ./iostat -dh -p ALL > tests/out.iostat-h.tmp
 02630	LC_ALL=C TZ=GMT ./iostat -kz -p ALL 1 2 > tests/out.iostat-kz.tmp
+02635	LC_ALL=C TZ=GMT ./iostat -Gz -p ALL 1 2 > tests/out.iostat-Gz.tmp
 02640	LC_ALL=C TZ=GMT ./iostat -dN -p ALL > tests/out.iostat-N.tmp
 02642	LC_ALL=C TZ=GMT ./iostat -N dm-2 sda1 > tests/out.iostat-N-list1.tmp
 02644	LC_ALL=C TZ=GMT ./iostat -dN virtualhd sdr > tests/out.iostat-N-list2.tmp
@@ -535,6 +536,7 @@ NOTES:
 =====	tapestat: Basic tests
 04000	LC_ALL=C TZ=GMT ./tapestat > tests/out.tapestat.tmp
 04010	LC_ALL=C TZ=GMT ./tapestat -m 1 2 > tests/out.tapestat-m.tmp
+04015	LC_ALL=C TZ=GMT ./tapestat -G 1 2 > tests/out.tapestat-G.tmp
 04020	LC_ALL=C TZ=GMT ./tapestat --human -y 1 2 > tests/out.tapestat-y.tmp
 04030	LC_ALL=C TZ=GMT ./tapestat -z 1 2 > tests/out.tapestat-z.tmp
 04040	LC_ALL=C TZ=GMT ./tapestat -t 1 2 > tests/out.tapestat-t.tmp
@@ -554,6 +556,7 @@ NOTES:
 04500	LC_ALL=C TZ=GMT ./cifsiostat > tests/out.cifsiostat.tmp
 04505	LC_ALL=C TZ=GMT ./cifsiostat 1 2 2>&1 | grep "No CIFS filesystems" >/dev/null
 04510	LC_ALL=C TZ=GMT ./cifsiostat -k 1 3 > tests/out.cifsiostat-k.tmp
+04513	LC_ALL=C TZ=GMT ./cifsiostat -G 1 3 > tests/out.cifsiostat-G.tmp
 04515	LC_ALL=C TZ=GMT ./cifsiostat -y -k 1 2 > tests/out.cifsiostat-yk.tmp
 04520	LC_ALL=C TZ=GMT ./cifsiostat -t --human 1 3 > tests/out.cifsiostat-t-human.tmp
 04530	LC_ALL=C TZ=GMT ./cifsiostat -h 2 3 > tests/out.cifsiostat-h.tmp

--- a/tests/expected.cifsiostat-G
+++ b/tests/expected.cifsiostat-G
@@ -1,0 +1,13 @@
+Linux 1.2.3-TEST (SYSSTAT.TEST) 	06/01/20 	_x86_64_	(9 CPU)
+
+Filesystem                    rGB/s        wGB/s    rops/s    wops/s         fo/s         fc/s         fd/s
+\\addr\SHARED                  0.00         0.00      0.00      0.00         0.00         0.00         0.00
+
+Filesystem                    rGB/s        wGB/s    rops/s    wops/s         fo/s         fc/s         fd/s
+\\addr\SHARED                  0.00         0.00      0.19      0.10         0.00         0.00         0.00
+\\server\share1                0.00         0.00      0.16      0.06         0.16         0.06         0.03
+
+Filesystem                    rGB/s        wGB/s    rops/s    wops/s         fo/s         fc/s         fd/s
+\\addr\SHARED                  0.00         0.00      0.00      0.00         0.10         0.19         0.16
+\\server\share1                0.00         0.00      0.29      0.38         0.32         0.32         0.32
+

--- a/tests/expected.iostat-Gz
+++ b/tests/expected.iostat-Gz
@@ -1,0 +1,34 @@
+Linux 1.2.3-TEST (SYSSTAT.TEST) 	06/01/20 	_x86_64_	(9 CPU)
+
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           1.49   39.91    1.67    0.94    0.00   56.00
+
+Device             tps    GB_read/s    GB_wrtn/s    GB_dscd/s    GB_read    GB_wrtn    GB_dscd
+sda               8.59         0.00         0.00         0.00          1          0          0
+sda1              0.01         0.00         0.00         0.00          0          0          0
+sda2              0.01         0.00         0.00         0.00          0          0          0
+sda3              0.01         0.00         0.00         0.00          0          0          0
+sda4              0.00         0.00         0.00         0.00          0          0          0
+sda5              0.01         0.00         0.00         0.00          0          0          0
+sda6              0.02         0.00         0.00         0.00          0          0          0
+sda7              0.02         0.00         0.00         0.00          0          0          0
+sda8              0.01         0.00         0.00         0.00          0          0          0
+sda9              6.60         0.00         0.00         0.00          1          0          0
+sda10             0.01         0.00         0.00         0.00          0          0          0
+sda11             0.01         0.00         0.00         0.00          0          0          0
+sda12             1.88         0.00         0.00         0.00          0          0          0
+sdb               0.01         0.00         0.00         0.00          0          0          0
+sdq               8.07         0.00         0.00         0.00          1          0          0
+sdr               2.77         0.00         0.00         0.00          0          0          0
+sds               0.15         0.00         0.00         0.00          0          0          0
+
+
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           2.15   12.50    2.35    0.12    0.00   82.89
+
+Device             tps    GB_read/s    GB_wrtn/s    GB_dscd/s    GB_read    GB_wrtn    GB_dscd
+sdq               9.62         0.00         0.00         0.00          0          0          0
+sdr               4.81         0.00         0.00         0.00          0          0          0
+sds               6.42         0.00         0.00         0.00          0          0          0
+
+

--- a/tests/expected.tapestat-G
+++ b/tests/expected.tapestat-G
@@ -1,0 +1,10 @@
+Linux 1.2.3-TEST (SYSSTAT.TEST) 	06/01/20 	_x86_64_	(9 CPU)
+
+Tape:     r/s     w/s   GB_read/s   GB_wrtn/s  %Rd  %Wr  %Oa    Rs/s    Ot/s
+st0         1     139           0           0    0    4    6       1       0
+st1         1     139           0           0    0    4    6       1       0
+
+Tape:     r/s     w/s   GB_read/s   GB_wrtn/s  %Rd  %Wr  %Oa    Rs/s    Ot/s
+st0         3      26           0           0    0    0    0       6       0
+st1         0       0           0           0    0    0    0       0       0
+


### PR DESCRIPTION
Add -G option to iostat, tapestat and cifsiostat to display I/O statistics in gibibytes per second, consistent with the existing -k (kibibytes) and -m (mebibytes) options.  Using -G rather than -g because iostat already uses -g to specify a device group name (-g <group_name>).

Resolves https://github.com/sysstat/sysstat/pull/389