### PR TITLE
Slightly reduce scope of install-cron configure script option

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -264,11 +264,11 @@ You can install the `sysstat` script by hand in the relevant startup
 directory, or you can ask sysstat to do it for you during configuration
 stage by entering:
 ```
-$ ./configure --enable-install-cron
+$ ./configure --enable-automated-sar-reporting
 ```
 Or you can answer 'y' to the question:
 ```
-Set crontab to start sar automatically? (y/n) [--enable-install-cron]
+Automate sar reporting (via systemd or cron)? (y/n) [--enable-automated-sar-reporting]
 ```
 if you use the Interactive Configuration script (iconfig).  
 Then compile sysstat as usual and run 'make install' as the last stage.

--- a/Makefile.in
+++ b/Makefile.in
@@ -173,8 +173,8 @@ LD = gcc
 LDFLAGS += $(CFLAGS)
 endif
 
-ifndef INSTALL_CRON
-INSTALL_CRON = @INSTALL_CRON@
+ifndef AUTOMATE_SAR
+AUTOMATE_SAR = @AUTOMATE_SAR@
 endif
 ifndef CRON_OWNER
 CRON_OWNER = @CRON_OWNER@
@@ -791,13 +791,13 @@ endif
 		rm -f $(DESTDIR)$(SYSTEMD_SLEEP_DIR)/sysstat.sleep; \
 	fi
 
-ifeq ($(INSTALL_CRON),y)
+ifeq ($(AUTOMATE_SAR),y)
 uninstall: uninstall_all
 else
 uninstall: uninstall_base
 endif
 
-ifeq ($(INSTALL_CRON),y)
+ifeq ($(AUTOMATE_SAR),y)
 install: install_all
 else
 install: install_base

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ You can set several variables and parameters on the command line. For example yo
 can enter the following option to activate data collecting (either using cron or systemd):
 
 ```
-$ ./configure --enable-install-cron
+$ ./configure --enable-automated-sar-reporting
 ```
 
 Enter `./configure --help` to display all possible options.

--- a/build/automated-sar-reporting
+++ b/build/automated-sar-reporting
@@ -1,0 +1,6 @@
+
+Answer y to automate sar reporting. The sa1 data collector and sa2 report
+generator will be run periodically using systemd timers if systemd is
+available, or via cron otherwise. System activity daily data files will
+be created in the /var/log/sa directory.
+Default answer is n here.

--- a/build/collect_interval
+++ b/build/collect_interval
@@ -1,0 +1,6 @@
+
+You may enter here the collection interval (in minutes) that the
+configuration script will use.
+Default value is 10. This means that sadc (the system activity data
+collector) will take a snapshot of the system counters every 10 minutes.
+Other reasonable values could be 5, 15 or 20 minutes.

--- a/build/cron_interval
+++ b/build/cron_interval
@@ -1,7 +1,0 @@
-
-You may enter here the sampling interval (in minutes) that the configuration
-script will use to customize the crontab.
-Default value is 10. This means that sadc (the system activity data collector
-called by sar) will take a snapshot of the system counters every 10 minutes.
-Other reasonable values could be 5, 15 or 20 minutes.
-

--- a/build/install-cron
+++ b/build/install-cron
@@ -1,9 +1,0 @@
-
-Answer y if you want to automate sar reporting. In this case, a crontab will
-be created to periodically start the data collector. System activity daily
-data files will then be created in the /var/log/sa directory.
-You can find various crontab templates in sysstat directory. By default
-sysstat will try to use sysstat.crond template and install it in the
-/etc/cron.d directory.
-Default answer is n here.
-

--- a/configure
+++ b/configure
@@ -645,18 +645,18 @@ STRIP
 WITH_DEBUG
 DFLAGS
 INSTALL_DOC
-COLLECT_ALL
-REM_CHOWN
-QUOTE
-CRON_COUNT
-CRON_INTERVAL_SEC
-CRON_INTERVAL
-SU_C_OWNER
-CRON_OWNER
 COPY_ONLY
 SADC_OPT
 sadc_options
-cron_interval
+COLLECT_ALL
+COLLECT_COUNT
+COLLECT_INTERVAL_SEC
+COLLECT_INTERVAL
+collect_interval
+SU_C_OWNER
+REM_CHOWN
+QUOTE
+CRON_OWNER
 USE_CROND
 cron_owner
 INSTALL_CRON
@@ -809,7 +809,7 @@ compressafter
 delay_range
 man_group
 cron_owner
-cron_interval
+collect_interval
 sadc_options'
 
 
@@ -1477,8 +1477,8 @@ Some influential environment variables:
               its reports
   man_group   group for manual pages
   cron_owner  crontab owner
-  cron_interval
-              crontab interval
+  collect_interval
+              collection interval (in minutes)
   sadc_options
               options to be passed to sadc
 
@@ -5241,19 +5241,19 @@ echo .
 #  --enable-lto	            compile with Link Time Optimizations
 #
 # Some influential environment variables:
-#  rcdir         directory where startup scripts are installed
-#  sa_lib_dir    sadc, sa1 and sa2 directory
-#  sa_dir        system activity daily datafiles directory
-#  sar_dir       sar binary location. Used only in sa2 shell script
-#  conf_dir      sysstat configuration directory (default is /etc/sysconfig)
-#  conf_file     sysstat configuration file (default is sysstat)
-#  history       number of daily datafiles to keep (default value is 7)
-#  delay_range   maximum delay (in seconds) to wait before sa2 script generates its reports
-#  compressafter number of days after which datafiles are compressed
-#  man_group     group for man pages
-#  cron_owner    crontab owner
-#  cron_interval crontab sampling interval
-#  sadc_options  options to be passed to sadc
+#  rcdir             directory where startup scripts are installed
+#  sa_lib_dir        sadc, sa1 and sa2 directory
+#  sa_dir            system activity daily datafiles directory
+#  sar_dir           sar binary location. Used only in sa2 shell script
+#  conf_dir          sysstat configuration directory (default is /etc/sysconfig)
+#  conf_file         sysstat configuration file (default is sysstat)
+#  history           number of daily datafiles to keep (default value is 7)
+#  delay_range       maximum delay (in seconds) to wait before sa2 script generates its reports
+#  compressafter     number of days after which datafiles are compressed
+#  man_group         group for man pages
+#  cron_owner        crontab owner
+#  collect_interval  collection interval (in minutes)
+#  sadc_options      options to be passed to sadc
 #
 # Fine tuning the installation directories:
 #  --mandir=DIR           man documentation directory [PREFIX/man]
