### PR TITLE
sadc: Fix heap buffer overflow in reallocate_buffer()

### DIFF
--- a/sa_wrap.c
+++ b/sa_wrap.c
@@ -45,8 +45,8 @@ extern struct record_header record_hdr;
 void *reallocate_buffer(struct activity *a)
 {
 	SREALLOC(a->_buf0, void,
-		 (size_t) a->msize * (size_t) a->nr_allocated * 2);	/* a->nr2 value is 1 */
-	memset(a->_buf0, 0, (size_t) a->msize * (size_t) a->nr_allocated * 2);
+		 (size_t) a->msize * (size_t) a->nr_allocated * (size_t) a->nr2 * 2);
+	memset(a->_buf0, 0, (size_t) a->msize * (size_t) a->nr_allocated * (size_t) a->nr2 * 2);
 
 	a->nr_allocated *= 2;	/* NB: nr_allocated > 0 */
 


### PR DESCRIPTION
reallocate_buffer() was allocating msize * nr_allocated * 2 bytes, ignoring the nr2 dimension. For matrix activities like A_IRQ where nr2 is the number of interrupt sources (~44), the reallocated buffer was ~44x too small, causing a heap buffer overflow when CPUs came online after the initial count.

The comment "a->nr2 value is 1" was true when this function was written, but became incorrect in commit 7c209484 (2022) which changed A_IRQ to read from /proc/interrupts with nr2 > 1.