### PR TITLE
sadf: Allow more than 99 days back in day offset argument

### DIFF
--- a/sadf.c
+++ b/sadf.c
@@ -1812,7 +1812,7 @@ int main(int argc, char **argv)
 		}
 
 		else if ((strlen(argv[opt]) > 1) &&
-			 (strlen(argv[opt]) < 4) &&
+			 (strlen(argv[opt]) < 7) &&
 			 !strncmp(argv[opt], "-", 1) &&
 			 (strspn(argv[opt] + 1, DIGITS) == (strlen(argv[opt]) - 1))) {
 			if (dfile[0] || day_offset) {

--- a/sar.c
+++ b/sar.c
@@ -1533,7 +1533,7 @@ int main(int argc, char **argv)
 		}
 #endif
 		else if ((strlen(argv[opt]) > 1) &&
-			 (strlen(argv[opt]) < 4) &&
+			 (strlen(argv[opt]) < 7) &&
 			 !strncmp(argv[opt], "-", 1) &&
 			 (strspn(argv[opt] + 1, DIGITS) == (strlen(argv[opt]) - 1))) {
 			if (from_file[0] || day_offset) {

--- a/tests/05610
+++ b/tests/05610
@@ -1,0 +1,17 @@
+# Test sadf accepts more than 99 days back (issue #449)
+# Validates that sadf properly parses day offset arguments with >2 digits
+# The arguments should be accepted without "Usage:" error (which indicates argument parsing failure)
+
+# Test with -100 days (3 digits) - should parse without "Usage:" error
+./sadf -d -100 2>&1 | grep -q "Usage:" && exit 1
+
+# Test with -365 days (3 digits, one year) - should parse without "Usage:" error
+./sadf -d -365 2>&1 | grep -q "Usage:" && exit 1
+
+# Test with -999 days (3 digits) - should parse without "Usage:" error
+./sadf -d -999 2>&1 | grep -q "Usage:" && exit 1
+
+# Test with -10000 days (5 digits) - should parse without "Usage:" error
+./sadf -d -10000 2>&1 | grep -q "Usage:" && exit 1
+
+exit 0

--- a/tests/05611
+++ b/tests/05611
@@ -1,0 +1,17 @@
+# Test sar accepts more than 99 days back (issue #449)
+# Validates that sar properly parses day offset arguments with >2 digits
+# The arguments should be accepted without "Usage:" error (which indicates argument parsing failure)
+
+# Test with -100 days (3 digits) - should parse without "Usage:" error
+./sar -d -100 2>&1 | grep -q "Usage:" && exit 1
+
+# Test with -365 days (3 digits, one year) - should parse without "Usage:" error
+./sar -d -365 2>&1 | grep -q "Usage:" && exit 1
+
+# Test with -999 days (3 digits) - should parse without "Usage:" error
+./sar -d -999 2>&1 | grep -q "Usage:" && exit 1
+
+# Test with -10000 days (5 digits) - should parse without "Usage:" error
+./sar -d -10000 2>&1 | grep -q "Usage:" && exit 1
+
+exit 0


### PR DESCRIPTION
Issue #449: sadf only accepted day offset arguments up to -99 due to a length check that limited the argument string to 3 characters. This prevented users from querying data older than 99 days.

Change the length limit from < 4 to < 7 characters in the argument parser, allowing up to 6 characters (dash + 5 digits), supporting values from -1 to -99999 days (~273 years).

Fixes #449