@@ -5795,24 +5795,39 @@ fi
 printf "%s\n" "$UCROND" >&6; }
 
 
-#  Crontab interval
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking crontab interval" >&5
-printf %s "checking crontab interval... " >&6; }
+else
+   CRON_OWNER="root"
+   QUOTE=""
+   REM_CHOWN="# REM_CHOWN"
+   SU_C_OWNER=""
+fi
 
-   if test x$cron_interval = x""; then
-      CRON_INTERVAL=10
-   else
-      CRON_INTERVAL=$cron_interval
-   fi
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CRON_INTERVAL" >&5
-printf "%s\n" "$CRON_INTERVAL" >&6; }
-   CRON_INTERVAL_SEC=`expr ${CRON_INTERVAL} \* 60`
-   CRON_COUNT=`expr 60 / ${CRON_INTERVAL}`
 
-#  Check whether sadc should collect all possible activities
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether sadc should collect all possible activities" >&5
+
+
+
+# Set collection interval
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking collection interval" >&5
+printf %s "checking collection interval... " >&6; }
+
+if test x$collect_interval = x""; then
+   COLLECT_INTERVAL=10
+else
+   COLLECT_INTERVAL=$collect_interval
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $COLLECT_INTERVAL" >&5
+printf "%s\n" "$COLLECT_INTERVAL" >&6; }
+
+
+COLLECT_INTERVAL_SEC=`expr ${COLLECT_INTERVAL} \* 60`
+COLLECT_COUNT=`expr 60 / ${COLLECT_INTERVAL}`
+
+
+
+# Check whether sadc should collect all possible activities
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether sadc should collect all possible activities" >&5
 printf %s "checking whether sadc should collect all possible activities... " >&6; }
-   # Check whether --enable-collect-all was given.
+# Check whether --enable-collect-all was given.
 if test ${enable_collect_all+y}
 then :
   enableval=$enable_collect_all; COLLECT_ALL=$enableval
@@ -5821,32 +5836,34 @@ else case e in #(
 esac
 fi
 
-   if test $COLLECT_ALL != "yes"; then
-      COLLECT_ALL=""
-      AUX_COLL=no
-   else
-      COLLECT_ALL="-S XALL"
-      AUX_COLL=yes
-   fi
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $AUX_COLL" >&5
+if test $COLLECT_ALL != "yes"; then
+   COLLECT_ALL=""
+   AUX_COLL=no
+else
+   COLLECT_ALL="-S XALL"
+   AUX_COLL=yes
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $AUX_COLL" >&5
 printf "%s\n" "$AUX_COLL" >&6; }
 
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking options to be passed to sadc" >&5
+COLLECT_ALL=""
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking options to be passed to sadc" >&5
 printf %s "checking options to be passed to sadc... " >&6; }
 
-   if test x"$sadc_options" != x""; then
-	SADC_OPT="$sadc_options"
-   else
-	SADC_OPT=
-   fi
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $SADC_OPT" >&5
+if test x"$sadc_options" != x""; then
+   SADC_OPT="$sadc_options"
+else
+   SADC_OPT=
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $SADC_OPT" >&5
 printf "%s\n" "$SADC_OPT" >&6; }
 
 
-#  Check whether files should only be copied
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether files should only be copied" >&5
+# Check whether files should only be copied
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether files should only be copied" >&5
 printf %s "checking whether files should only be copied... " >&6; }
-   # Check whether --enable-copy-only was given.
+# Check whether --enable-copy-only was given.
 if test ${enable_copy_only+y}
 then :
   enableval=$enable_copy_only; OCOPY=$enableval
@@ -5855,33 +5872,14 @@ else case e in #(
 esac
 fi
 
-   if test $OCOPY != "yes"; then
-      COPY_ONLY=n
-      OCOPY=no
-   else
-      COPY_ONLY=y
-   fi
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $OCOPY" >&5
-printf "%s\n" "$OCOPY" >&6; }
-
-
+if test $OCOPY != "yes"; then
+   COPY_ONLY=n
+   OCOPY=no
 else
-   CRON_OWNER="root"
-   SU_C_OWNER=""
-   QUOTE=""
-   REM_CHOWN="# REM_CHOWN"
-   CRON_INTERVAL=10
-   CRON_INTERVAL_SEC=600
-   CRON_COUNT=6
-   COLLECT_ALL=""
+   COPY_ONLY=y
 fi
-
-
-
-
-
-
-
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $OCOPY" >&5
+printf "%s\n" "$OCOPY" >&6; }
 
 
 # Check whether documentation should be installed

--- a/configure
+++ b/configure
@@ -645,10 +645,10 @@ STRIP
 WITH_DEBUG
 DFLAGS
 INSTALL_DOC
-COPY_ONLY
 SADC_OPT
 sadc_options
 COLLECT_ALL
+COPY_ONLY
 COLLECT_COUNT
 COLLECT_INTERVAL_SEC
 COLLECT_INTERVAL
@@ -659,7 +659,7 @@ QUOTE
 CRON_OWNER
 USE_CROND
 cron_owner
-INSTALL_CRON
+AUTOMATE_SAR
 CLEAN_SA_DIR
 COMPRESS_MANPG
 IGNORE_FILE_ATTRIBUTES
@@ -781,7 +781,7 @@ enable_lto
 enable_file_attr
 enable_compress_manpg
 enable_clean_sa_dir
-enable_install_cron
+enable_automated_sar_reporting
 enable_use_crond
 enable_collect_all
 enable_copy_only
@@ -1438,7 +1438,8 @@ Optional Features:
   --disable-compress-manpg
                           do not compress sysstat manual pages
   --enable-clean-sa-dir   clean system activity directory
