### PR TITLE
sar: let --fs match mountpoints as well as device names

### DIFF
--- a/json_stats.c
+++ b/json_stats.c
@@ -2257,9 +2257,8 @@ __print_funct_t json_print_filesystem_stats(struct activity *a, int curr, int ta
 		dev_name = get_fs_name_to_display(a, flags, sfc);
 
 		if (a->item_list != NULL) {
-			/* A list of devices has been entered on the command line */
-			if (!search_list_item(a->item_list, dev_name))
-				/* Device not found */
+			/* Match --fs= against device name and/or mountpoint */
+			if (!match_sa_filesystem_item(a->item_list, sfc, dev_name))
 				continue;
 		}
 

--- a/man/sadf.in
+++ b/man/sadf.in
@@ -112,7 +112,8 @@ since the epoch (given as a 10 digit number).
 Specify the filesystems for which statistics are to be displayed by
 .BR "sadf" "."
 .I fs_list
-is a list of comma-separated filesystem names or mountpoints. Useful with option
+is a list of comma-separated filesystem device names and/or mountpoints.
+Either form is accepted for filtering. Useful with option
 .BR "\-F " "from " "sar" "."
 .TP
 .B \-g

--- a/man/sar.in
+++ b/man/sar.in
@@ -316,7 +316,13 @@ located. Option
 Specify the filesystems for which statistics are to be displayed by
 .BR "sar" "."
 .I fs_list
-is a list of comma-separated filesystem names or mountpoints.
+is a list of comma-separated filesystem device names (for example
+.IR /dev/sdb1 )
+and/or mountpoints (for example
+.IR /srv ).
+Either form is accepted for filtering, independent of whether
+.B \-F
+is showing device names or mountpoints.
 .TP
 .B \-H
 Report hugepages utilization statistics.

--- a/pcp_stats.c
+++ b/pcp_stats.c
@@ -1767,9 +1767,8 @@ __print_funct_t pcp_print_filesystem_stats(struct activity *a, int curr)
 		dev_name = get_fs_name_to_display(a, flags, sfc);
 
 		if (a->item_list != NULL) {
-			/* A list of devices has been entered on the command line */
-			if (!search_list_item(a->item_list, dev_name))
-				/* Device not found */
+			/* Match --fs= against device name and/or mountpoint */
+			if (!match_sa_filesystem_item(a->item_list, sfc, dev_name))
 				continue;
 		}
 

--- a/pr_stats.c
+++ b/pr_stats.c
@@ -3860,9 +3860,8 @@ __print_funct_t stub_print_filesystem_stats(struct activity *a, int prev, int cu
 		dev_name = get_fs_name_to_display(a, flags, sfc);
 
 		if (a->item_list != NULL) {
-			/* A list of devices has been entered on the command line */
-			if (!search_list_item(a->item_list, dev_name))
-				/* Device not found */
+			/* Match --fs= against device name and/or mountpoint */
+			if (!match_sa_filesystem_item(a->item_list, sfc, dev_name))
 				continue;
 		}
 

--- a/raw_stats.c
+++ b/raw_stats.c
@@ -1579,9 +1579,8 @@ __print_funct_t raw_print_filesystem_stats(struct activity *a, char *timestr, in
 		dev_name = get_fs_name_to_display(a, flags, sfc);
 
 		if (a->item_list != NULL) {
-			/* A list of devices has been entered on the command line */
-			if (!search_list_item(a->item_list, dev_name))
-				/* Device not found */
+			/* Match --fs= against device name and/or mountpoint */
+			if (!match_sa_filesystem_item(a->item_list, sfc, dev_name))
 				continue;
 		}
 

--- a/rndr_stats.c
+++ b/rndr_stats.c
@@ -2986,9 +2986,8 @@ __print_funct_t render_filesystem_stats(struct activity *a, int isdb, char *pre,
 		dev_name = get_fs_name_to_display(a, flags, sfc);
 
 		if (a->item_list != NULL) {
-			/* A list of devices has been entered on the command line */
-			if (!search_list_item(a->item_list, dev_name))
-				/* Device not found */
+			/* Match --fs= against device name and/or mountpoint */
+			if (!match_sa_filesystem_item(a->item_list, sfc, dev_name))
 				continue;
 		}
 

--- a/sa.h
+++ b/sa.h
@@ -1678,6 +1678,8 @@ void save_minmax
 	(struct activity *, int, double);
 struct sa_item *search_list_item
 	(struct sa_item *, char *);
+int match_sa_filesystem_item
+	(struct sa_item *, struct stats_filesystem *, char *);
 void select_all_activities
 	(struct activity * []);
 void select_default_activity

--- a/sa_common.c
+++ b/sa_common.c
@@ -2397,6 +2397,38 @@ struct sa_item *search_list_item(struct sa_item *list, char *item_name)
 
 /*
  ***************************************************************************
+ * Check whether a filesystem matches an --fs= selection list.
+ * The man page documents both device names and mountpoints; match either
+ * (and the currently displayed name) so --fs=/srv works without needing
+ * -F MOUNT output mode.
+ *
+ * IN:
+ * @list		Selection list (may be NULL).
+ * @st_fs		Filesystem statistics entry.
+ * @displayed		Name currently used for display (may be NULL).
+ *
+ * RETURNS:
+ * 1 if list is empty or the filesystem matches, 0 otherwise.
+ ***************************************************************************
+ */
+int match_sa_filesystem_item(struct sa_item *list, struct stats_filesystem *st_fs,
+			     char *displayed)
+{
+	if (list == NULL)
+		return 1;
+
+	if (displayed && *displayed && search_list_item(list, displayed))
+		return 1;
+	if (st_fs->fs_name[0] && search_list_item(list, st_fs->fs_name))
+		return 1;
+	if (st_fs->mountp[0] && search_list_item(list, st_fs->mountp))
+		return 1;
+
+	return 0;
+}
+
+/*
+ ***************************************************************************
  * Add item to the list.
  *
  * IN:

--- a/svg_stats.c
+++ b/svg_stats.c
@@ -2131,8 +2131,9 @@ __print_funct_t svg_print_disk_stats(struct activity *a, int curr, int action, s
 						   USE_STABLE_ID(flags), NULL);
 
 			if (a->item_list != NULL) {
-				/* Match --fs= against device name and/or mountpoint */
-				if (!match_sa_filesystem_item(a->item_list, sfc, dev_name))
+				/* A list of devices has been entered on the command line */
+				if (!search_list_item(a->item_list, dev_name))
+					/* Device not found */
 					continue;
 			}
 
@@ -4691,9 +4692,8 @@ __print_funct_t svg_print_filesystem_stats(struct activity *a, int curr, int act
 			dev_name = get_fs_name_to_display(a, flags, sfc);
 
 			if (a->item_list != NULL) {
-				/* A list of devices has been entered on the command line */
-				if (!search_list_item(a->item_list, dev_name))
-					/* Device not found */
+				/* Match --fs= against device name and/or mountpoint */
+				if (!match_sa_filesystem_item(a->item_list, sfc, dev_name))
 					continue;
 			}
 

--- a/svg_stats.c
+++ b/svg_stats.c
@@ -2131,9 +2131,8 @@ __print_funct_t svg_print_disk_stats(struct activity *a, int curr, int action, s
 						   USE_STABLE_ID(flags), NULL);
 
 			if (a->item_list != NULL) {
-				/* A list of devices has been entered on the command line */
-				if (!search_list_item(a->item_list, dev_name))
-					/* Device not found */
+				/* Match --fs= against device name and/or mountpoint */
+				if (!match_sa_filesystem_item(a->item_list, sfc, dev_name))
 					continue;
 			}
 

--- a/xml_stats.c
+++ b/xml_stats.c
@@ -2149,9 +2149,8 @@ __print_funct_t xml_print_filesystem_stats(struct activity *a, int curr, int tab
 		dev_name = get_fs_name_to_display(a, flags, sfc);
 
 		if (a->item_list != NULL) {
-			/* A list of devices has been entered on the command line */
-			if (!search_list_item(a->item_list, dev_name))
-				/* Device not found */
+			/* Match --fs= against device name and/or mountpoint */
+			if (!match_sa_filesystem_item(a->item_list, sfc, dev_name))
 				continue;
 		}
 


### PR DESCRIPTION
`--fs=` only compared the currently displayed filesystem name. With the default device-name columns that meant `--fs=/srv` never matched even though the man page says mountpoints are allowed.

Match device name and mountpoint (and the displayed label) in all sar/sadf output paths, and clarify the man text.

Fixes #420