### PR TITLE
svg_stats: Fix integer overflow in allocate_graph_lines size computation

### DIFF
--- a/svg_stats.c
+++ b/svg_stats.c
@@ -133,17 +133,36 @@ char **allocate_graph_lines(struct activity *a, int n, int **outsize)
 	char **out;
 	char *out_p;
 	int i;
+	size_t alloc_sz;
+
+	/*
+	 * Sanity-check @n. Callers compute it as
+	 * <ARRAY_SZ> * a->item_list_sz using signed int multiplication,
+	 * which overflows when item_list_sz is large (item_list_sz is read
+	 * from a potentially crafted data file and bounded only by nr_max;
+	 * e.g. DISK_ARRAY_SZ(9) * MAX_NR_DISKS or FS_ARRAY_SZ(8) * MAX_NR_FS
+	 * both exceed INT_MAX). The resulting negative n would otherwise be
+	 * passed to malloc() below, yielding undefined behaviour and a
+	 * huge/under-sized allocation (DoS).
+	 */
+	if (n <= 0) {
+		fprintf(stderr, "allocate_graph_lines: invalid number of lines (%d)\n", n);
+		exit(4);
+	}
 
 	/*
 	 * Allocate an array of pointers. Each of these pointers will
-	 * be an array of chars.
+	 * be an array of chars. Use an overflow-checked size so that the
+	 * n * sizeof(...) products are validated too (relevant on 32-bit).
 	 */
-	if ((out = (char **) malloc(n * sizeof(char *))) == NULL) {
+	alloc_sz = mul_check_overflow3((size_t) n, sizeof(char *), 1);
+	if ((out = (char **) malloc(alloc_sz)) == NULL) {
 		perror("malloc");
 		exit(4);
 	}
 	/* Allocate array that will contain the size of each array of chars */
-	if ((*outsize = (int *) malloc(n * sizeof(int))) == NULL) {
+	alloc_sz = mul_check_overflow3((size_t) n, sizeof(int), 1);
+	if ((*outsize = (int *) malloc(alloc_sz)) == NULL) {
 		perror("malloc");
 		exit(4);
 	}


### PR DESCRIPTION
## Summary

`allocate_graph_lines()` in `svg_stats.c` takes its line count `n` as a
`signed int`, but every caller computes it as `<ARRAY_SZ> * a->item_list_sz`
using `int` multiplication. `item_list_sz` is `__nr_t` (`int`) and is read
from a (potentially crafted) data file, bounded only by `nr_max`. For the
disk and filesystem activities `nr_max = MAX_NR_DISKS = MAX_NR_FS =
65536*4096 = 268435456`, so:

```
DISK_ARRAY_SZ(9) * 268435456 = 2,415,919,104  > INT_MAX   (signed UB)
FS_ARRAY_SZ (8) * 268435456 = 2,147,483,648  == INT_MIN   (signed UB)
```

The overflowed (negative) `n` reaches `malloc(n * sizeof(char *))` /
`malloc(n * sizeof(int))`: on 64-bit, `(size_t)n` becomes a multi-exabyte
value, `malloc()` returns `NULL` and the program calls `exit(4)` — a
**denial of service** triggered by a crafted `.sa` file processed with
`sadf -g`. The signed overflow itself is also undefined behaviour.

The affected call sites are the ones that multiply an array size by
`a->item_list_sz`:

```
svg_stats.c:1075  CPU_ARRAY_SZ    * a->item_list_sz
svg_stats.c:2107  DISK_ARRAY_SZ   * a->item_list_sz   <- overflows for large item_list_sz
svg_stats.c:2327  NET_DEV_ARRAY_SZ* a->item_list_sz
svg_stats.c:2543  NET_EDEV_ARRAY_SZ*a->item_list_sz
svg_stats.c:4339  TEMP_ARRAY_SZ   * a->item_list_sz
svg_stats.c:4427  IN_ARRAY_SZ     * a->item_list_sz
svg_stats.c:4681  FS_ARRAY_SZ     * a->item_list_sz   <- overflows for large item_list_sz
svg_stats.c:4883  FC_ARRAY_SZ     * a->item_list_sz
svg_stats.c:5071  SOFT_ARRAY_SZ   * a->item_list_sz
```

## Root cause

`__nr_t` is `int` (`rd_stats.h`). `item_list_sz` is `__nr_t`, set in
`sadf.c` (~line 518-538) to the maximum `nr[0]` seen while scanning the
data file. `nr[0]` is validated only against `nr_max` (which is
`MAX_NR_DISKS`/`MAX_NR_FS` = 268435456). The `int * int` product at the
call sites therefore overflows for the disk and filesystem activities.
`allocate_graph_lines()` then trusts `n` and uses it directly in the
`malloc()` size computation, with no overflow check (the
`mul_check_overflow3/4` helpers that exist elsewhere in sysstat are not
used here).

## Fix

In `allocate_graph_lines()`:

* reject `n <= 0` explicitly (the realistic overflow wraps `n` negative
  for both DISK and FS, since `9*268435456` and `8*268435456` both exceed
  `INT_MAX`);
* compute both allocation sizes through the existing `mul_check_overflow3()`
  helper (already used in `sadc.c`/`sa_common.c`) so the
  `n * sizeof(...)` products are validated too (relevant on 32-bit builds).

This has no effect on normal operation, where `item_list_sz` is small.

## Verification

* Builds cleanly with `./configure && make` (no new warnings).
* `sadf -g` on a real `.sa` produces **byte-identical** SVG before and
  after the change (no regression).
* A unit reproducer for the arithmetic + `malloc` sink confirms the
  overflow (gcc emits `-Woverflow`: `9*MAX_NR_DISKS -> -1879048192`,
  `8*MAX_NR_FS -> -2147483648`); the unfixed path computes a multi-exabyte
  `malloc()` size that returns `NULL` -> `exit(4)` (DoS), while the fixed
  path rejects `n <= 0` cleanly. Reachability confirmed: the disk graph
  handler that calls `allocate_graph_lines(a, DISK_ARRAY_SZ *
  a->item_list_sz, ...)` at `svg_stats.c:2107` is exercised by the normal
  `sadf -g` code path on an untrusted `.sa` file.

An end-to-end `.sa` triggering the full overflow would need ~268M disk
structures (~20 GB), so a unit-level reproducer of the sink was used.

## Scope

Single-file change: `svg_stats.c` (+22/-3). No behaviour change for
non-pathological inputs.