-  --enable-install-cron   install a crontab to start sar
+  --enable-automated-sar-reporting
+                          automate sar reporting via systemd or cron
   --enable-use-crond      use standard cron daemon
   --enable-collect-all    collect all possible activities
   --enable-copy-only      only copy files when installing
@@ -5227,7 +5228,7 @@ echo .
 #  --disable-largefile      omit support for large files
 #  --disable-nls            disable National Language Support
 #  --disable-file-attr      don't set attributes on files being installed
-#  --enable-install-cron    tell sysstat to install cron scripts
+#  --enable-automated-sar-reporting  automate sar reporting via systemd or cron
 #  --collect-all            tell sadc to collect all possible data
 #  --enable-clean-sa-dir    clean system activity directory
 #  --disable-compress-manpg do not compress manual pages when installed
@@ -5715,23 +5716,23 @@ fi
 printf "%s\n" "$AUX_CSD" >&6; }
 
 
-# Start crontab
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether cron should start sar automatically" >&5
-printf %s "checking whether cron should start sar automatically... " >&6; }
-# Check whether --enable-install-cron was given.
-if test ${enable_install_cron+y}
+# Automate sar reporting
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether to automate sar reporting" >&5
+printf %s "checking whether to automate sar reporting... " >&6; }
+# Check whether --enable-automated-sar-reporting was given.
+if test ${enable_automated_sar_reporting+y}
 then :
-  enableval=$enable_install_cron; INSTALL_CRON=$enableval
+  enableval=$enable_automated_sar_reporting; AUTOMATE_SAR=$enableval
 else case e in #(
-  e) INSTALL_CRON=n ;;
+  e) AUTOMATE_SAR=n ;;
 esac
 fi
 
-if test $INSTALL_CRON != "yes"; then
-   INSTALL_CRON=n
+if test $AUTOMATE_SAR != "yes"; then
+   AUTOMATE_SAR=n
    AUX_CRON=no
 else
-   INSTALL_CRON=y
+   AUTOMATE_SAR=y
    AUX_CRON=yes
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $AUX_CRON" >&5
@@ -5740,7 +5741,7 @@ printf "%s\n" "$AUX_CRON" >&6; }
 
 # Crontab owner
 CUSR="root"
-if test $INSTALL_CRON = "y"; then
+if test $AUTOMATE_SAR = "y"; then
    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking crontab owner" >&5
 printf %s "checking crontab owner... " >&6; }
 
@@ -5795,33 +5796,51 @@ fi
 printf "%s\n" "$UCROND" >&6; }
 
 
+#  Set collection interval
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking collection interval" >&5
+printf %s "checking collection interval... " >&6; }
+
+   if test x$collect_interval = x""; then
+      COLLECT_INTERVAL=10
+   else
+      COLLECT_INTERVAL=$collect_interval
+   fi
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $COLLECT_INTERVAL" >&5
+printf "%s\n" "$COLLECT_INTERVAL" >&6; }
+   COLLECT_INTERVAL_SEC=`expr ${COLLECT_INTERVAL} \* 60`
+   COLLECT_COUNT=`expr 60 / ${COLLECT_INTERVAL}`
+
+#  Check whether files should only be copied
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether files should only be copied" >&5
+printf %s "checking whether files should only be copied... " >&6; }
+   # Check whether --enable-copy-only was given.
+if test ${enable_copy_only+y}
+then :
+  enableval=$enable_copy_only; OCOPY=$enableval
+else case e in #(
+  e) OCOPY=no ;;
+esac
+fi
+
+   if test $OCOPY != "yes"; then
+      COPY_ONLY=n
+      OCOPY=no
+   else
+      COPY_ONLY=y
+   fi
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $OCOPY" >&5
+printf "%s\n" "$OCOPY" >&6; }
+
 else
    CRON_OWNER="root"
    QUOTE=""
    REM_CHOWN="# REM_CHOWN"
    SU_C_OWNER=""
-fi
-
-
-
-
-
-# Set collection interval
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking collection interval" >&5
-printf %s "checking collection interval... " >&6; }
-
-if test x$collect_interval = x""; then
    COLLECT_INTERVAL=10
-else
-   COLLECT_INTERVAL=$collect_interval
+   COLLECT_INTERVAL_SEC=600
+   COLLECT_COUNT=6
+   COPY_ONLY=n
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $COLLECT_INTERVAL" >&5
-printf "%s\n" "$COLLECT_INTERVAL" >&6; }
-
-
-COLLECT_INTERVAL_SEC=`expr ${COLLECT_INTERVAL} \* 60`
-COLLECT_COUNT=`expr 60 / ${COLLECT_INTERVAL}`
-
 
 
 # Check whether sadc should collect all possible activities
@@ -5858,28 +5877,6 @@ else
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $SADC_OPT" >&5
 printf "%s\n" "$SADC_OPT" >&6; }
-
-
-# Check whether files should only be copied
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether files should only be copied" >&5
-printf %s "checking whether files should only be copied... " >&6; }
-# Check whether --enable-copy-only was given.
-if test ${enable_copy_only+y}
-then :
-  enableval=$enable_copy_only; OCOPY=$enableval
-else case e in #(
-  e) OCOPY=no ;;
-esac
-fi
-
-if test $OCOPY != "yes"; then
-   COPY_ONLY=n
-   OCOPY=no
-else
-   COPY_ONLY=y
-fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $OCOPY" >&5
-printf "%s\n" "$OCOPY" >&6; }
 
 
 # Check whether documentation should be installed

--- a/configure
+++ b/configure
@@ -1438,8 +1438,8 @@ Optional Features:
   --disable-compress-manpg
                           do not compress sysstat manual pages
   --enable-clean-sa-dir   clean system activity directory
-  --enable-automated-sar-reporting
-                          automate sar reporting via systemd or cron
+  --disable-automated-sar-reporting
+                          do not automate sar reporting via systemd or cron
   --enable-use-crond      use standard cron daemon
   --enable-collect-all    collect all possible activities
   --enable-copy-only      only copy files when installing
