### PR TITLE
Fix sa scripts long name handling

### DIFF
--- a/sa1.in
+++ b/sa1.in
@@ -25,11 +25,8 @@ umask ${UMASK}
 [ -d ${SA_DIR} ] || SA_DIR=@SA_DIR@
 [ -d @SA_DIR@ ] || mkdir @SA_DIR@
 
-if [ ${HISTORY} -gt 28 ]
-then
-	SADC_OPTIONS="${SADC_OPTIONS} -D"
-	LONG_NAME=y
-fi
+[ ${HISTORY} -gt 28 ] && SADC_OPTIONS="${SADC_OPTIONS} -D"
+case "${SADC_OPTIONS}" in *-D*) LONG_NAME=y ;; esac
 
 ENDIR=@SA_LIB_DIR@
 cd ${ENDIR}

--- a/sa2.in
+++ b/sa2.in
@@ -41,7 +41,8 @@ else
 	DATE_OPTS="--date=yesterday"
 fi
 
-if [ ${HISTORY} -gt 28 ]
+case "${SADC_OPTIONS}" in *-D*) LONG_NAME=y ;; esac
+if [ ${HISTORY} -gt 28 ] || [ "${LONG_NAME}" = "y" ]
 then
 	DATE=`date ${DATE_OPTS} +%Y%m%d`
 else


### PR DESCRIPTION
If -D is set explicitly in SADC_OPTIONS the rotate path still uses the short saDD format, creating misnamed data directories.