@@ -5228,7 +5228,7 @@ echo .
 #  --disable-largefile      omit support for large files
 #  --disable-nls            disable National Language Support
 #  --disable-file-attr      don't set attributes on files being installed
-#  --enable-automated-sar-reporting  automate sar reporting via systemd or cron
+#  --disable-automated-sar-reporting  do not automate sar reporting via systemd or cron
 #  --collect-all            tell sadc to collect all possible data
 #  --enable-clean-sa-dir    clean system activity directory
 #  --disable-compress-manpg do not compress manual pages when installed
@@ -5724,7 +5724,7 @@ if test ${enable_automated_sar_reporting+y}
 then :
   enableval=$enable_automated_sar_reporting; AUTOMATE_SAR=$enableval
 else case e in #(
-  e) AUTOMATE_SAR=n ;;
+  e) AUTOMATE_SAR=yes ;;
 esac
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -251,19 +251,19 @@ echo .
 #  --enable-lto	            compile with Link Time Optimizations
 #
 # Some influential environment variables:
-#  rcdir         directory where startup scripts are installed
-#  sa_lib_dir    sadc, sa1 and sa2 directory
-#  sa_dir        system activity daily datafiles directory
-#  sar_dir       sar binary location. Used only in sa2 shell script
-#  conf_dir      sysstat configuration directory (default is /etc/sysconfig)
-#  conf_file     sysstat configuration file (default is sysstat)
-#  history       number of daily datafiles to keep (default value is 7)
-#  delay_range   maximum delay (in seconds) to wait before sa2 script generates its reports
-#  compressafter number of days after which datafiles are compressed
-#  man_group     group for man pages
-#  cron_owner    crontab owner
-#  cron_interval crontab sampling interval
-#  sadc_options  options to be passed to sadc
+#  rcdir             directory where startup scripts are installed
+#  sa_lib_dir        sadc, sa1 and sa2 directory
+#  sa_dir            system activity daily datafiles directory
+#  sar_dir           sar binary location. Used only in sa2 shell script
+#  conf_dir          sysstat configuration directory (default is /etc/sysconfig)
+#  conf_file         sysstat configuration file (default is sysstat)
+#  history           number of daily datafiles to keep (default value is 7)
+#  delay_range       maximum delay (in seconds) to wait before sa2 script generates its reports
+#  compressafter     number of days after which datafiles are compressed
+#  man_group         group for man pages
+#  cron_owner        crontab owner
+#  collect_interval  collection interval (in minutes)
+#  sadc_options      options to be passed to sadc
 #
 # Fine tuning the installation directories:
 #  --mandir=DIR           man documentation directory [PREFIX/man]
@@ -634,74 +634,72 @@ if test $INSTALL_CRON = "y"; then
    AC_MSG_RESULT($UCROND)
    AC_SUBST(USE_CROND)
 
-#  Crontab interval
-   AC_MSG_CHECKING(crontab interval)
-   AC_ARG_VAR([cron_interval],[crontab interval])
-   if test x$cron_interval = x""; then
-      CRON_INTERVAL=10
-   else
-      CRON_INTERVAL=$cron_interval
-   fi
-   AC_MSG_RESULT($CRON_INTERVAL)
-   CRON_INTERVAL_SEC=`expr ${CRON_INTERVAL} \* 60`
-   CRON_COUNT=`expr 60 / ${CRON_INTERVAL}`
-
-#  Check whether sadc should collect all possible activities
-   AC_MSG_CHECKING(whether sadc should collect all possible activities)
-   AC_ARG_ENABLE(collect-all,
-	         AS_HELP_STRING([--enable-collect-all],[collect all possible activities]),
-			        COLLECT_ALL=$enableval,COLLECT_ALL=n)
-   if test $COLLECT_ALL != "yes"; then
-      COLLECT_ALL=""
-      AUX_COLL=no
-   else
-      COLLECT_ALL="-S XALL"
-      AUX_COLL=yes
-   fi
-   AC_MSG_RESULT($AUX_COLL)
-
-   AC_MSG_CHECKING(options to be passed to sadc)
-   AC_ARG_VAR([sadc_options],[options to be passed to sadc])
-   if test x"$sadc_options" != x""; then
-	SADC_OPT="$sadc_options"
-   else
-	SADC_OPT=
-   fi
-   AC_MSG_RESULT($SADC_OPT)
-   AC_SUBST(SADC_OPT)
-
-#  Check whether files should only be copied
-   AC_MSG_CHECKING(whether files should only be copied)
-   AC_ARG_ENABLE(copy-only,
-	         AS_HELP_STRING([--enable-copy-only],[only copy files when installing]),
-			        OCOPY=$enableval,OCOPY=no)
-   if test $OCOPY != "yes"; then
-      COPY_ONLY=n
-      OCOPY=no
-   else
-      COPY_ONLY=y
-   fi
-   AC_MSG_RESULT($OCOPY)
-   AC_SUBST(COPY_ONLY)
-
 else
    CRON_OWNER="root"
-   SU_C_OWNER=""
    QUOTE=""
    REM_CHOWN="# REM_CHOWN"
-   CRON_INTERVAL=10
-   CRON_INTERVAL_SEC=600
-   CRON_COUNT=6
-   COLLECT_ALL=""
+   SU_C_OWNER=""
 fi
 AC_SUBST(CRON_OWNER)
-AC_SUBST(SU_C_OWNER)
-AC_SUBST(CRON_INTERVAL)
-AC_SUBST(CRON_INTERVAL_SEC)
-AC_SUBST(CRON_COUNT)
 AC_SUBST(QUOTE)
 AC_SUBST(REM_CHOWN)
+AC_SUBST(SU_C_OWNER)
+
+# Set collection interval
+AC_MSG_CHECKING(collection interval)
+AC_ARG_VAR([collect_interval],[collection interval (in minutes)])
+if test x$collect_interval = x""; then
+   COLLECT_INTERVAL=10
+else
+   COLLECT_INTERVAL=$collect_interval
+fi
+AC_MSG_RESULT($COLLECT_INTERVAL)
+AC_SUBST(COLLECT_INTERVAL)
+
+COLLECT_INTERVAL_SEC=`expr ${COLLECT_INTERVAL} \* 60`
+COLLECT_COUNT=`expr 60 / ${COLLECT_INTERVAL}`
+AC_SUBST(COLLECT_INTERVAL_SEC)
+AC_SUBST(COLLECT_COUNT)
+
+# Check whether sadc should collect all possible activities
+AC_MSG_CHECKING(whether sadc should collect all possible activities)
+AC_ARG_ENABLE(collect-all,
+	      AS_HELP_STRING([--enable-collect-all],[collect all possible activities]),
+			     COLLECT_ALL=$enableval,COLLECT_ALL=n)
+if test $COLLECT_ALL != "yes"; then
+   COLLECT_ALL=""
+   AUX_COLL=no
+else
+   COLLECT_ALL="-S XALL"
+   AUX_COLL=yes
+fi
+AC_MSG_RESULT($AUX_COLL)
 AC_SUBST(COLLECT_ALL)
+COLLECT_ALL=""
+
+AC_MSG_CHECKING(options to be passed to sadc)
+AC_ARG_VAR([sadc_options],[options to be passed to sadc])
+if test x"$sadc_options" != x""; then
+   SADC_OPT="$sadc_options"
+else
+   SADC_OPT=
+fi
+AC_MSG_RESULT($SADC_OPT)
+AC_SUBST(SADC_OPT)
+
+# Check whether files should only be copied
+AC_MSG_CHECKING(whether files should only be copied)
+AC_ARG_ENABLE(copy-only,
+	      AS_HELP_STRING([--enable-copy-only],[only copy files when installing]),
+			     OCOPY=$enableval,OCOPY=no)
+if test $OCOPY != "yes"; then
+   COPY_ONLY=n
+   OCOPY=no
+else
+   COPY_ONLY=y
+fi
+AC_MSG_RESULT($OCOPY)
+AC_SUBST(COPY_ONLY)
 
 # Check whether documentation should be installed
 AC_MSG_CHECKING(whether documentation should be installed)

--- a/configure.ac
+++ b/configure.ac
@@ -237,7 +237,7 @@ echo .
 #  --disable-largefile      omit support for large files
 #  --disable-nls            disable National Language Support
 #  --disable-file-attr      don't set attributes on files being installed
-#  --enable-install-cron    tell sysstat to install cron scripts
+#  --enable-automated-sar-reporting  automate sar reporting via systemd or cron
 #  --collect-all            tell sadc to collect all possible data
 #  --enable-clean-sa-dir    clean system activity directory
 #  --disable-compress-manpg do not compress manual pages when installed
@@ -574,24 +574,24 @@ fi
 AC_MSG_RESULT($AUX_CSD)
 AC_SUBST(CLEAN_SA_DIR)
 
-# Start crontab
-AC_MSG_CHECKING(whether cron should start sar automatically)
-AC_ARG_ENABLE(install-cron,
-	      AS_HELP_STRING([--enable-install-cron],[install a crontab to start sar]),
-			     INSTALL_CRON=$enableval,INSTALL_CRON=n)
-if test $INSTALL_CRON != "yes"; then
-   INSTALL_CRON=n
+# Automate sar reporting
+AC_MSG_CHECKING(whether to automate sar reporting)
+AC_ARG_ENABLE(automated-sar-reporting,
+	      AS_HELP_STRING([--enable-automated-sar-reporting],[automate sar reporting via systemd or cron]),
+			     AUTOMATE_SAR=$enableval,AUTOMATE_SAR=n)
+if test $AUTOMATE_SAR != "yes"; then
+   AUTOMATE_SAR=n
    AUX_CRON=no
 else
-   INSTALL_CRON=y
+   AUTOMATE_SAR=y
    AUX_CRON=yes
 fi
 AC_MSG_RESULT($AUX_CRON)
-AC_SUBST(INSTALL_CRON)
+AC_SUBST(AUTOMATE_SAR)
 
 # Crontab owner
 CUSR="root"
-if test $INSTALL_CRON = "y"; then
+if test $AUTOMATE_SAR = "y"; then
    AC_MSG_CHECKING(crontab owner)
    AC_ARG_VAR([cron_owner],[crontab owner])
    if test x$cron_owner = x""; then
@@ -634,32 +634,49 @@ if test $INSTALL_CRON = "y"; then
    AC_MSG_RESULT($UCROND)
    AC_SUBST(USE_CROND)
 
+#  Set collection interval
+   AC_MSG_CHECKING(collection interval)
+   AC_ARG_VAR([collect_interval],[collection interval (in minutes)])
+   if test x$collect_interval = x""; then
+      COLLECT_INTERVAL=10
+   else
+      COLLECT_INTERVAL=$collect_interval
+   fi
+   AC_MSG_RESULT($COLLECT_INTERVAL)
+   COLLECT_INTERVAL_SEC=`expr ${COLLECT_INTERVAL} \* 60`
+   COLLECT_COUNT=`expr 60 / ${COLLECT_INTERVAL}`
+
+#  Check whether files should only be copied
+   AC_MSG_CHECKING(whether files should only be copied)
+   AC_ARG_ENABLE(copy-only,
+	         AS_HELP_STRING([--enable-copy-only],[only copy files when installing]),
+			        OCOPY=$enableval,OCOPY=no)
+   if test $OCOPY != "yes"; then
+      COPY_ONLY=n
+      OCOPY=no
+   else
+      COPY_ONLY=y
+   fi
+   AC_MSG_RESULT($OCOPY)
+
 else
    CRON_OWNER="root"
    QUOTE=""
    REM_CHOWN="# REM_CHOWN"
    SU_C_OWNER=""
+   COLLECT_INTERVAL=10
+   COLLECT_INTERVAL_SEC=600
+   COLLECT_COUNT=6
+   COPY_ONLY=n
 fi
 AC_SUBST(CRON_OWNER)
 AC_SUBST(QUOTE)
 AC_SUBST(REM_CHOWN)
 AC_SUBST(SU_C_OWNER)
-
-# Set collection interval
-AC_MSG_CHECKING(collection interval)
-AC_ARG_VAR([collect_interval],[collection interval (in minutes)])
-if test x$collect_interval = x""; then
-   COLLECT_INTERVAL=10
-else
-   COLLECT_INTERVAL=$collect_interval
-fi
-AC_MSG_RESULT($COLLECT_INTERVAL)
 AC_SUBST(COLLECT_INTERVAL)
-
-COLLECT_INTERVAL_SEC=`expr ${COLLECT_INTERVAL} \* 60`
-COLLECT_COUNT=`expr 60 / ${COLLECT_INTERVAL}`
 AC_SUBST(COLLECT_INTERVAL_SEC)
 AC_SUBST(COLLECT_COUNT)
+AC_SUBST(COPY_ONLY)
 
 # Check whether sadc should collect all possible activities
 AC_MSG_CHECKING(whether sadc should collect all possible activities)
@@ -686,20 +703,6 @@ else
 fi
 AC_MSG_RESULT($SADC_OPT)
 AC_SUBST(SADC_OPT)
-
-# Check whether files should only be copied
-AC_MSG_CHECKING(whether files should only be copied)
-AC_ARG_ENABLE(copy-only,
-	      AS_HELP_STRING([--enable-copy-only],[only copy files when installing]),
-			     OCOPY=$enableval,OCOPY=no)
-if test $OCOPY != "yes"; then
-   COPY_ONLY=n
-   OCOPY=no
-else
-   COPY_ONLY=y
-fi
-AC_MSG_RESULT($OCOPY)
-AC_SUBST(COPY_ONLY)
 
 # Check whether documentation should be installed
 AC_MSG_CHECKING(whether documentation should be installed)

--- a/configure.ac
+++ b/configure.ac
@@ -237,7 +237,7 @@ echo .
 #  --disable-largefile      omit support for large files
 #  --disable-nls            disable National Language Support
 #  --disable-file-attr      don't set attributes on files being installed
-#  --enable-automated-sar-reporting  automate sar reporting via systemd or cron
+#  --disable-automated-sar-reporting  do not automate sar reporting via systemd or cron
 #  --collect-all            tell sadc to collect all possible data
 #  --enable-clean-sa-dir    clean system activity directory
 #  --disable-compress-manpg do not compress manual pages when installed
@@ -577,8 +577,8 @@ AC_SUBST(CLEAN_SA_DIR)
 # Automate sar reporting
 AC_MSG_CHECKING(whether to automate sar reporting)
 AC_ARG_ENABLE(automated-sar-reporting,
-	      AS_HELP_STRING([--enable-automated-sar-reporting],[automate sar reporting via systemd or cron]),
-			     AUTOMATE_SAR=$enableval,AUTOMATE_SAR=n)
+	      AS_HELP_STRING([--disable-automated-sar-reporting],[do not automate sar reporting via systemd or cron]),
+			     AUTOMATE_SAR=$enableval,AUTOMATE_SAR=yes)
 if test $AUTOMATE_SAR != "yes"; then
    AUTOMATE_SAR=n
    AUX_CRON=no

--- a/cron/crontab.sample
+++ b/cron/crontab.sample
@@ -5,13 +5,13 @@
 #
 # 8am-7pm activity reports every 20 minutes during weekdays.
 # 0 8-18 * * 1-5 @SA_LIB_DIR@/sa1 1200 3
-# activity reports every @CRON_INTERVAL@ minutes everyday.
-0 * * * * @SA_LIB_DIR@/sa1 @CRON_INTERVAL_SEC@ @CRON_COUNT@
+# Activity reports every @COLLECT_INTERVAL@ minute(s) everyday.
+0 * * * * @SA_LIB_DIR@/sa1 @COLLECT_INTERVAL_SEC@ @COLLECT_COUNT@
 #
-# Activity reports every an hour on Saturday and Sunday.
+# Activity reports every hour on Saturday and Sunday.
 # 0 * * * 0,6 @SA_LIB_DIR@/sa1
 #
-# 7pm-8am activity reports every an hour during weekdays.
+# 7pm-8am activity reports every hour during weekdays.
 # 0 19-7 * * 1-5 @SA_LIB_DIR@/sa1
 #
 # Previous day summary prepared at 00:07.

--- a/cron/sysstat-collect.timer.in
+++ b/cron/sysstat-collect.timer.in
@@ -2,13 +2,13 @@
 # (C) 2014 Tomasz Torcz <tomek@pipebreaker.pl>
 #
 # @PACKAGE_NAME@-@PACKAGE_VERSION@ systemd unit file:
-#        Activates activity collector every @CRON_INTERVAL@ minutes
+#        Activates activity collector every @COLLECT_INTERVAL@ minute(s)
 
 [Unit]
-Description=Run system activity accounting tool every @CRON_INTERVAL@ minutes
+Description=Run system activity accounting tool every @COLLECT_INTERVAL@ minute(s)
 
 [Timer]
-OnCalendar=*:00/@CRON_INTERVAL@
+OnCalendar=*:00/@COLLECT_INTERVAL@
 
 [Install]
 WantedBy=sysstat.service

--- a/cron/sysstat.cron.hourly.in
+++ b/cron/sysstat.cron.hourly.in
@@ -1,3 +1,3 @@
 #!/bin/sh
-# Run system activity accounting tool every @CRON_INTERVAL@ minutes
-@SA_LIB_DIR@/sa1 @CRON_INTERVAL_SEC@ @CRON_COUNT@
+# Run system activity accounting tool every @COLLECT_INTERVAL@ minute(s)
+@SA_LIB_DIR@/sa1 @COLLECT_INTERVAL_SEC@ @COLLECT_COUNT@

--- a/cron/sysstat.crond.in
+++ b/cron/sysstat.crond.in
@@ -1,8 +1,8 @@
 # Rotate file at midnight
 0 0 * * * @CRON_OWNER@ @SA_LIB_DIR@/sa1 --rotate
-# Run system activity accounting tool every @CRON_INTERVAL@ minutes
-*/@CRON_INTERVAL@ * * * * @CRON_OWNER@ @SA_LIB_DIR@/sa1 1 1
-# 0 * * * * @CRON_OWNER@ @SA_LIB_DIR@/sa1 @CRON_INTERVAL_SEC@ @CRON_COUNT@
+# Run system activity accounting tool every @COLLECT_INTERVAL@ minute(s)
+*/@COLLECT_INTERVAL@ * * * * @CRON_OWNER@ @SA_LIB_DIR@/sa1 1 1
+# 0 * * * * @CRON_OWNER@ @SA_LIB_DIR@/sa1 @COLLECT_INTERVAL_SEC@ @COLLECT_COUNT@
 # Generate a text summary of previous day process accounting at 00:07
 7 0 * * * @CRON_OWNER@ @SA_LIB_DIR@/sa2 -A
 

--- a/iconfig
+++ b/iconfig
@@ -178,25 +178,20 @@ then
 	fi
 fi
 
-if [ "${CRON}" != "" ];
-then
-	CRON_INTERVAL=`${ASK} 'Crontab sampling interval (in minutes):' "cron_interval" "cron_interval"`
-	if [ "${CRON_INTERVAL}" != "" ]; then
-		CRON="${CRON}cron_interval=${CRON_INTERVAL} "
-	fi
+COLLECT_INTERVAL=`${ASK} 'Collection interval (in minutes):' "collect_interval" "collect_interval"`
+if [ "${COLLECT_INTERVAL}" != "" ]; then
+	COLLECT_INTERVAL="collect_interval=${COLLECT_INTERVAL} "
 fi
 
-if [ "${CRON}" != "" ];
-then
-	COLL_ALL=`${ASK} 'Should sadc collect optional activities? (y/n)' "--enable-collect-all" "collect-all"`
-	if [ "${COLL_ALL}" = "y" ]; then
-		CRON="${CRON}--enable-collect-all "
-	else
-		echo "Parameter --enable-collect-all is NOT set"
-	fi
+COLLECT_ALL=`${ASK} 'Should sadc collect optional activities? (y/n)' "--enable-collect-all" "collect-all"`
+if [ "${COLLECT_ALL}" = "y" ]; then
+	COLLECT_ALL="--enable-collect-all "
+else
+	COLLECT_ALL=""
+	echo "Parameter --enable-collect-all is NOT set"
 fi
 
-if [ "${CRON}" != "" -a "${COLL_ALL}" != "y" ];
+if [ "${COLLECT_ALL}" != "y" ];
 then
 	# Optional args for sadc
 	SADC_OPT=`${ASK} 'Options to be passed to sadc:' "sadc_options" "sadc_options"`
@@ -204,25 +199,19 @@ else
 	SADC_OPT=
 fi
 
-if [ "${CRON}" != "" ];
-then
-	# rc directory
-	RCDIR=`${ASK} 'rc directory:' "rcdir" "rcdir"`
-	if [ "${RCDIR}" != "" ]; then
-	        RCDIR="rcdir=${RCDIR} "
-	fi
+# rc directory
+RCDIR=`${ASK} 'rc directory:' "rcdir" "rcdir"`
+if [ "${RCDIR}" != "" ]; then
+        RCDIR="rcdir=${RCDIR} "
 fi
 
-if [ "${CRON}" != "" ];
-then
-	# Only copy files
-	COPY_ONLY=`${ASK} 'Only copy files when installing sysstat? (y/n)' "--enable-copy-only" "copy-only"`
-	if [ "${COPY_ONLY}" = "y" ]; then
-		COPY_ONLY="--enable-copy-only "
-	else
-		COPY_ONLY=""
-		echo "Parameter --enable-copy-only is NOT set"
-	fi
+# Only copy files
+COPY_ONLY=`${ASK} 'Only copy files when installing sysstat? (y/n)' "--enable-copy-only" "copy-only"`
+if [ "${COPY_ONLY}" = "y" ]; then
+	COPY_ONLY="--enable-copy-only "
+else
+	COPY_ONLY=""
+	echo "Parameter --enable-copy-only is NOT set"
 fi
 
 # Compress manual pages
@@ -264,7 +253,7 @@ fi
 echo
 echo -n "${srcdir}/configure ${PREFIX}${SA_LIB_DIR}${SA_DIR}${SYSCONFIG_DIR}${SYSCONFIG_FILE} \
 ${CLEAN_SA_DIR}${NLS}${LTO}${HISTORY}${DELAY_RANGE}${COMPRESSAFTER}${MAN}${IGNORE_FILE_ATTR} \
-${CRON}${USE_CROND}${RCDIR}"
+${CRON}${USE_CROND}${RCDIR}${COLLECT_INTERVAL}${COLLECT_ALL}"
 if [ "${SADC_OPT}" != "" ];
 then
 	echo -n "sadc_options=\"${SADC_OPT}\""
@@ -274,6 +263,7 @@ echo
 
 ${srcdir}/configure ${PREFIX}${SA_LIB_DIR}${SA_DIR}${SYSCONFIG_DIR}${SYSCONFIG_FILE} \
 ${CLEAN_SA_DIR}${NLS}${LTO} \
-${HISTORY}${DELAY_RANGE}${COMPRESSAFTER}${MAN}${IGNORE_FILE_ATTR}${CRON}${USE_CROND}${RCDIR} \
+${HISTORY}${DELAY_RANGE}${COMPRESSAFTER}${MAN}${IGNORE_FILE_ATTR}${CRON}${USE_CROND} \
+${RCDIR}${COLLECT_INTERVAL}${COLLECT_ALL} \
 sadc_options="${SADC_OPT}" ${COMPRESSMANPG}${INSTALL_DOC}${DEBUGINFO}${SENSORS} \
 ${PCP}${STRIP}${COPY_ONLY}

--- a/iconfig
+++ b/iconfig
@@ -150,24 +150,24 @@ else
 	echo "Parameter --disable-file-attr is NOT set"
 fi
 
-# Crontab
-CRON=`${ASK} 'Set crontab to start sar automatically? (y/n)' "--enable-install-cron" "install-cron"`
-if [ "${CRON}" = "y" ]; then
-	CRON="--enable-install-cron "
+# Automate sar reporting
+AUTOMATE=`${ASK} 'Automate sar reporting (via systemd or cron)? (y/n)' "--enable-automated-sar-reporting" "automated-sar-reporting"`
+if [ "${AUTOMATE}" = "y" ]; then
+	AUTOMATE="--enable-automated-sar-reporting "
 else
-	CRON=""
-	echo "Parameter --enable-install-cron is NOT set"
+	AUTOMATE=""
+	echo "Parameter --enable-automated-sar-reporting is NOT set"
 fi
 
-if [ "${CRON}" != "" ];
+if [ "${AUTOMATE}" != "" ];
 then
 	CRON_OWNER=`${ASK} 'Crontab owner:' "cron_owner" "cron_owner"`
 	if [ "${CRON_OWNER}" != "" ]; then
-		CRON="${CRON}cron_owner=${CRON_OWNER} "
+		AUTOMATE="${AUTOMATE}cron_owner=${CRON_OWNER} "
 	fi
 fi
 
-if [ "${CRON}" != "" ];
+if [ "${AUTOMATE}" != "" ];
 then
 	USE_CROND=`${ASK} 'Use standard cron daemon? (y/n)' "--enable-use-crond" "use-crond"`
 	if [ "${USE_CROND}" = "y" ]; then
@@ -178,9 +178,12 @@ then
 	fi
 fi
 
-COLLECT_INTERVAL=`${ASK} 'Collection interval (in minutes):' "collect_interval" "collect_interval"`
-if [ "${COLLECT_INTERVAL}" != "" ]; then
-	COLLECT_INTERVAL="collect_interval=${COLLECT_INTERVAL} "
+if [ "${AUTOMATE}" != "" ];
+then
+	COLLECT_INTERVAL=`${ASK} 'Collection interval (in minutes):' "collect_interval" "collect_interval"`
+	if [ "${COLLECT_INTERVAL}" != "" ]; then
+		COLLECT_INTERVAL="collect_interval=${COLLECT_INTERVAL} "
+	fi
 fi
 
 COLLECT_ALL=`${ASK} 'Should sadc collect optional activities? (y/n)' "--enable-collect-all" "collect-all"`
@@ -199,19 +202,25 @@ else
 	SADC_OPT=
 fi
 
-# rc directory
-RCDIR=`${ASK} 'rc directory:' "rcdir" "rcdir"`
-if [ "${RCDIR}" != "" ]; then
-        RCDIR="rcdir=${RCDIR} "
+if [ "${AUTOMATE}" != "" ];
+then
+	# rc directory
+	RCDIR=`${ASK} 'rc directory:' "rcdir" "rcdir"`
+	if [ "${RCDIR}" != "" ]; then
+	        RCDIR="rcdir=${RCDIR} "
+	fi
 fi
 
-# Only copy files
-COPY_ONLY=`${ASK} 'Only copy files when installing sysstat? (y/n)' "--enable-copy-only" "copy-only"`
-if [ "${COPY_ONLY}" = "y" ]; then
-	COPY_ONLY="--enable-copy-only "
-else
-	COPY_ONLY=""
-	echo "Parameter --enable-copy-only is NOT set"
+if [ "${AUTOMATE}" != "" ];
+then
+	# Only copy files
+	COPY_ONLY=`${ASK} 'Only copy files when installing sysstat? (y/n)' "--enable-copy-only" "copy-only"`
+	if [ "${COPY_ONLY}" = "y" ]; then
+		COPY_ONLY="--enable-copy-only "
+	else
+		COPY_ONLY=""
+		echo "Parameter --enable-copy-only is NOT set"
+	fi
 fi
 
 # Compress manual pages
@@ -253,7 +262,7 @@ fi
 echo
 echo -n "${srcdir}/configure ${PREFIX}${SA_LIB_DIR}${SA_DIR}${SYSCONFIG_DIR}${SYSCONFIG_FILE} \
 ${CLEAN_SA_DIR}${NLS}${LTO}${HISTORY}${DELAY_RANGE}${COMPRESSAFTER}${MAN}${IGNORE_FILE_ATTR} \
-${CRON}${USE_CROND}${RCDIR}${COLLECT_INTERVAL}${COLLECT_ALL}"
+${AUTOMATE}${USE_CROND}${RCDIR}${COLLECT_INTERVAL}${COLLECT_ALL}"
 if [ "${SADC_OPT}" != "" ];
 then
 	echo -n "sadc_options=\"${SADC_OPT}\""
@@ -263,7 +272,7 @@ echo
 
 ${srcdir}/configure ${PREFIX}${SA_LIB_DIR}${SA_DIR}${SYSCONFIG_DIR}${SYSCONFIG_FILE} \
 ${CLEAN_SA_DIR}${NLS}${LTO} \
-${HISTORY}${DELAY_RANGE}${COMPRESSAFTER}${MAN}${IGNORE_FILE_ATTR}${CRON}${USE_CROND} \
+${HISTORY}${DELAY_RANGE}${COMPRESSAFTER}${MAN}${IGNORE_FILE_ATTR}${AUTOMATE}${USE_CROND} \
 ${RCDIR}${COLLECT_INTERVAL}${COLLECT_ALL} \
 sadc_options="${SADC_OPT}" ${COMPRESSMANPG}${INSTALL_DOC}${DEBUGINFO}${SENSORS} \
 ${PCP}${STRIP}${COPY_ONLY}


### PR DESCRIPTION
The scope of the --install-cron configure option prevents some options being available without cron.  In particular, systemd unit and timer files are installed whether or not cron is, but important options are unavailable (even though these variables are used in systemd files) to systemd-only installs.

For example, the collection interval can currently only be set when --install-cron is true.  However, modern distributions do not install cron files at all, so this setting cannot be used; it should still be configurable though.

This commit reduces the scope of --install-cron to just those settings that directly affect cron files, and allows the other settings to be more widely accessed.

Note that this changes the CRON_INTERVAL and related variables to use more general COLLECT_INTERVAL naming conventions but is otherwise functionally equivalent.